### PR TITLE
Update FilterPattern in logs subscription -- [Do not merge]

### DIFF
--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -226,7 +226,7 @@ class Transaction {
       span.tags = tags
       envelope.payload = span
 
-      console.log(JSON.stringify(envelope))
+      console.log('SERVERLESS_ENTERPRISE', JSON.stringify(envelope))
       this.processed = true
     }
   }

--- a/src/lib/awsLambdaLogsCollection.js
+++ b/src/lib/awsLambdaLogsCollection.js
@@ -64,7 +64,7 @@ export default async (ctx) => {
       Type: 'AWS::Logs::SubscriptionFilter',
       Properties: {
         DestinationArn: destinationArn,
-        FilterPattern: '{ $.origin = "sls-agent" }',
+        FilterPattern: '?"\"origin\":\"sls-agent\"" ?"REPORT RequestId: "', // eslint-disable-line
         LogGroupName: {
           Ref: lambdaLogGroupKey
         }

--- a/src/lib/awsLambdaLogsCollection.js
+++ b/src/lib/awsLambdaLogsCollection.js
@@ -64,7 +64,7 @@ export default async (ctx) => {
       Type: 'AWS::Logs::SubscriptionFilter',
       Properties: {
         DestinationArn: destinationArn,
-        FilterPattern: '?"\"origin\":\"sls-agent\"" ?"REPORT RequestId: "', // eslint-disable-line
+        FilterPattern: '[w1=REPORT || w1=SERVERLESS_ENTERPRISE]',
         LogGroupName: {
           Ref: lambdaLogGroupKey
         }

--- a/src/lib/awsLambdaLogsCollection.test.js
+++ b/src/lib/awsLambdaLogsCollection.test.js
@@ -67,7 +67,7 @@ describe('awsLambdaLogsCollection', () => {
           Properties: {
             DestinationArn: 'arn:logdest',
 
-            FilterPattern: '?"\"origin\":\"sls-agent\"" ?"REPORT RequestId: "', // eslint-disable-line
+            FilterPattern: '[w1=REPORT || w1=SERVERLESS_ENTERPRISE]',
             LogGroupName: {
               Ref: 'lambdaLogs'
             }

--- a/src/lib/awsLambdaLogsCollection.test.js
+++ b/src/lib/awsLambdaLogsCollection.test.js
@@ -67,7 +67,7 @@ describe('awsLambdaLogsCollection', () => {
           Properties: {
             DestinationArn: 'arn:logdest',
 
-            FilterPattern: '{ $.origin = "sls-agent" }',
+            FilterPattern: '?"\"origin\":\"sls-agent\"" ?"REPORT RequestId: "', // eslint-disable-line
             LogGroupName: {
               Ref: 'lambdaLogs'
             }


### PR DESCRIPTION
[PLAT-864](https://serverlessteam.atlassian.net/browse/PLAT-864)

DO NOT MERGE -- Awaiting other changes in infra

Updates the FilterPattern for our subscription filter. It will now match if either of the following two patterns are matched:

1. "origin": "sls-agent" (Logs from the SDK)

2. "REPORT RequestId: " (Report logs from AWS Lambda)