### PR TITLE
Capture spans for AWS SDK requests

### DIFF
--- a/sdk-js/package-lock.json
+++ b/sdk-js/package-lock.json
@@ -2826,13 +2826,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2849,19 +2851,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2992,7 +2997,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3006,6 +3012,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3022,6 +3029,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3030,13 +3038,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3057,6 +3067,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3145,7 +3156,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3159,6 +3171,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3296,6 +3309,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5145,6 +5159,11 @@
         "minimist": "0.0.8"
       }
     },
+    "module-details-from-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
+      "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -5626,8 +5645,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-type": {
       "version": "2.0.0",
@@ -6043,6 +6061,31 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-in-the-middle": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-4.0.0.tgz",
+      "integrity": "sha512-GX12iFhCUzzNuIqvei0dTLUbBEjZ420KTY/MmDxe2GQKPDGyH/wgfGMWFABpnM/M6sLwC3IaSg8A95U6gIb+HQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.10.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -6053,7 +6096,6 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
       "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }

--- a/sdk-js/package.json
+++ b/sdk-js/package.json
@@ -14,8 +14,9 @@
   "license": "ISC",
   "dependencies": {
     "lodash": "^4.17.11",
-    "uuid": "^3.3.2",
-    "stackman": "^3.0.2"
+    "require-in-the-middle": "^4.0.0",
+    "stackman": "^3.0.2",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "eslint": "^5.8.0",

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -155,9 +155,6 @@ class ServerlessSDK {
         trans.set('compute.custom.envMemoryFree', os.freemem())
         trans.set('compute.custom.envCpus', JSON.stringify(os.cpus()))
 
-        const transactionSpans = []
-        trans.set('spans', transactionSpans)
-
         // Capture Event Data: aws.apigateway.http
         if (eventType === 'aws.apigateway.http') {
           const timestamp = event.requestContext.requestTimeEpoch || Date.now().valueOf() // local testing does not contain a requestTimeEpoc
@@ -179,6 +176,8 @@ class ServerlessSDK {
           trans.set('event.custom.userAgent', event.headers['User-Agent'])
         }
         trans.set('event.custom.stage', meta.stageName)
+
+        const transactionSpans = trans.$.spans
 
         /*
          * Callback Wrapper

--- a/sdk-js/src/lib/parsers.js
+++ b/sdk-js/src/lib/parsers.js
@@ -179,11 +179,13 @@ module.exports.captureAwsRequestSpan = function(resp) {
   const spanDetails = {
     tags: {
       requestHostname: hostname,
-      'aws.region': awsRegion,
-      'aws.service': awsService,
-      'aws.operation': resp.request.operation,
-      'aws.requestId': resp.requestId,
-      'aws.errorCode': (resp.error && resp.error.code) || null
+      aws: {
+        region: awsRegion,
+        service: awsService,
+        operation: resp.request.operation,
+        requestId: resp.requestId,
+        errorCode: (resp.error && resp.error.code) || null
+      }
     },
     startTime: resp.request.startTime.toISOString(),
     endTime: endTime.toISOString(),

--- a/sdk-js/src/lib/parsers.js
+++ b/sdk-js/src/lib/parsers.js
@@ -161,3 +161,34 @@ exports.parseCallsite = function(callsite, isError, agent, cb) {
     cb(null, frame)
   })
 }
+
+module.exports.captureAwsRequestSpan = function(resp) {
+  const endTime = new Date()
+
+  const awsRegion = resp.request.httpRequest.region || null
+  // Global services do not include a region in the hostname
+  const awsBaseDomain = resp.request.service.isGlobalEndpoint
+    ? 'amazonaws.com'
+    : `${awsRegion}.amazonaws.com`
+  const hostname = resp.request.service.endpoint.host
+  // Strip the base domain (with region if applicable) from the end of the hostname to get the AWS service subdomain
+  const awsService = resp.request.service.endpoint.host.endsWith(awsBaseDomain)
+    ? resp.request.service.endpoint.host.slice(0, -1 * (awsBaseDomain.length + 1))
+    : resp.request.service.endpoint.host
+
+  const spanDetails = {
+    tags: {
+      requestHostname: hostname,
+      'aws.region': awsRegion,
+      'aws.service': awsService,
+      'aws.operation': resp.request.operation,
+      'aws.requestId': resp.requestId,
+      'aws.errorCode': (resp.error && resp.error.code) || null
+    },
+    startTime: resp.request.startTime.toISOString(),
+    endTime: endTime.toISOString(),
+    duration: endTime.getTime() - resp.request.startTime.getTime()
+  }
+
+  return spanDetails
+}

--- a/sdk-js/src/lib/proxyAwsSdk.js
+++ b/sdk-js/src/lib/proxyAwsSdk.js
@@ -1,0 +1,29 @@
+const EventEmitter = require('events')
+const requireHook = require('require-in-the-middle')
+const { captureAwsRequestSpan } = require('./parsers')
+
+const emitter = new EventEmitter()
+
+requireHook(['aws-sdk'], (awsSdk) => {
+  // Skip patching for extremely old version of aws-sdk that lack the necessary events
+  if (!awsSdk.Request || !awsSdk.Request.prototype.send || !awsSdk.Request.prototype.on) {
+    return awsSdk
+  }
+
+  // Monkey patch the send method with a proxy
+  awsSdk.Request.prototype.send = new Proxy(awsSdk.Request.prototype.send, {
+    apply: (_send, _thisRequest, _args) => {
+      // When the request is complete, capture span info
+      _thisRequest.on('complete', (_resp) => {
+        const span = captureAwsRequestSpan(_resp)
+        emitter.emit('span', span)
+      })
+      // Send the request as usual
+      return _send.apply(_thisRequest, _args)
+    }
+  })
+
+  return awsSdk
+})
+
+module.exports = emitter

--- a/sdk-js/src/lib/schemas/transaction-function.json
+++ b/sdk-js/src/lib/schemas/transaction-function.json
@@ -8,6 +8,7 @@
   "stageName": null,
   "functionName": null,
   "timeout": null,
+  "spans": [],
   "compute": {
     "type": "unknown",
     "runtime": null,

--- a/sdk-js/src/lib/schemas/transaction-function.json
+++ b/sdk-js/src/lib/schemas/transaction-function.json
@@ -8,7 +8,6 @@
   "stageName": null,
   "functionName": null,
   "timeout": null,
-  "spans": [],
   "compute": {
     "type": "unknown",
     "runtime": null,

--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -143,10 +143,6 @@ class Transaction {
   }
 
   /*
-   * TODO: Span
-   */
-
-  /*
    * Error
    * - Sends the error and ends the transaction
    */

--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -216,6 +216,7 @@ class Transaction {
       envelope.requestId = tags.computeCustomAwsRequestId
       envelope.type = type
 
+      // TODO: Redundant with `spans`? Why is there a singular span on the whole transaction?
       span.operationName = this.$.schema.schemaType
       span.startTime = this.$.schema.timestamp
       span.endTime = new Date().toISOString()

--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -74,7 +74,8 @@ class Transaction {
     this.$ = {
       schema: null,
       eTransaction: null,
-      duration: nanosecondnow() // start transaction timer
+      duration: nanosecondnow(), // start transaction timer
+      spans: []
     }
 
     /*
@@ -228,6 +229,7 @@ class Transaction {
       }
       span.tags = tags
       envelope.payload = span
+      envelope.payload.spans = this.$.spans
 
       console.log('SERVERLESS_ENTERPRISE', JSON.stringify(envelope))
       this.processed = true


### PR DESCRIPTION
This adds spans to the transaction payload and automatically captures all requests coming from `aws-sdk`. 

Something to note: I did not use the existing `span` schema that is present in the project. Since we decided that the spans will be included in the existing transaction payload, that was redundant.
