### PR TITLE
Register missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "regenerator-runtime": "^0.13.1",
     "semver": "^5.6.0",
     "source-map-support": "^0.5.12",
+    "uuid": "^3.3.2",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Issue that sneaked with #167

Currently works by a chance, that some of our dependencies lists `uuid` as its dependency, but we do not control version of it in any way.

Such errors will be automatically detected once we switch to [@serverless/eslint-config](https://github.com/serverless/eslint-config#serverlesseslint-config) (hopefully soon), as it's covered by `import/no-extraneous-dependencies` rule
