### PR TITLE
ditch babel-polyfill in favor of rgenerator-runtime

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,5 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.js'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   testEnvironment: 'node',
-  setupFiles: ['<rootDir>/src/polyfill.js']
+  setupFiles: ['<rootDir>/src/runtime.js']
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "serverless": "^1.43.0"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.2.5",
     "@serverless/event-mocks": "^1.1.1",
     "@serverless/platform-sdk": "^1.0.0",
     "chalk": "^2.4.2",
@@ -35,7 +34,8 @@
     "semver": "^5.6.0",
     "serialize-error": "^4.1.0",
     "yamljs": "^0.3.0",
-    "zlib": "^1.0.5"
+    "zlib": "^1.0.5",
+    "regenerator-runtime": "^0.13.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "node-dir": "^0.1.17",
     "node-fetch": "^2.3.0",
     "semver": "^5.6.0",
-    "serialize-error": "^4.1.0",
     "yamljs": "^0.3.0",
     "zlib": "^1.0.5",
     "regenerator-runtime": "^0.13.1"

--- a/sdk-js/package-lock.json
+++ b/sdk-js/package-lock.json
@@ -2826,15 +2826,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2851,22 +2849,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2997,8 +2992,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3012,7 +3006,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3029,7 +3022,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3038,15 +3030,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3067,7 +3057,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3156,8 +3145,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3171,7 +3159,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3309,7 +3296,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-require('./polyfill')
+require('./runtime')
 
 module.exports = require('./lib/plugin').default

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,8 @@
+describe('index', () => {
+  test('registers regeneratorRuntime', () => {
+    jest.resetModules()
+    global.regeneratorRuntime = undefined
+    require('./')
+    expect(global.regeneratorRuntime).toBe(require('regenerator-runtime'))
+  })
+})

--- a/src/lib/errorHandler.js
+++ b/src/lib/errorHandler.js
@@ -2,7 +2,7 @@
  * Error Handler
  */
 
