### PR TITLE
Upload used secrets as part of new deployment reporting

### DIFF
--- a/src/lib/deployment/parse.js
+++ b/src/lib/deployment/parse.js
@@ -50,7 +50,6 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
       secrets: Array.from(ctx.state.secretsUsed),
       error
     })
-    console.log(JSON.stringify(deployment.data)) // eslint-disable-line no-console
 
     /*
      * Add this deployment's functions...

--- a/src/lib/deployment/parse.js
+++ b/src/lib/deployment/parse.js
@@ -47,9 +47,10 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
       plugins: service.plugins || [],
       custom: service.custom || {},
       safeguards: ctx.state.safeguardsResults,
-      secrets: ctx.state.secretsUsed,
+      secrets: Array.from(ctx.state.secretsUsed),
       error
     })
+    console.log(JSON.stringify(deployment.data)) // eslint-disable-line no-console
 
     /*
      * Add this deployment's functions...
@@ -143,7 +144,7 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
       regionName: ctx.provider.getRegion(),
       archived,
       status,
-      secrets: ctx.state.secretsUsed,
+      secrets: Array.from(ctx.state.secretsUsed),
       error
     })
   }

--- a/src/lib/deployment/parse.test.js
+++ b/src/lib/deployment/parse.test.js
@@ -65,7 +65,7 @@ describe('parseDeploymentData', () => {
     }
     const state = {
       safeguardsResults: [],
-      secretsUsed: ['secret']
+      secretsUsed: new Set(['secret'])
     }
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state })
@@ -171,7 +171,7 @@ describe('parseDeploymentData', () => {
     }
     const state = {
       safeguardsResults: [],
-      secretsUsed: ['secret']
+      secretsUsed: new Set(['secret'])
     }
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state })
@@ -266,7 +266,7 @@ describe('parseDeploymentData', () => {
     }
     const state = {
       safeguardsResults: [],
-      secretsUsed: ['secret']
+      secretsUsed: new Set(['secret'])
     }
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state })
@@ -364,7 +364,7 @@ describe('parseDeploymentData', () => {
     }
     const state = {
       safeguardsResults: [],
-      secretsUsed: ['secret']
+      secretsUsed: new Set(['secret'])
     }
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state })

--- a/src/lib/variables.js
+++ b/src/lib/variables.js
@@ -12,7 +12,7 @@ export const hookIntoVariableGetter = (ctx) => {
 
   ctx.sls.variables.getValueFromSource = (variableString) => {
     if (variableString.startsWith(`secrets:`)) {
-      ctx.state.secretsUsed.add(variableString)
+      ctx.state.secretsUsed.add(variableString.substring(8))
       if (ctx.sls.processedInput.commands[0] === 'login') {
         return {}
       }

--- a/src/lib/variables.js
+++ b/src/lib/variables.js
@@ -12,6 +12,7 @@ export const hookIntoVariableGetter = (ctx) => {
 
   ctx.sls.variables.getValueFromSource = (variableString) => {
     if (variableString.startsWith(`secrets:`)) {
+      ctx.state.secretsUsed.add(variableString)
       if (ctx.sls.processedInput.commands[0] === 'login') {
         return {}
       }
@@ -22,7 +23,6 @@ export const hookIntoVariableGetter = (ctx) => {
     }
 
     const value = getValueFromSource.bind(ctx.sls.variables)(variableString)
-    ctx.state.secretsUsed.add(variableString)
     return value
   }
 

--- a/src/lib/variables.test.js
+++ b/src/lib/variables.test.js
@@ -11,14 +11,14 @@ afterAll(() => jest.restoreAllMocks())
 describe('variables - getSecretFromEnterprise', () => {
   it('gets the access key and grabs the secret from backend', async () => {
     await getSecretFromEnterprise({
-      secretName: 'name',
+      secretName: 'secrets:name',
       app: 'app',
       service: 'service',
       tenant: 'tenant'
     })
     expect(getAccessKeyForTenant).toBeCalledWith('tenant')
     expect(getSecret).toBeCalledWith({
-      secretName: 'name',
+      secretName: 'secrets:name',
       accessKey: 'accessKey',
       app: 'app',
       service: 'service',
@@ -35,7 +35,10 @@ describe('variables - hookIntoVariableGetter', () => {
       service: 'service',
       tenant: 'tenant'
     },
-    variables: { getValueFromSource }
+    variables: { getValueFromSource },
+    processedInput: {
+      commands: []
+    }
   }
   const state = { secretsUsed: new Set() }
 
@@ -46,10 +49,10 @@ describe('variables - hookIntoVariableGetter', () => {
   it('overrides the default variable getter', async () => {
     const restore = hookIntoVariableGetter({ sls: serverless, state })
     expect(serverless.variables.getValueFromSource).not.toEqual(getValueFromSource)
-    serverless.variables.getValueFromSource('name')
+    serverless.variables.getValueFromSource('secrets:name')
     expect(getAccessKeyForTenant).toBeCalledWith('tenant')
     expect(getSecret).toBeCalledWith({
-      secretName: 'name',
+      secretName: 'secrets:name',
       accessKey: 'accessKey',
       app: 'app',
       service: 'service',


### PR DESCRIPTION
This was already being done, but there were a couple of bugs:
- JSON.stringify on the used secrets set
- When accumulating used secrets, filter for `secrets:` key prefix
  not applied