### PR TITLE
Set transactionId for APIGW requests

### DIFF
--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -169,6 +169,9 @@ class ServerlessSDK {
           trans.set('event.custom.httpMethod', event.requestContext.httpMethod)
           trans.set('event.custom.xTraceId', event.headers['X-Amzn-Trace-Id'])
           trans.set('event.custom.userAgent', event.headers['User-Agent'])
+
+          // For APIGW access logs
+          trans.$.schema.transactionId = event.requestContext.requestId
         }
         trans.set('event.custom.stage', meta.stageName)
 

--- a/sdk-js/src/lib/eventDetection/eventTypes/customAuthorizer.js
+++ b/sdk-js/src/lib/eventDetection/eventTypes/customAuthorizer.js
@@ -1,0 +1,10 @@
+const type = 'aws.apigateway.authorizer'
+
+module.exports = function eventType(event) {
+  if (typeof event === 'object') {
+    const hasMethodArn = event.methodArn
+    const hasType = ['TOKEN', 'REQUEST'].includes(event.type)
+    return hasMethodArn && hasType ? type : false
+  }
+  return false
+}

--- a/sdk-js/src/lib/eventDetection/index.js
+++ b/sdk-js/src/lib/eventDetection/index.js
@@ -1,5 +1,6 @@
 const alexaSkill = require('./eventTypes/alexaSkill')
 const apiGateway = require('./eventTypes/apiGateway')
+const customAuthorizer = require('./eventTypes/customAuthorizer')
 const cloudFront = require('./eventTypes/cloudFront')
 const firehose = require('./eventTypes/firehose')
 const kinesis = require('./eventTypes/kinesis')
@@ -11,6 +12,8 @@ const sqs = require('./eventTypes/sqs')
 
 const detectEventType = (event) =>
   alexaSkill(event) ||
+  // Custom authorizer must come before apiGateway because they share similar keys.
+  customAuthorizer(event) ||
   apiGateway(event) ||
   cloudFront(event) ||
   firehose(event) ||

--- a/sdk-js/src/lib/eventDetection/index.test.js
+++ b/sdk-js/src/lib/eventDetection/index.test.js
@@ -157,6 +157,64 @@ const cloudFront = {
   ]
 }
 
+const customAuthorizerToken = {
+  type: 'TOKEN',
+  authorizationToken: 'allow',
+  methodArn: 'arn:aws:execute-api:us-west-2:123456789012:ymy8tbxw7b/*/GET/'
+}
+
+const customAuthorizerRequest = {
+  type: 'REQUEST',
+  methodArn: 'arn:aws:execute-api:us-east-1:123456789012:s4x3opwd6i/test/GET/request',
+  resource: '/request',
+  path: '/request',
+  httpMethod: 'GET',
+  headers: {
+    'X-AMZ-Date': '20170718T062915Z',
+    Accept: '*/*',
+    HeaderAuth1: 'headerValue1',
+    'CloudFront-Viewer-Country': 'US',
+    'CloudFront-Forwarded-Proto': 'https',
+    'CloudFront-Is-Tablet-Viewer': 'false',
+    'CloudFront-Is-Mobile-Viewer': 'false',
+    'User-Agent': '...',
+    'X-Forwarded-Proto': 'https',
+    'CloudFront-Is-SmartTV-Viewer': 'false',
+    Host: '....execute-api.us-east-1.amazonaws.com',
+    'Accept-Encoding': 'gzip, deflate',
+    'X-Forwarded-Port': '443',
+    'X-Amzn-Trace-Id': '...',
+    Via: '...cloudfront.net (CloudFront)',
+    'X-Amz-Cf-Id': '...',
+    'X-Forwarded-For': '..., ...',
+    'Postman-Token': '...',
+    'cache-control': 'no-cache',
+    'CloudFront-Is-Desktop-Viewer': 'true',
+    'Content-Type': 'application/x-www-form-urlencoded'
+  },
+  queryStringParameters: {
+    QueryString1: 'queryValue1'
+  },
+  pathParameters: {},
+  stageVariables: {
+    StageVar1: 'stageValue1'
+  },
+  requestContext: {
+    path: '/request',
+    accountId: '123456789012',
+    resourceId: '05c7jb',
+    stage: 'test',
+    requestId: '...',
+    identity: {
+      apiKey: '...',
+      sourceIp: '...'
+    },
+    resourcePath: '/request',
+    httpMethod: 'GET',
+    apiId: 's4x3opwd6i'
+  }
+}
+
 const firehose = {
   invocationId: 'invoked123',
   deliveryStreamArn: 'aws:lambda:events',
@@ -368,6 +426,14 @@ describe('eventDetection', () => {
 
   it('identifies cloudFront', () => {
     expect(detectEventType(cloudFront)).toEqual('aws.cloudfront')
+  })
+
+  it('identifies token custom authorizers', () => {
+    expect(detectEventType(customAuthorizerToken)).toEqual('aws.apigateway.authorizer')
+  })
+
+  it('identifies request custom authorizers', () => {
+    expect(detectEventType(customAuthorizerRequest)).toEqual('aws.apigateway.authorizer')
   })
 
   it('identifies firehose', () => {


### PR DESCRIPTION
[PLAT-1167](https://serverlessteam.atlassian.net/browse/PLAT-1167)

This does two things:

1) It identifies when an event type is a APIGW custom authorizer and sets the eventType to `aws.apigateway.authorizer`.

2) When the eventType is `aws.apigateway.http`, it sets the transaction's `transactionId` property to the APIGW request Id, which will be used for APIGW access log correlation.