### PR TITLE
update platform sdk & use its new abliity to configure CAs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -843,9 +843,9 @@
       }
     },
     "@serverless/platform-sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-sdk/-/platform-sdk-0.7.0.tgz",
-      "integrity": "sha512-3VuXTkWSmfoGXiql0v/5lMHOMfRtk01C81w0QinmSZKpO49f+9UgSwJvLK1LaVJmOTBZidr1vBI5SZHTNZW2WA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-sdk/-/platform-sdk-0.7.1.tgz",
+      "integrity": "sha512-+oV/UiSq45eGlMQIHyJmBsysREHOE+dKx5WadjIuxjvRF/wYmN+1QTb08wJRqHkXItns4S26v1EI9yqyNXbfWg==",
       "requires": {
         "babel-polyfill": "^6.26.0",
         "body-parser": "^1.18.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
-    "@serverless/platform-sdk": "^0.7.0",
+    "@serverless/platform-sdk": "^0.7.1",
     "chalk": "^2.4.2",
     "flat": "^4.1.0",
     "fs-extra": "^7.0.1",

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -1,4 +1,4 @@
-import { getLoggedInUser } from '@serverless/platform-sdk'
+import { configureFetchDefaults, getLoggedInUser } from '@serverless/platform-sdk'
 import errorHandler from './errorHandler'
 // import awsApiGatewayLogsCollection from './awsApiGatewayLogsCollection'
 import awsLambdaLogsCollection from './awsLambdaLogsCollection'
@@ -19,6 +19,7 @@ import { hookIntoVariableGetter } from './variables'
 
 class ServerlessEnterprisePlugin {
   constructor(sls) {
+    configureFetchDefaults()
     const user = getLoggedInUser()
     const currentCommand = sls.processedInput.commands[0]
 

--- a/src/lib/plugin.test.js
+++ b/src/lib/plugin.test.js
@@ -32,6 +32,7 @@ const sls = {
 
 // Mock SDK
 jest.mock('@serverless/platform-sdk', () => ({
+  configureFetchDefaults: jest.fn(),
   getLoggedInUser: jest.fn().mockReturnValue({
     accessKeys: {
       tenant: '12345'


### PR DESCRIPTION
Depends on serverless/platform-sdk#47 and it being released to NPM as 0.7.1 (will need to run `npm i` to update `package-lock.json` in this PR)