### PR TITLE
Hackathon: Add generate-event to sls enterprise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1356,6 +1356,13 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
+    "aws-event-mocks": {
+      "version": "github:serverless/aws-event-mocks#0913986d7db12f5d3fc36bb096d1e35c9805dad1",
+      "from": "github:serverless/aws-event-mocks#master",
+      "requires": {
+        "lodash": "^4.13.1"
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -2387,7 +2394,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -6768,6 +6776,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -9924,7 +9933,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "yamljs": {
       "version": "0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -842,6 +842,15 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@serverless/event-mocks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@serverless/event-mocks/-/event-mocks-1.0.0.tgz",
+      "integrity": "sha512-ifP6u9Q7vbwwfK9iQBYRKCbyR87sFCsXetDXEdesyUusjilmuem/wMhQSADdW5gm8nRxyvVD6H7uEo7BvyMuWg==",
+      "requires": {
+        "@types/lodash": "^4.14.123",
+        "lodash": "^4.17.11"
+      }
+    },
     "@serverless/platform-sdk": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@serverless/platform-sdk/-/platform-sdk-0.7.0.tgz",
@@ -863,6 +872,11 @@
         "uuid": "^3.3.2",
         "write-file-atomic": "^2.3.0"
       }
+    },
+    "@types/lodash": {
+      "version": "4.14.123",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
+      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q=="
     },
     "@webassemblyjs/ast": {
       "version": "1.7.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1370,13 +1370,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
-    "aws-event-mocks": {
-      "version": "github:serverless/aws-event-mocks#0700d3b0d03a91148fae9b6c55539e41bfc93ce2",
-      "from": "github:serverless/aws-event-mocks#master",
-      "requires": {
-        "lodash": "^4.13.1"
-      }
-    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1357,7 +1357,7 @@
       "dev": true
     },
     "aws-event-mocks": {
-      "version": "github:serverless/aws-event-mocks#0913986d7db12f5d3fc36bb096d1e35c9805dad1",
+      "version": "github:serverless/aws-event-mocks#0700d3b0d03a91148fae9b6c55539e41bfc93ce2",
       "from": "github:serverless/aws-event-mocks#master",
       "requires": {
         "lodash": "^4.13.1"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
+    "@serverless/event-mocks": "^1.0.0",
     "@serverless/platform-sdk": "^0.7.0",
     "aws-event-mocks": "github:serverless/aws-event-mocks#master",
     "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@serverless/platform-sdk": "^0.7.0",
+    "aws-event-mocks": "github:serverless/aws-event-mocks#master",
     "chalk": "^2.4.2",
     "flat": "^4.1.0",
     "fs-extra": "^7.0.1",

--- a/sdk-js/package-lock.json
+++ b/sdk-js/package-lock.json
@@ -1891,7 +1891,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1912,12 +1913,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1932,17 +1935,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2059,7 +2065,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2071,6 +2078,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2085,6 +2093,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2092,12 +2101,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2116,6 +2127,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2196,7 +2208,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2208,6 +2221,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2293,7 +2307,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2329,6 +2344,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2348,6 +2364,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2391,12 +2408,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/lib/generateEvent.js
+++ b/src/lib/generateEvent.js
@@ -1,0 +1,31 @@
+const createEvent = require('aws-event-mocks')
+
+export default async function(ctx) {
+  const { options } = ctx.sls.processedInput
+  let e
+  switch (options.type) {
+    case 'http':
+      e = createEvent({
+        template: 'aws:apiGateway',
+        merge: {
+          body: JSON.parse(options.body)
+        }
+      })
+      break
+    case 'sns':
+      e = createEvent({
+        template: 'aws:sns',
+        merge: {
+          Records: [
+            {
+              Sns: {
+                Message: options.message
+              }
+            }
+          ]
+        }
+      })
+  }
+  // eslint-disable-next-line no-console
+  return console.log(JSON.stringify(e))
+}

--- a/src/lib/generateEvent.js
+++ b/src/lib/generateEvent.js
@@ -2,13 +2,20 @@ const createEvent = require('aws-event-mocks')
 
 export default async function(ctx) {
   const { options } = ctx.sls.processedInput
-  let e
+  let e, parsedBody
+  if (options.body) {
+    try {
+      parsedBody = JSON.parse(options.body)
+    } catch (error) {
+      parsedBody = {}
+    }
+  }
   switch (options.type) {
     case 'http':
       e = createEvent({
         template: 'aws:apiGateway',
         merge: {
-          body: JSON.parse(options.body)
+          body: parsedBody
         }
       })
       break
@@ -32,7 +39,7 @@ export default async function(ctx) {
         merge: {
           Records: [
             {
-              body: options.body
+              body: parsedBody
             }
           ]
         }

--- a/src/lib/generateEvent.js
+++ b/src/lib/generateEvent.js
@@ -1,4 +1,4 @@
-const createEvent = require('aws-event-mocks')
+import createEvent from '@serverless/event-mocks'
 
 export default async function(ctx) {
   const { options } = ctx.sls.processedInput
@@ -12,37 +12,26 @@ export default async function(ctx) {
   }
   switch (options.type) {
     case 'http':
-      e = createEvent({
-        template: 'aws:apiGateway',
-        merge: {
-          body: parsedBody
-        }
-      })
+      e = createEvent('aws:apiGateway', { body: parsedBody })
       break
     case 'sns':
-      e = createEvent({
-        template: 'aws:sns',
-        merge: {
-          Records: [
-            {
-              Sns: {
-                Message: options.message
-              }
+      e = createEvent('aws:sns', {
+        Records: [
+          {
+            Sns: {
+              Message: options.message
             }
-          ]
-        }
+          }
+        ]
       })
       break
     case 'sqs':
-      e = createEvent({
-        template: 'aws:sqs',
-        merge: {
-          Records: [
-            {
-              body: parsedBody
-            }
-          ]
-        }
+      e = createEvent('aws:sqs', {
+        Records: [
+          {
+            body: parsedBody
+          }
+        ]
       })
       break
     default:

--- a/src/lib/generateEvent.js
+++ b/src/lib/generateEvent.js
@@ -34,6 +34,15 @@ export default async function(ctx) {
         ]
       })
       break
+    case 'dynamodb':
+      e = createEvent('aws:dynamo', {
+        Records: [
+          {
+            dynamodb: parsedBody
+          }
+        ]
+      })
+      break
     default:
       throw new Error('Invalid event specified.')
   }

--- a/src/lib/generateEvent.js
+++ b/src/lib/generateEvent.js
@@ -25,6 +25,22 @@ export default async function(ctx) {
           ]
         }
       })
+      break
+    case 'sqs':
+      e = createEvent({
+        template: 'aws:sqs',
+        merge: {
+          Records: [
+            {
+              body: options.body
+            }
+          ]
+        }
+      })
+      break
+    default:
+      ctx.sls.cli.error('Invalid event specified.')
+      return
   }
   // eslint-disable-next-line no-console
   return console.log(JSON.stringify(e))

--- a/src/lib/generateEvent.js
+++ b/src/lib/generateEvent.js
@@ -39,8 +39,7 @@ export default async function(ctx) {
       })
       break
     default:
-      ctx.sls.cli.error('Invalid event specified.')
-      return
+      throw new Error('Invalid event specified.')
   }
   // eslint-disable-next-line no-console
   return console.log(JSON.stringify(e))

--- a/src/lib/generateEvent.test.js
+++ b/src/lib/generateEvent.test.js
@@ -1,0 +1,109 @@
+import generateEvent from './generateEvent'
+
+describe('generating events', () => {
+  it('builds http events', async () => {
+    const logSpy = jest.spyOn(global.console, 'log')
+    const ctx = {
+      sls: {
+        processedInput: {
+          options: {
+            type: 'http',
+            body: '{"foo": "bar"}'
+          }
+        }
+      }
+    }
+    const that = { serverless: { classes: { Error } } }
+    await generateEvent.bind(that)(ctx)
+    expect(logSpy).toBeCalledWith(
+      JSON.stringify({
+        body: { foo: 'bar' },
+        method: 'GET',
+        principalId: '',
+        stage: 'dev',
+        headers: {
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          'Accept-Encoding': 'gzip, deflate',
+          'Accept-Language': 'en-us',
+          'CloudFront-Forwarded-Proto': 'https',
+          'CloudFront-Is-Desktop-Viewer': 'true',
+          'CloudFront-Is-Mobile-Viewer': 'false',
+          'CloudFront-Is-SmartTV-Viewer': 'false',
+          'CloudFront-Is-Tablet-Viewer': 'false',
+          'CloudFront-Viewer-Country': 'US',
+          Cookie:
+            '__gads=ID=d51d609e5753330d:T=1443694116:S=ALNI_MbjWKzLwdEpWZ5wR5WXRI2dtjIpHw; __qca=P0-179798513-1443694132017; _ga=GA1.2.344061584.1441769647',
+          Host: 'xxx.execute-api.us-east-1.amazonaws.com',
+          'User-Agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/601.6.17 (KHTML, like Gecko) Version/9.1.1 Safari/601.6.17',
+          Via: '1.1 c8a5bb0e20655459eaam174e5c41443b.cloudfront.net (CloudFront)',
+          'X-Amz-Cf-Id': 'z7Ds7oXaY8hgUn7lcedZjoIoxyvnzF6ycVzBdQmhn3QnOPEjJz4BrQ==',
+          'X-Forwarded-For': '221.24.103.21, 54.242.148.216',
+          'X-Forwarded-Port': '443',
+          'X-Forwarded-Proto': 'https'
+        },
+        query: {},
+        path: {},
+        identity: {
+          cognitoIdentityPoolId: '',
+          accountId: '',
+          cognitoIdentityId: '',
+          caller: '',
+          apiKey: '',
+          sourceIp: '221.24.103.21',
+          cognitoAuthenticationType: '',
+          cognitoAuthenticationProvider: '',
+          userArn: '',
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/601.6.17 (KHTML, like Gecko) Version/9.1.1 Safari/601.6.17',
+          user: ''
+        },
+        stageVariables: {}
+      })
+    )
+  })
+
+  it('builds SNS events', async () => {
+    const logSpy = jest.spyOn(global.console, 'log')
+    const ctx = {
+      sls: {
+        processedInput: {
+          options: {
+            type: 'sns',
+            message: '{"json_string": "with some attrs"}'
+          }
+        }
+      }
+    }
+    const that = { serverless: { classes: { Error } } }
+    await generateEvent.bind(that)(ctx)
+    expect(logSpy).toBeCalledWith(
+      JSON.stringify({
+        Records: [
+          {
+            EventSource: 'aws:sns',
+            EventVersion: '1.0',
+            EventSubscriptionArn:
+              'arn:aws:sns:us-east-1:123456789:service-1474781718017-1:fdaa4474-f0ff-4777-b1c4-79b96f5a504f',
+            Sns: {
+              Type: 'Notification',
+              MessageId: '52ed5e3d-5fgf-56bf-923d-0e5c3b503c2a',
+              TopicArn: 'arn:aws:sns:us-east-1:123456789:service-1474781718017-1',
+              Subject: null,
+              Message: '{"json_string": "with some attrs"}',
+              Timestamp: '2016-09-25T05:37:51.150Z',
+              SignatureVersion: '1',
+              Signature:
+                'V5QL/dhow62Thr9PXYsoHA7bOsDFkLdWZVd8D6LyptA6mrq0Mvldvj/XNtai3VaPp84G3bD2nQbiuwYbYpu9u9uHZ3PFMAxIcugV0dkOGWmYgKxSjPApItIoAgZyeH0HzcXHPEUXXO5dVT987jZ4eelD4hYLqBwgulSsECO9UDCdCS0frexiBHRGoLbWpX+2Nf2AJAL+olEEAAgxfiPEJ6J1ArzfvTFZXdd4XLAbrQe+4OeYD2dw39GBzGXQZemWDKf4d52kk+SwXY1ngaR4UfExQ10lDpKyfBVkSwroaq0pzbWFaxT2xrKIr4sk2s78BsPk0NBi55xA4k1E4tr9Pg==',
+              SigningCertUrl:
+                'https://sns.us-east-1.amazonaws.com/SimpleNotificationService-b95095beb82e8f6a0e6b3aafc7f4149a.pem',
+              UnsubscribeUrl:
+                'https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789:service-1474781718017-1:fdaa4474-f0ff-4777-b1c4-79b96f5a504f',
+              MessageAttributes: {}
+            }
+          }
+        ]
+      })
+    )
+  })
+})

--- a/src/lib/generateEvent.test.js
+++ b/src/lib/generateEvent.test.js
@@ -144,4 +144,18 @@ describe('generating events', () => {
       })
     )
   })
+  it('throws errors for invalid events', async () => {
+    const ctx = {
+      sls: {
+        processedInput: {
+          options: {
+            type: 'none',
+            body: '{"json_string": "with some attrs"}'
+          }
+        }
+      }
+    }
+    const that = { serverless: { classes: { Error } } }
+    await expect(generateEvent.bind(that)(ctx)).toThrowError
+  })
 })

