### PR TITLE
fix safeguard import paths to always use /, even on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "The Serverless Enterprise plugin",
   "main": "dist/index.js",
   "scripts": {

--- a/src/lib/safeguards/index.js
+++ b/src/lib/safeguards/index.js
@@ -13,7 +13,7 @@ const checkEmoji = '\u2705'
 
 // NOTE: not using path.join because it strips off the leading
 export const loadPolicy = (policyPath, safeguardName) =>
-  require(`${policyPath || `.${path.sep}policies`}${path.sep}${safeguardName}`)
+  require(`${policyPath || `./policies`}/${safeguardName}`)
 
 async function runPolicies(ctx) {
   const basePath = ctx.sls.config.servicePath

--- a/src/lib/safeguards/index.test.js
+++ b/src/lib/safeguards/index.test.js
@@ -70,7 +70,7 @@ beforeEach(() => {
 
 describe('safeguards - loadPolicy', () => {
   it('loads a safeguard from inside the plugin', async () => {
-    expect(typeof loadPolicy('./policies', 'require-dlq')).toBe('function')
+    expect(typeof loadPolicy(undefined, 'require-dlq')).toBe('function')
   })
 
   it('loads a safeguard from outside the plugin', async () => {


### PR DESCRIPTION
includes version bump so i can release this change