### PR TITLE
remove peer dep on sls since plugin will be a dep of sls

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,6 @@
     "prettier": "^1.14.3",
     "webpack": "4.24.0"
   },
-  "peerDependencies": {
-    "serverless": "^1.39.1"
-  },
   "author": "",
   "license": "Apache-2.0",
   "lint-staged": {


### PR DESCRIPTION
it isnt actually an issue on newer versions of node it seems, but old node npm versions complain