--- a/src/lib/generateEvent.test.js
+++ b/src/lib/generateEvent.test.js
@@ -106,4 +106,42 @@ describe('generating events', () => {
       })
     )
   })
+
+  it('builds SQS events', async () => {
+    const logSpy = jest.spyOn(global.console, 'log')
+    const ctx = {
+      sls: {
+        processedInput: {
+          options: {
+            type: 'sqs',
+            body: '{"json_string": "with some attrs"}'
+          }
+        }
+      }
+    }
+    const that = { serverless: { classes: { Error } } }
+    await generateEvent.bind(that)(ctx)
+    expect(logSpy).toBeCalledWith(
+      JSON.stringify({
+        Records: [
+          {
+            messageId: '059f36b4-87a3-44ab-83d2-661975830a7d',
+            receiptHandle: 'AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...',
+            body: '{"json_string": "with some attrs"}',
+            attributes: {
+              ApproximateReceiveCount: '1',
+              SentTimestamp: '1545082649183',
+              SenderId: 'AIDAIENQZJOLO23YVJ4VO',
+              ApproximateFirstReceiveTimestamp: '1545082649185'
+            },
+            messageAttributes: {},
+            md5OfBody: '098f6bcd4621d373cade4e832627b4f6',
+            eventSource: 'aws:sqs',
+            eventSourceARN: 'arn:aws:sqs:us-east-2:123456789012:my-queue',
+            awsRegion: 'us-east-2'
+          }
+        ]
+      })
+    )
+  })
 })

