### PR TITLE
Fix tests setup and meta data

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   coverageDirectory: './coverage/',
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.js'],
-  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  testPathIgnorePatterns: ['/dist', '/node_modules'],
   testEnvironment: 'node',
   setupFiles: ['<rootDir>/src/runtime.js']
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   coverageDirectory: './coverage/',
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.js'],
-  testPathIgnorePatterns: ['/dist', '/node_modules'],
+  testPathIgnorePatterns: ['/dist', '/node_modules', '/sdk-js'],
   testEnvironment: 'node',
   setupFiles: ['<rootDir>/src/runtime.js']
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-config-prettier": "^3.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-prettier": "^3.0.0",
-    "jest": "^23.6.0",
+    "jest": "^24.8.0",
     "lint-staged": "^8.1.5",
     "pre-commit": "^1.2.2",
     "prettier": "^1.14.3",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "moment": "^2.24.0",
     "node-dir": "^0.1.17",
     "node-fetch": "^2.3.0",
+    "regenerator-runtime": "^0.13.1",
     "semver": "^5.6.0",
-    "yamljs": "^0.3.0",
-    "regenerator-runtime": "^0.13.1"
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "fs-extra": "^7.0.1",
     "iso8601-duration": "^1.1.7",
     "isomorphic-fetch": "^2.2.1",
+    "js-yaml": "^3.13.1",
     "jsonata": "^1.6.4",
     "jszip": "^3.2.1",
     "lodash": "^4.17.11",
@@ -31,6 +32,7 @@
     "node-fetch": "^2.3.0",
     "regenerator-runtime": "^0.13.1",
     "semver": "^5.6.0",
+    "source-map-support": "^0.5.12",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Upgrade `jest` to v24

Project relies on `babel@7` while `jest@23` was configured with `babel@6`, and some of its dependencies depend on it

It worked ok so far (with regular npm installation) just by fact of `babel-core@6` being installed as a deep `jest` dependency (for `jest-runtime` and some others) and not being exposed to `babel-jest`.

While in scenario where e.g. `jest` is installed with `npm link` it crashed with below error, as `babel-jest` will have `babel-core@6` exposed

```
ERROR: Requires Babel "^7.0.0-0", but was loaded with "6.26.3". If you are sure you have a compatible version of @babel/core, it is likely that something in your build process is loading the wrong version. Inspect the stack trace of this error to look for the first entry that doesn't mention "@babel/core" or "babel-core" to see what is calling Babel.
```

#### Add missing dependencies

- `source-map-support` - used by [`src/runtime.js`](https://github.com/serverless/enterprise-plugin/blob/1539205d4b3253f7ad5b80d3c07ac0c549f52a1b/src/runtime.js#L7)
- `js-yaml` - used by [`src/lib/test/index.js`](https://github.com/serverless/enterprise-plugin/blob/1539205d4b3253f7ad5b80d3c07ac0c549f52a1b/src/lib/test/index.js#L4)

In normal installation they were seen only because they're dependencies of dependencies (while versioning of it was not being controlled in any way, after this change is in, it is)

#### Do not run tests of sdk-js in context of main tests configuration

It fails, when sdk-js is not setup, and to my understanding test suites for both are intended to be setup independently
