### PR TITLE
Update EnterpriseLogsAccessIamRole Output

### DIFF
--- a/src/lib/injectLogsIamRole.js
+++ b/src/lib/injectLogsIamRole.js
@@ -49,7 +49,7 @@ export default async function(ctx) {
   }
   ctx.sls.service.provider.compiledCloudFormationTemplate.Outputs.EnterpriseLogAccessIamRole = {
     Value: {
-      Ref: 'EnterpriseLogAccessIamRole'
+      'Fn::GetAtt': ['EnterpriseLogAccessIamRole', 'Arn']
     }
   }
 }

--- a/src/lib/injectLogsIamRole.js
+++ b/src/lib/injectLogsIamRole.js
@@ -38,7 +38,7 @@ export default async function(ctx) {
                 )
                   .filter(([, { Type }]) => Type === 'AWS::Logs::LogGroup')
                   .map(([logicalId]) => ({
-                    'Fn::Sub': `arn:aws:logs:$\{AWS::Region}:$\{AWS::AccountId}:log-group:$\{${logicalId}}`
+                    'Fn::GetAtt': [logicalId, 'Arn']
                   }))
               }
             ]

--- a/src/lib/injectLogsIamRole.test.js
+++ b/src/lib/injectLogsIamRole.test.js
@@ -60,12 +60,10 @@ describe('injectLogsIamRole', () => {
                       Action: ['logs:FilterLogEvents'],
                       Resource: [
                         {
-                          'Fn::Sub':
-                            'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${Foo}'
+                          'Fn::GetAtt': ['Foo', 'Arn']
                         },
                         {
-                          'Fn::Sub':
-                            'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${Bar}'
+                          'Fn::GetAtt': ['Bar', 'Arn']
                         }
                       ]
                     }

--- a/src/lib/injectLogsIamRole.test.js
+++ b/src/lib/injectLogsIamRole.test.js
@@ -79,7 +79,7 @@ describe('injectLogsIamRole', () => {
       Outputs: {
         EnterpriseLogAccessIamRole: {
           Value: {
-            Ref: 'EnterpriseLogAccessIamRole'
+            'Fn::GetAtt': ['EnterpriseLogAccessIamRole', 'Arn']
           }
         }
       }


### PR DESCRIPTION
`Ref` was only returning the Role name. This update returns the full ARN for the role.