--- a/src/lib/generateEvent.test.js
+++ b/src/lib/generateEvent.test.js
@@ -17,48 +17,71 @@ describe('generating events', () => {
     await generateEvent.bind(that)(ctx)
     expect(logSpy).toBeCalledWith(
       JSON.stringify({
-        body: { foo: 'bar' },
-        method: 'GET',
-        principalId: '',
-        stage: 'dev',
+        body: {
+          foo: 'bar'
+        },
+        path: '/test/hello',
         headers: {
-          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-          'Accept-Encoding': 'gzip, deflate',
-          'Accept-Language': 'en-us',
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+          'Accept-Encoding': 'gzip, deflate, lzma, sdch, br',
+          'Accept-Language': 'en-US,en;q=0.8',
           'CloudFront-Forwarded-Proto': 'https',
           'CloudFront-Is-Desktop-Viewer': 'true',
           'CloudFront-Is-Mobile-Viewer': 'false',
           'CloudFront-Is-SmartTV-Viewer': 'false',
           'CloudFront-Is-Tablet-Viewer': 'false',
           'CloudFront-Viewer-Country': 'US',
-          Cookie:
-            '__gads=ID=d51d609e5753330d:T=1443694116:S=ALNI_MbjWKzLwdEpWZ5wR5WXRI2dtjIpHw; __qca=P0-179798513-1443694132017; _ga=GA1.2.344061584.1441769647',
-          Host: 'xxx.execute-api.us-east-1.amazonaws.com',
+          Host: 'wt6mne2s9k.execute-api.us-west-2.amazonaws.com',
+          'Upgrade-Insecure-Requests': '1',
           'User-Agent':
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/601.6.17 (KHTML, like Gecko) Version/9.1.1 Safari/601.6.17',
-          Via: '1.1 c8a5bb0e20655459eaam174e5c41443b.cloudfront.net (CloudFront)',
-          'X-Amz-Cf-Id': 'z7Ds7oXaY8hgUn7lcedZjoIoxyvnzF6ycVzBdQmhn3QnOPEjJz4BrQ==',
-          'X-Forwarded-For': '221.24.103.21, 54.242.148.216',
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48',
+          Via: '1.1 fb7cca60f0ecd82ce07790c9c5eef16c.cloudfront.net (CloudFront)',
+          'X-Amz-Cf-Id': 'nBsWBOrSHMgnaROZJK1wGCZ9PcRcSpq_oSXZNQwQ10OTZL4cimZo3g==',
+          'X-Forwarded-For': '192.168.100.1, 192.168.1.1',
           'X-Forwarded-Port': '443',
           'X-Forwarded-Proto': 'https'
         },
-        query: {},
-        path: {},
-        identity: {
-          cognitoIdentityPoolId: '',
-          accountId: '',
-          cognitoIdentityId: '',
-          caller: '',
-          apiKey: '',
-          sourceIp: '221.24.103.21',
-          cognitoAuthenticationType: '',
-          cognitoAuthenticationProvider: '',
-          userArn: '',
-          userAgent:
-            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/601.6.17 (KHTML, like Gecko) Version/9.1.1 Safari/601.6.17',
-          user: ''
+        pathParameters: {
+          proxy: 'hello'
         },
-        stageVariables: {}
+        multiValueHeaders: {},
+        isBase64Encoded: false,
+        multiValueQueryStringParameters: {},
+        requestContext: {
+          accountId: '123456789012',
+          resourceId: 'us4z18',
+          stage: 'test',
+          requestId: '41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9',
+          identity: {
+            accessKey: '',
+            apiKeyId: '',
+            cognitoIdentityPoolId: '',
+            accountId: '',
+            cognitoIdentityId: '',
+            caller: '',
+            apiKey: '',
+            sourceIp: '192.168.100.1',
+            cognitoAuthenticationType: '',
+            cognitoAuthenticationProvider: '',
+            userArn: '',
+            userAgent:
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48',
+            user: ''
+          },
+          path: '',
+          requestTimeEpoch: 0,
+          resourcePath: '/{proxy+}',
+          httpMethod: 'GET',
+          apiId: 'wt6mne2s9k'
+        },
+        resource: '/{proxy+}',
+        httpMethod: 'GET',
+        queryStringParameters: {
+          name: 'me'
+        },
+        stageVariables: {
+          stageVarName: 'stageVarValue'
+        }
       })
     )
   })
@@ -89,7 +112,7 @@ describe('generating events', () => {
               Type: 'Notification',
               MessageId: '52ed5e3d-5fgf-56bf-923d-0e5c3b503c2a',
               TopicArn: 'arn:aws:sns:us-east-1:123456789:service-1474781718017-1',
-              Subject: null,
+              Subject: '',
               Message: '{"json_string": "with some attrs"}',
               Timestamp: '2016-09-25T05:37:51.150Z',
               SignatureVersion: '1',

--- a/src/lib/generateEvent.test.js
+++ b/src/lib/generateEvent.test.js
@@ -127,7 +127,9 @@ describe('generating events', () => {
           {
             messageId: '059f36b4-87a3-44ab-83d2-661975830a7d',
             receiptHandle: 'AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...',
-            body: '{"json_string": "with some attrs"}',
+            body: {
+              json_string: 'with some attrs'
+            },
             attributes: {
               ApproximateReceiveCount: '1',
               SentTimestamp: '1545082649183',

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -85,11 +85,11 @@ class ServerlessEnterprisePlugin {
             required: true
           },
           body: {
-            usage: `Specify the HTTP body.`,
+            usage: `Specify the HTTP or SQS body.`,
             shortcut: 'b'
           },
           message: {
-            usage: `Specify the SNS/SQS Message.`,
+            usage: `Specify the SNS Message.`,
             shortcut: 'm'
           }
         },

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -82,17 +82,13 @@ class ServerlessEnterprisePlugin {
         lifecycleEvents: ['generate-event'],
         options: {
           type: {
-            usage: `Specify event type. HTTP, SNS, SQS are supported.`,
+            usage: `Specify event type. aws:http, aws:sns, aws:sns, aws:s3, aws:dynamo, and aws:kinesis are supported.`,
             shortcut: 't',
             required: true
           },
           body: {
-            usage: `Specify the HTTP or SQS body.`,
+            usage: `Specify the body for the message, request, or stream event.`,
             shortcut: 'b'
-          },
-          message: {
-            usage: `Specify the SNS Message.`,
-            shortcut: 'm'
           }
         },
         enterprise: true

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -7,6 +7,7 @@ import logout from './logout'
 import wrap from './wrap'
 import wrapClean from './wrapClean'
 import runPolicies from './safeguards'
+import generateEvent from './generateEvent'
 import getCredentials from './credentials'
 import getAppUids from './appUids'
 import removeDestination from './removeDestination'
@@ -73,6 +74,26 @@ class ServerlessEnterprisePlugin {
         usage: 'Logout from Serverless Enterprise',
         lifecycleEvents: ['logout'],
         enterprise: true
+      },
+      'generate-event': {
+        usage: 'Generate event',
+        lifecycleEvents: ['generate-event'],
+        options: {
+          type: {
+            usage: `Specify event type. HTTP, SNS, SQS are supported.`,
+            shortcut: 't',
+            required: true
+          },
+          body: {
+            usage: `Specify the HTTP body.`,
+            shortcut: 'b'
+          },
+          message: {
+            usage: `Specify the SNS/SQS Message.`,
+            shortcut: 'm'
+          }
+        },
+        enterprise: true
       }
     }
 
@@ -101,6 +122,7 @@ class ServerlessEnterprisePlugin {
       'before:step-functions-offline:start': this.route('before:step-functions-offline:start').bind(this), // eslint-disable-line
       'login:login': this.route('login:login').bind(this), // eslint-disable-line
       'logout:logout': this.route('logout:logout').bind(this), // eslint-disable-line
+      'generate-event:generate-event': this.route('generate-event:generate-event').bind(this), // eslint-disable-line
     }
   }
 
@@ -185,6 +207,9 @@ class ServerlessEnterprisePlugin {
           break
         case 'logout:logout':
           await logout(self)
+          break
+        case 'generate-event:generate-event':
+          await generateEvent(self)
           break
       }
     }

--- a/src/lib/plugin.test.js
+++ b/src/lib/plugin.test.js
@@ -8,6 +8,7 @@ import runPolicies from './safeguards'
 import removeDestination from './removeDestination'
 import { saveDeployment } from './deployment'
 import { hookIntoVariableGetter } from './variables'
+import generateEvent from './generateEvent'
 
 afterAll(() => jest.restoreAllMocks())
 
@@ -26,7 +27,10 @@ const sls = {
     log: jest.fn()
   },
   processedInput: {
-    commands: []
+    commands: [],
+    options: {
+      type: 'sqs'
+    }
   }
 }
 
@@ -54,6 +58,7 @@ jest.mock('./awsLambdaLogsCollection', () => jest.fn())
 jest.mock('./removeDestination', () => jest.fn())
 jest.mock('./deployment', () => ({ saveDeployment: jest.fn() }))
 jest.mock('./variables', () => ({ hookIntoVariableGetter: jest.fn() }))
+jest.mock('./generateEvent', () => jest.fn())
 
 describe('plugin', () => {
   it('constructs and sets hooks', () => {
@@ -172,5 +177,11 @@ describe('plugin', () => {
     const instance = new ServerlessEnterprisePlugin(sls)
     await instance.route('before:deploy:deploy')()
     expect(runPolicies).toBeCalledWith(instance)
+  })
+
+  it('routes generate-event:generate-event hook correctly', async () => {
+    const instance = new ServerlessEnterprisePlugin(sls)
+    await instance.route('generate-event:generate-event')()
+    expect(generateEvent).toBeCalledWith(instance)
   })
 })

--- a/src/lib/plugin.test.js
+++ b/src/lib/plugin.test.js
@@ -79,7 +79,8 @@ describe('plugin', () => {
       'before:offline:start:init',
       'before:step-functions-offline:start',
       'login:login',
-      'logout:logout'
+      'logout:logout',
+      'generate-event:generate-event'
     ])
     expect(sls.getProvider).toBeCalledWith('aws')
     expect(sls.cli.log).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
This PR adds the ability to generate:
- [ ] AWS Api Gateway HTTP requests
- [ ] AWS SNS events
- [ ] AWS SQS events
- [ ] AWS DynamoDB Stream events
- [ ] AWS Kinesis Stream Events
- [ ] AWS S3 events
and then pipes the generated event w/ the user input to stdout to be redirected/piped into sls invoke, or into a file.

The idea is that we can use this logic to pipe into sls invoke, and eventually into new features (saved collections, test sequences, etc).