### PR TITLE
Add missing dependency to 'sdk-js'

### DIFF
--- a/integration-testing/safegaurds.test.js
+++ b/integration-testing/safegaurds.test.js
@@ -13,6 +13,10 @@ describe('integration', () => {
     const stdout = proc.stdout.toString()
     expect(stdout).toMatch('warned - require-cfn-role')
     expect(stdout).toMatch('Warned - no cfnRole set')
+    if (proc.status) {
+      process.stderr.write(proc.stdout)
+      process.stderr.write(proc.stderr)
+    }
     expect(proc.status).toEqual(0)
   })
 
@@ -50,6 +54,10 @@ describe('integration', () => {
     expect(stdout).toMatch(
       `Warned - iamRoleStatement granting Resource='*'. Wildcard resources in iamRoleStatements are not permitted.`
     )
+    if (proc.status) {
+      process.stderr.write(proc.stdout)
+      process.stderr.write(proc.stderr)
+    }
     expect(proc.status).toEqual(0)
   })
 
@@ -67,6 +75,10 @@ describe('integration', () => {
     expect(stdout).toMatch(
       `Warned - Environment variable variable1 on function 'hello' looks like it contains a secret value`
     )
+    if (proc.status) {
+      process.stderr.write(proc.stdout)
+      process.stderr.write(proc.stderr)
+    }
     expect(proc.status).toEqual(0)
   })
 
@@ -80,6 +92,10 @@ describe('integration', () => {
     expect(stdout).toMatch(
       `Warned - Function \"hello\" doesn't have a Dead Letter Queue configured.`
     )
+    if (proc.status) {
+      process.stderr.write(proc.stdout)
+      process.stderr.write(proc.stderr)
+    }
     expect(proc.status).toEqual(0)
   })
 })

--- a/sdk-js/package.json
+++ b/sdk-js/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "after-all-results": "^2.0.0",
     "lodash": "^4.17.11",
     "require-in-the-middle": "^4.0.0",
     "stackman": "^3.0.2",


### PR DESCRIPTION
`after-all-results` used in [`src/lib/parsers.js`](https://github.com/serverless/enterprise-plugin/blob/e25dfeedab8c3ed7583867261ef96aaee3e0f050/sdk-js/src/lib/parsers.js#L2) but not enlisted as dependency

--- 

Additionally as integration tests failed for some moment, ensured they expose process output in case of crash