### PR TITLE
Hotfix bug with async init in disabled conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "node": ">=6.0"
   },

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -23,6 +23,8 @@ import { configureDeployProfile } from './deployProfile'
 
 class ServerlessEnterprisePlugin {
   constructor(sls) {
+    this.sls = sls
+
     configureFetchDefaults()
     const user = getLoggedInUser()
     const currentCommand = sls.processedInput.commands[0]
@@ -88,7 +90,6 @@ class ServerlessEnterprisePlugin {
     sls.enterpriseEnabled = true
 
     // Defaults
-    this.sls = sls
     this.state = {} // Useful for storing data across hooks
     this.state.secretsUsed = new Set()
     this.provider = this.sls.getProvider('aws')


### PR DESCRIPTION
always set this.sls. this bug would occur if you have no app/tenant set and not logged in but have the plugin
which for example.. will be the case when integrated with SFO