-import serializeError from 'serialize-error'
+import serializeError from './serializeError'
 import { parseDeploymentData } from './deployment'
 
 export default function(ctx) {

--- a/src/lib/injectLogsIamRole.js
+++ b/src/lib/injectLogsIamRole.js
@@ -1,4 +1,5 @@
 import { getAccessKeyForTenant, getMetadata } from '@serverless/platform-sdk'
+import { entries } from 'lodash'
 
 export default async function(ctx) {
   if (
@@ -40,9 +41,7 @@ export default async function(ctx) {
               {
                 Effect: 'Allow',
                 Action: ['logs:FilterLogEvents'],
-                Resource: Object.entries(
-                  ctx.sls.service.provider.compiledCloudFormationTemplate.Resources
-                )
+                Resource: entries(ctx.sls.service.provider.compiledCloudFormationTemplate.Resources)
                   .filter(([, { Type }]) => Type === 'AWS::Logs::LogGroup')
                   .map(([logicalId]) => ({
                     'Fn::GetAtt': [logicalId, 'Arn']

--- a/src/lib/safeguards/policies/allowed-function-names.js
+++ b/src/lib/safeguards/policies/allowed-function-names.js
@@ -1,5 +1,5 @@
 const vm = require('vm')
-const { fromPairs } = require('lodash')
+const { entries, fromPairs } = require('lodash')
 
 /*
  * Converts a string that looks like a tagged template literal into a RegExp.
@@ -22,7 +22,7 @@ module.exports = function allowedFunctionNamesPolicy(policy, service, options) {
     Object.keys(functions || {}).map((funcName) => [naming.getLambdaLogicalId(funcName), funcName])
   )
 
-  for (const [funcName, { Properties, Type }] of Object.entries(Resources)) {
+  for (const [funcName, { Properties, Type }] of entries(Resources)) {
     if (Type !== 'AWS::Lambda::Function') {
       continue
     }

--- a/src/lib/safeguards/policies/forbid-s3-http-access.js
+++ b/src/lib/safeguards/policies/forbid-s3-http-access.js
@@ -1,3 +1,5 @@
+import { entries } from 'lodash'
+
 module.exports = function forbidS3HttpAccessPolicy(policy, service) {
   let failed = false
   const {
@@ -6,11 +8,9 @@ module.exports = function forbidS3HttpAccessPolicy(policy, service) {
     }
   } = service
 
-  const buckets = new Map(
-    Object.entries(Resources).filter(([, { Type }]) => Type === 'AWS::S3::Bucket')
-  )
+  const buckets = new Map(entries(Resources).filter(([, { Type }]) => Type === 'AWS::S3::Bucket'))
   const bucketPolicies = new Map(
-    Object.entries(Resources).filter(([, { Type }]) => Type === 'AWS::S3::BucketPolicy')
+    entries(Resources).filter(([, { Type }]) => Type === 'AWS::S3::BucketPolicy')
   )
   for (const [bucketName, bucket] of buckets) {
     let foundMatchingPolicy = false

--- a/src/lib/safeguards/policies/no-secret-env-vars.js
+++ b/src/lib/safeguards/policies/no-secret-env-vars.js
@@ -1,4 +1,4 @@
-const { fromPairs } = require('lodash')
+const { entries, fromPairs } = require('lodash')
 
 // from https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
 const truffleHogRegexes = {
@@ -53,7 +53,7 @@ module.exports = function noSecretEnvVarsPolicy(policy, service) {
     Object.keys(functions || {}).map((funcName) => [naming.getLambdaLogicalId(funcName), funcName])
   )
 
-  for (const [funcName, { Properties, Type }] of Object.entries(Resources)) {
+  for (const [funcName, { Properties, Type }] of entries(Resources)) {
     if (
       Type !== 'AWS::Lambda::Function' ||
       !Properties.Environment ||
@@ -62,7 +62,7 @@ module.exports = function noSecretEnvVarsPolicy(policy, service) {
       continue
     }
 
-    for (const [name, value] of Object.entries(Properties.Environment.Variables)) {
+    for (const [name, value] of entries(Properties.Environment.Variables)) {
       if (isSecret(value)) {
         const configFuncName = logicalFuncNamesToConfigFuncName[funcName] || funcName
         failed = true

--- a/src/lib/safeguards/policies/no-secret-env-vars.js
+++ b/src/lib/safeguards/policies/no-secret-env-vars.js
@@ -1,4 +1,4 @@
-const { entries, fromPairs } = require('lodash')
+const { entries, fromPairs, values } = require('lodash')
 
 // from https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
 const truffleHogRegexes = {
@@ -32,7 +32,7 @@ const truffleHogRegexes = {
   'Password in URL': new RegExp('[a-zA-Z]{3,10}://[^/\\s:@]{3,20}:[^/\\s:@]{3,20}@.{1,100}["\'\\s]')
 }
 function isSecret(string) {
-  for (const regex of Object.values(truffleHogRegexes)) {
+  for (const regex of values(truffleHogRegexes)) {
     if (regex.test(string)) {
       return true
     }

--- a/src/lib/safeguards/policies/no-wild-iam-role-statements.js
+++ b/src/lib/safeguards/policies/no-wild-iam-role-statements.js
@@ -1,3 +1,5 @@
+import { values } from 'lodash'
+
 module.exports = function noWildIamPolicy(policy, service) {
   let failed = false
   const {
@@ -6,7 +8,7 @@ module.exports = function noWildIamPolicy(policy, service) {
     }
   } = service
 
-  for (const { Type, Properties } of Object.values(Resources)) {
+  for (const { Type, Properties } of values(Resources)) {
     if (Type !== 'AWS::IAM::Role') {
       continue
     }

--- a/src/lib/safeguards/policies/require-description.js
+++ b/src/lib/safeguards/policies/require-description.js
@@ -1,4 +1,4 @@
-const { fromPairs } = require('lodash')
+const { entries, fromPairs } = require('lodash')
 
 module.exports = function requireDescriptionPolicy(policy, service, options) {
   let failed = false
@@ -13,7 +13,7 @@ module.exports = function requireDescriptionPolicy(policy, service, options) {
     Object.keys(functions || {}).map((funcName) => [naming.getLambdaLogicalId(funcName), funcName])
   )
 
-  for (const [funcName, { Properties, Type }] of Object.entries(Resources)) {
+  for (const [funcName, { Properties, Type }] of entries(Resources)) {
     if (Type !== 'AWS::Lambda::Function') {
       continue
     }

--- a/src/lib/safeguards/policies/require-dlq.js
+++ b/src/lib/safeguards/policies/require-dlq.js
@@ -1,4 +1,4 @@
-const { fromPairs } = require('lodash')
+const { entries, fromPairs } = require('lodash')
 
 const asyncEvents = new Set([
   's3',
@@ -23,8 +23,8 @@ module.exports = function dlqPolicy(policy, service) {
     Object.keys(functions || {}).map((funcName) => [naming.getLambdaLogicalId(funcName), funcName])
   )
 
-  // for (const [name, { events, onError }] of Object.entries(functions)) {
-  for (const [funcName, { Properties, Type }] of Object.entries(Resources)) {
+  // for (const [name, { events, onError }] of entries(functions)) {
+  for (const [funcName, { Properties, Type }] of entries(Resources)) {
     if (
       Type !== 'AWS::Lambda::Function' ||
       (Properties.DeadLetterConfig && Properties.DeadLetterConfig.TargetArn)

--- a/src/lib/safeguards/policies/require-global-vpc.js
+++ b/src/lib/safeguards/policies/require-global-vpc.js
@@ -1,4 +1,4 @@
-const { fromPairs } = require('lodash')
+const { entries, fromPairs } = require('lodash')
 
 module.exports = function requireGlobalVpcPolicy(
   policy,
@@ -23,7 +23,7 @@ module.exports = function requireGlobalVpcPolicy(
       Properties: { VpcConfig },
       Type
     }
-  ] of Object.entries(Resources)) {
+  ] of entries(Resources)) {
     if (Type !== 'AWS::Lambda::Function') {
       continue
     }

--- a/src/lib/serializeError.js
+++ b/src/lib/serializeError.js
@@ -1,0 +1,56 @@
+// coppied from https://github.com/sindresorhus/serialize-error/blob/master/index.js and converted
+// to use _.entries instead of Object.entries. and linted for our standards
+
+import { entries } from 'lodash'
+
+const destroyCircular = (from, seen) => {
+  const to = Array.isArray(from) ? [] : {}
+
+  seen.push(from)
+
+  for (const [key, value] of entries(from)) {
+    if (typeof value === 'function') {
+      continue
+    }
+
+    if (!value || typeof value !== 'object') {
+      to[key] = value
+      continue
+    }
+
+    if (!seen.includes(from[key])) {
+      to[key] = destroyCircular(from[key], seen.slice())
+      continue
+    }
+
+    to[key] = '[Circular]'
+  }
+
+  const commonProperties = ['name', 'message', 'stack', 'code']
+
+  for (const property of commonProperties) {
+    if (typeof from[property] === 'string') {
+      to[property] = from[property]
+    }
+  }
+
+  return to
+}
+
+const serializeError = (value) => {
+  if (typeof value === 'object') {
+    return destroyCircular(value, [])
+  }
+
+  // People sometimes throw things besides Error objects…
+  if (typeof value === 'function') {
+    // `JSON.stringify()` discards functions. We do too, unless a function is thrown directly.
+    return `[Function: ${value.name || 'anonymous'}]`
+  }
+
+  return value
+}
+
+module.exports = serializeError
+// TODO: Remove this for the next major release
+module.exports.default = serializeError

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,0 +1,7 @@
+if (!global.regeneratorRuntime) {
+  // eslint-disable-next-line global-require
+  global.regeneratorRuntime = require('regenerator-runtime')
+}
+
+// eslint-disable-next-line global-require
+require('source-map-support/register')

--- a/src/runtime.test.js
+++ b/src/runtime.test.js
@@ -1,0 +1,8 @@
+describe('runtime.js', () => {
+  test('it registers regeneratorRuntime', () => {
+    jest.resetModules()
+    global.regeneratorRuntime = undefined
+    require('./runtime')
+    expect(global.regeneratorRuntime).toBe(require('regenerator-runtime'))
+  })
+})


### PR DESCRIPTION
Also refactored to use `_.entries` in place of `Object.entries` to maintain node 6 compatibility.

This will get rid of the `core-js` ad