### PR TITLE
add a flag on to the sls object to let it know SFE is enabled

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -83,6 +83,8 @@ class ServerlessEnterprisePlugin {
       return
     }
 
+    sls.enterpriseEnabled = true
+
     // Defaults
     this.sls = sls
     this.state = {} // Useful for storing data across hooks


### PR DESCRIPTION
this is different from the plugin just being loaded(note the various `return` conditions before it's set) and necessary for SFO to determine if it needs to check the version of the plugin and issue a warning. could all be done in the plugin, but if we ever want to move to auto-update, the framework has to drive the actions