### PR TITLE
Switch to require from ESM

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,11 +2,8 @@
   "presets": [
     ["@babel/env", {
       "targets": {
-        "node": "4"
+        "node": "6"
       }
     }]
-  ],
-  "plugins": [
-    ["@babel/plugin-proposal-object-rest-spread", { "useBuiltIns": true }]
   ]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,13 +7,8 @@ module.exports = {
     jest: true,
     node: true
   },
-  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
-    sourceType: 'module',
-    ecmaFeatures: {
-      jsx: true
-    }
   },
   rules: {
     'array-bracket-spacing': [

--- a/integration-testing/outputs.test.js
+++ b/integration-testing/outputs.test.js
@@ -1,5 +1,5 @@
-import stripAnsi from 'strip-ansi'
-import setup from './setup'
+const stripAnsi = require('strip-ansi')
+const setup = require('./setup')
 
 let sls1, sls2, teardown
 

--- a/integration-testing/safeguards.test.js
+++ b/integration-testing/safeguards.test.js
@@ -1,5 +1,5 @@
-import stripAnsi from 'strip-ansi'
-import setup from './setup'
+const stripAnsi = require('strip-ansi')
+const setup = require('./setup')
 
 let sls, teardown
 

--- a/integration-testing/secrets.test.js
+++ b/integration-testing/secrets.test.js
@@ -1,5 +1,5 @@
-import stripAnsi from 'strip-ansi'
-import setup from './setup'
+const stripAnsi = require('strip-ansi')
+const setup = require('./setup')
 
 let sls
 

--- a/integration-testing/setup.js
+++ b/integration-testing/setup.js
@@ -1,11 +1,19 @@
-import path from 'path'
-import os from 'os'
-import crypto from 'crypto'
-import { copy, ensureDir, ensureSymlink, readFile, remove, writeFile, writeJson } from 'fs-extra'
-import spawn from 'child-process-ext/spawn'
-import fetch from 'node-fetch'
-import tar from 'tar'
-import { memoize } from 'lodash'
+const path = require('path')
+const os = require('os')
+const crypto = require('crypto')
+const {
+  copy,
+  ensureDir,
+  ensureSymlink,
+  readFile,
+  remove,
+  writeFile,
+  writeJson
+} = require('fs-extra')
+const spawn = require('child-process-ext/spawn')
+const fetch = require('node-fetch')
+const tar = require('tar')
+const { memoize } = require('lodash')
 
 const tmpDir = os.tmpdir()
 
@@ -49,7 +57,7 @@ const retrieveServerless = memoize(async () => {
   return path.join(serverlessTmpDir, 'bin/serverless')
 })
 
-export default async function(templateName) {
+module.exports = async function(templateName) {
   const randomPostfix = crypto.randomBytes(2).toString('hex')
   const serviceTmpDir = path.join(tmpDir, `serverless-enterprise-plugin-test-${randomPostfix}`)
 

--- a/package.json
+++ b/package.json
@@ -39,13 +39,7 @@
   "devDependencies": {
     "@babel/cli": "^7.1.0",
     "@babel/core": "^7.1.0",
-    "@babel/node": "^7.0.0",
-    "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
-    "@babel/register": "^7.0.0",
-    "babel-core": "^7.0.0-bridge.0",
-    "babel-eslint": "^10.0.1",
-    "babel-jest": "^23.6.0",
     "child-process-ext": "^2.0.0",
     "eslint": "^5.8.0",
     "eslint-config-prettier": "^3.1.0",

--- a/sdk-js/.eslintrc.js
+++ b/sdk-js/.eslintrc.js
@@ -7,13 +7,8 @@ module.exports = {
     jest: true,
     node: true
   },
-  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2018,
-    sourceType: 'module',
-    ecmaFeatures: {
-      jsx: true
-    }
   },
   rules: {
     'array-bracket-spacing': [

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 require('./runtime')
 const { version } = require('@serverless/platform-sdk/package.json')
 
-module.exports = require('./lib/plugin').default
+module.exports = require('./lib/plugin')
 module.exports.sdkVersion = version

--- a/src/lib/appUids.js
+++ b/src/lib/appUids.js
@@ -1,6 +1,6 @@
-import { getApp } from '@serverless/platform-sdk'
+const { getApp } = require('@serverless/platform-sdk')
 
-export default async function(tenantName, appName) {
+module.exports = async function(tenantName, appName) {
   const app = await getApp({
     tenant: tenantName,
     app: appName

--- a/src/lib/appUids.test.js
+++ b/src/lib/appUids.test.js
@@ -1,5 +1,5 @@
-import appUids from './appUids'
-import { getApp } from '@serverless/platform-sdk'
+const appUids = require('./appUids')
+const { getApp } = require('@serverless/platform-sdk')
 
 jest.mock('@serverless/platform-sdk', () => ({
   getApp: jest.fn().mockReturnValue(Promise.resolve({ appUid: 'AUID', tenantUid: 'TUID' }))

--- a/src/lib/archiveService.js
+++ b/src/lib/archiveService.js
@@ -2,9 +2,9 @@
  * Archive Service
  */
 
-import { archiveService, getAccessKeyForTenant } from '@serverless/platform-sdk'
+const { archiveService, getAccessKeyForTenant } = require('@serverless/platform-sdk')
 
-export default async function(ctx) {
+module.exports = async function(ctx) {
   // Defaults
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant)
 

--- a/src/lib/credentials.js
+++ b/src/lib/credentials.js
@@ -1,6 +1,6 @@
-import { getCredentials, getAccessKeyForTenant } from '@serverless/platform-sdk'
+const { getCredentials, getAccessKeyForTenant } = require('@serverless/platform-sdk')
 
-export default async function(ctx) {
+module.exports = async function(ctx) {
   if (!process.env.SLS_CLOUD_ACCESS) {
     return Promise.resolve()
   }

--- a/src/lib/credentials.test.js
+++ b/src/lib/credentials.test.js
@@ -1,5 +1,5 @@
-import getCredentialsLocal from './credentials'
-import { getCredentials, getAccessKeyForTenant } from '@serverless/platform-sdk'
+const getCredentialsLocal = require('./credentials')
+const { getCredentials, getAccessKeyForTenant } = require('@serverless/platform-sdk')
 
 jest.mock('@serverless/platform-sdk', () => ({
   getAccessKeyForTenant: jest.fn().mockReturnValue(Promise.resolve('ACCESS_KEY')),

--- a/src/lib/dashboard.js
+++ b/src/lib/dashboard.js
@@ -1,6 +1,6 @@
-import { urls } from '@serverless/platform-sdk'
+const { urls } = require('@serverless/platform-sdk')
 
-export const getDashboardUrl = (ctx) => {
+module.exports.getDashboardUrl = (ctx) => {
   let dashboardUrl = urls.frontendUrl
   dashboardUrl += `tenants/${ctx.sls.service.tenant}/`
   dashboardUrl += `applications/${ctx.sls.service.app}/`

--- a/src/lib/deployProfile.js
+++ b/src/lib/deployProfile.js
@@ -1,8 +1,8 @@
-import _ from 'lodash'
-import { getAccessKeyForTenant, getDeployProfile } from '@serverless/platform-sdk'
-import { hookIntoVariableGetter } from './variables'
+const _ = require('lodash')
+const { getAccessKeyForTenant, getDeployProfile } = require('@serverless/platform-sdk')
+const { hookIntoVariableGetter } = require('./variables')
 
-export const configureDeployProfile = async (ctx) => {
+module.exports.configureDeployProfile = async (ctx) => {
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant)
   const deploymentProfile = await getDeployProfile({
     accessKey,

--- a/src/lib/deployProfile.test.js
+++ b/src/lib/deployProfile.test.js
@@ -1,6 +1,6 @@
-import { getAccessKeyForTenant, getDeployProfile } from '@serverless/platform-sdk'
-import { hookIntoVariableGetter } from './variables'
-import { configureDeployProfile } from './deployProfile'
+const { getAccessKeyForTenant, getDeployProfile } = require('@serverless/platform-sdk')
+const { hookIntoVariableGetter } = require('./variables')
+const { configureDeployProfile } = require('./deployProfile')
 
 jest.mock('@serverless/platform-sdk', () => ({
   getAccessKeyForTenant: jest.fn().mockReturnValue(Promise.resolve('accessKey')),

--- a/src/lib/deployment/createAndSetUid.js
+++ b/src/lib/deployment/createAndSetUid.js
@@ -1,7 +1,7 @@
-import uuid from 'uuid'
+const uuid = require('uuid')
 
 const createAndSetDeploymentUid = (ctx) => {
   ctx.deploymentUid = uuid.v4()
 }
 
-export default createAndSetDeploymentUid
+module.exports = createAndSetDeploymentUid

--- a/src/lib/deployment/createAndSetUid.test.js
+++ b/src/lib/deployment/createAndSetUid.test.js
@@ -1,4 +1,4 @@
-import createAndSetDeploymentUid from './createAndSetUid'
+const createAndSetDeploymentUid = require('./createAndSetUid')
 
 describe('createAndSetDeploymentUid', () => {
   it('generates a random id and sets it on the contxt', () => {

--- a/src/lib/deployment/getServerlessFilePath.js
+++ b/src/lib/deployment/getServerlessFilePath.js
@@ -1,5 +1,5 @@
-import path from 'path'
-import fs from 'fs-extra'
+const path = require('path')
+const fs = require('fs-extra')
 
 const fileExists = async (filename) => {
   try {
@@ -10,7 +10,7 @@ const fileExists = async (filename) => {
   }
 }
 
-export default async function getServerlessFilePath(filename, servicePath) {
+module.exports = async function getServerlessFilePath(filename, servicePath) {
   if (filename) {
     const filePath = path.join(servicePath, filename)
     const customExists = await fileExists(filePath)

--- a/src/lib/deployment/getServerlessFilePath.js
+++ b/src/lib/deployment/getServerlessFilePath.js
@@ -5,7 +5,7 @@ const fileExists = async (filename) => {
   try {
     const stat = await fs.lstat(filename)
     return stat.isFile()
-  } catch {
+  } catch (error) {
     return false
   }
 }

--- a/src/lib/deployment/getServerlessFilePath.test.js
+++ b/src/lib/deployment/getServerlessFilePath.test.js
@@ -1,5 +1,5 @@
-import getServerlessFilePath from './getServerlessFilePath'
-import fs from 'fs-extra'
+const getServerlessFilePath = require('./getServerlessFilePath')
+const fs = require('fs-extra')
 
 jest.mock('fs-extra', () => ({
   lstat: jest.fn().mockReturnValue(Promise.resolve({ isFile: jest.fn().mockReturnValue(true) }))

--- a/src/lib/deployment/index.js
+++ b/src/lib/deployment/index.js
@@ -1,4 +1,6 @@
-export { default as parseDeploymentData } from './parse'
-export { default as saveDeployment } from './save'
-export { default as getServerlessFilePath } from './getServerlessFilePath'
-export { default as createAndSetDeploymentUid } from './createAndSetUid'
+module.exports = {
+  parseDeploymentData: require('./parse'),
+  saveDeployment: require('./save'),
+  getServerlessFilePath: require('./getServerlessFilePath'),
+  createAndSetDeploymentUid: require('./createAndSetUid')
+}

--- a/src/lib/deployment/parse.js
+++ b/src/lib/deployment/parse.js
@@ -3,11 +3,11 @@
  * - This uses the new deployment data model.
  */
 
-import fs from 'fs-extra'
-import _ from 'lodash'
-import SDK from '@serverless/platform-sdk'
-import getServerlessFilePath from './getServerlessFilePath'
-import { version as packageJsonVersion } from '../../../package.json'
+const fs = require('fs-extra')
+const _ = require('lodash')
+const SDK = require('@serverless/platform-sdk')
+const getServerlessFilePath = require('./getServerlessFilePath')
+const { version: packageJsonVersion } = require('../../../package.json')
 
 /*
  * Parse Deployment Data
@@ -170,4 +170,4 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
   return deployment
 }
 
-export default parseDeploymentData
+module.exports = parseDeploymentData

--- a/src/lib/deployment/parse.test.js
+++ b/src/lib/deployment/parse.test.js
@@ -1,6 +1,6 @@
-import { version as pluginVersion } from '../../../package.json'
-import { version as sdkVersion } from '@serverless/platform-sdk/package.json'
-import parseDeploymentData from './parse'
+const { version: pluginVersion } = require('../../../package.json')
+const { version: sdkVersion } = require('@serverless/platform-sdk/package.json')
+const parseDeploymentData = require('./parse')
 
 const frameworkVersion = '1.38.0'
 

--- a/src/lib/deployment/save.js
+++ b/src/lib/deployment/save.js
@@ -3,9 +3,9 @@
  * - This uses the new deployment data model.
  */
 
-import parseDeploymentData from './parse'
+const parseDeploymentData = require('./parse')
 
-export default async function(ctx, archived = false) {
+module.exports = async function(ctx, archived = false) {
   ctx.sls.cli.log('Publishing service to the Enterprise Dashboard...', 'Serverless Enterprise')
 
   const deployment = await parseDeploymentData(ctx, undefined, undefined, archived)

--- a/src/lib/deployment/save.test.js
+++ b/src/lib/deployment/save.test.js
@@ -1,5 +1,5 @@
-import parseDeploymentData from './parse'
-import saveDeployment from './save'
+const parseDeploymentData = require('./parse')
+const saveDeployment = require('./save')
 
 jest.mock('./parse', () =>
   jest.fn().mockReturnValue(

--- a/src/lib/errorHandler.js
+++ b/src/lib/errorHandler.js
@@ -2,10 +2,10 @@
  * Error Handler
  */
 
-import serializeError from './serializeError'
-import { parseDeploymentData } from './deployment'
+const serializeError = require('./serializeError')
+const { parseDeploymentData } = require('./deployment')
 
-export default function(ctx) {
+module.exports = function(ctx) {
   return async function(error, id) { // eslint-disable-line
     /*
      * Error: Failed Deployment

--- a/src/lib/errorHandler.test.js
+++ b/src/lib/errorHandler.test.js
@@ -1,5 +1,5 @@
-import errorHandler from './errorHandler'
-import { parseDeploymentData } from './deployment'
+const errorHandler = require('./errorHandler')
+const { parseDeploymentData } = require('./deployment')
 
 jest.mock('./deployment', () => ({
   parseDeploymentData: jest

--- a/src/lib/generateEvent.js
+++ b/src/lib/generateEvent.js
@@ -1,5 +1,5 @@
-import createEvent from '@serverless/event-mocks'
-import zlib from 'zlib'
+const createEvent = require('@serverless/event-mocks').default
+const zlib = require('zlib')
 
 function recordWrapper(event) {
   return {
@@ -28,7 +28,7 @@ function parsedBody(body) {
   return JSON.parse(body)
 }
 
-export const eventDict = {
+const eventDict = {
   'aws:apiGateway': (body) => ({ body: body }),
   'aws:websocket': (body) => ({ body: body }),
   'aws:sns': (body) => recordWrapper({ Sns: { Message: body } }),
@@ -58,7 +58,7 @@ async function wrapEvent(eventType, body) {
   throw new Error('Invalid event specified.')
 }
 
-export async function generate(ctx) {
+const generate = async function(ctx) {
   const { options } = ctx.sls.processedInput
   const body = options.body === undefined ? '{}' : options.body
   const event = await wrapEvent(options.type, body)

--- a/src/lib/generateEvent.test.js
+++ b/src/lib/generateEvent.test.js
@@ -1,5 +1,5 @@
-import { generate } from './generateEvent'
-import zlib from 'zlib'
+const { generate } = require('./generateEvent')
+const zlib = require('zlib')
 
 describe('generating events', () => {
   afterEach(() => {

--- a/src/lib/injectLogsIamRole.js
+++ b/src/lib/injectLogsIamRole.js
@@ -1,7 +1,7 @@
-import { getAccessKeyForTenant, getMetadata } from '@serverless/platform-sdk'
-import { entries, values } from 'lodash'
+const { getAccessKeyForTenant, getMetadata } = require('@serverless/platform-sdk')
+const { entries, values } = require('lodash')
 
-export default async function(ctx) {
+module.exports = async function(ctx) {
   if (
     ctx.sls.service.custom &&
     ctx.sls.service.custom.enterprise &&

--- a/src/lib/injectLogsIamRole.test.js
+++ b/src/lib/injectLogsIamRole.test.js
@@ -1,5 +1,5 @@
-import injectLogsIamRole from './injectLogsIamRole'
-import { getAccessKeyForTenant, getMetadata } from '@serverless/platform-sdk'
+const injectLogsIamRole = require('./injectLogsIamRole')
+const { getAccessKeyForTenant, getMetadata } = require('@serverless/platform-sdk')
 
 jest.mock('@serverless/platform-sdk', () => ({
   getAccessKeyForTenant: jest.fn().mockReturnValue(Promise.resolve('token')),

--- a/src/lib/login.js
+++ b/src/lib/login.js
@@ -1,6 +1,6 @@
-import { login } from '@serverless/platform-sdk'
+const { login } = require('@serverless/platform-sdk')
 
-export default async function(ctx) {
+module.exports = async function(ctx) {
   ctx.sls.cli.log('Logging you in via your default browser...', 'Serverless Enterprise')
   // Include a "tenant" in "login()"...
   // This will create a new accessKey for that tenant on every login.

--- a/src/lib/login.test.js
+++ b/src/lib/login.test.js
@@ -1,5 +1,5 @@
-import sdk from '@serverless/platform-sdk'
-import login from './login'
+const sdk = require('@serverless/platform-sdk')
+const login = require('./login')
 
 jest.mock('@serverless/platform-sdk', () => ({
   login: jest

--- a/src/lib/logout.js
+++ b/src/lib/logout.js
@@ -1,6 +1,6 @@
-import { logout } from '@serverless/platform-sdk'
+const { logout } = require('@serverless/platform-sdk')
 
-export default async function(ctx) {
+module.exports = async function(ctx) {
   return logout().then(() => {
     ctx.sls.cli.log('You sucessfully logged out of Serverless Enterprise.', 'Serverless Enterprise')
     process.exit(0)

--- a/src/lib/logsCollection.js
+++ b/src/lib/logsCollection.js
@@ -4,16 +4,16 @@
  * - Collects `sls-access-logs` from API Gateway access logs
  */
 
-import {
+const {
   pickResourceType,
   upperFirst,
   API_GATEWAY_FILTER_PATTERN,
   LAMBDA_FILTER_PATTERN
-} from './utils'
+} = require('./utils')
 
-import { getAccessKeyForTenant, getLogDestination } from '@serverless/platform-sdk'
+const { getAccessKeyForTenant, getLogDestination } = require('@serverless/platform-sdk')
 
-export default async (ctx) => {
+module.exports = async (ctx) => {
   if (
     ctx.sls.service.custom &&
     ctx.sls.service.custom.enterprise &&

--- a/src/lib/logsCollection.test.js
+++ b/src/lib/logsCollection.test.js
@@ -1,6 +1,6 @@
-import logsCollection from './logsCollection'
-import { LAMBDA_FILTER_PATTERN, API_GATEWAY_FILTER_PATTERN } from './utils'
-import { getLogDestination } from '@serverless/platform-sdk'
+const logsCollection = require('./logsCollection')
+const { LAMBDA_FILTER_PATTERN, API_GATEWAY_FILTER_PATTERN } = require('./utils')
+const { getLogDestination } = require('@serverless/platform-sdk')
 
 jest.mock('@serverless/platform-sdk', () => ({
   getLogDestination: jest.fn().mockReturnValue(Promise.resolve({ destinationArn: 'arn:logdest' })),

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -1,23 +1,23 @@
-import chalk from 'chalk'
-import { configureFetchDefaults, getLoggedInUser, openBrowser } from '@serverless/platform-sdk'
-import errorHandler from './errorHandler'
-import logsCollection from './logsCollection'
-import login from './login'
-import logout from './logout'
-import wrap from './wrap'
-import injectLogsIamRole from './injectLogsIamRole'
-import wrapClean from './wrapClean'
-import runPolicies from './safeguards'
-import getCredentials from './credentials'
-import getAppUids from './appUids'
-import removeDestination from './removeDestination'
-import { saveDeployment, createAndSetDeploymentUid } from './deployment'
-import { hookIntoVariableGetter } from './variables'
-import { generate, eventDict } from './generateEvent'
-import { configureDeployProfile } from './deployProfile'
-import { test } from './test'
-import { getDashboardUrl } from './dashboard'
-import setApiGatewayAccessLogFormat from './setApiGatewayAccessLogFormat'
+const chalk = require('chalk')
+const { configureFetchDefaults, getLoggedInUser, openBrowser } = require('@serverless/platform-sdk')
+const errorHandler = require('./errorHandler')
+const logsCollection = require('./logsCollection')
+const login = require('./login')
+const logout = require('./logout')
+const wrap = require('./wrap')
+const injectLogsIamRole = require('./injectLogsIamRole')
+const wrapClean = require('./wrapClean')
+const runPolicies = require('./safeguards')
+const getCredentials = require('./credentials')
+const getAppUids = require('./appUids')
+const removeDestination = require('./removeDestination')
+const { saveDeployment, createAndSetDeploymentUid } = require('./deployment')
+const { hookIntoVariableGetter } = require('./variables')
+const { generate, eventDict } = require('./generateEvent')
+const { configureDeployProfile } = require('./deployProfile')
+const { test } = require('./test')
+const { getDashboardUrl } = require('./dashboard')
+const setApiGatewayAccessLogFormat = require('./setApiGatewayAccessLogFormat')
 
 /*
  * Serverless Enterprise Plugin
@@ -290,4 +290,4 @@ class ServerlessEnterprisePlugin {
   }
 }
 
-export default ServerlessEnterprisePlugin
+module.exports = ServerlessEnterprisePlugin

--- a/src/lib/plugin.test.js
+++ b/src/lib/plugin.test.js
@@ -1,17 +1,17 @@
-import chalk from 'chalk'
-import ServerlessEnterprisePlugin from './plugin'
-import getCredentials from './credentials'
-import logsCollection from './logsCollection'
-import wrap from './wrap'
-import wrapClean from './wrapClean'
-import runPolicies from './safeguards'
-import removeDestination from './removeDestination'
-import { saveDeployment, createAndSetDeploymentUid } from './deployment'
-import { generate } from './generateEvent'
-import { configureDeployProfile } from './deployProfile'
-import injectLogsIamRole from './injectLogsIamRole'
-import setApiGatewayAccessLogFormat from './setApiGatewayAccessLogFormat'
-import _ from 'lodash'
+const chalk = require('chalk')
+const ServerlessEnterprisePlugin = require('./plugin')
+const getCredentials = require('./credentials')
+const logsCollection = require('./logsCollection')
+const wrap = require('./wrap')
+const wrapClean = require('./wrapClean')
+const runPolicies = require('./safeguards')
+const removeDestination = require('./removeDestination')
+const { saveDeployment, createAndSetDeploymentUid } = require('./deployment')
+const { generate } = require('./generateEvent')
+const { configureDeployProfile } = require('./deployProfile')
+const injectLogsIamRole = require('./injectLogsIamRole')
+const setApiGatewayAccessLogFormat = require('./setApiGatewayAccessLogFormat')
+const _ = require('lodash')
 
 afterAll(() => jest.restoreAllMocks())
 

--- a/src/lib/removeDestination.js
+++ b/src/lib/removeDestination.js
@@ -1,6 +1,6 @@
-import { getAccessKeyForTenant, removeLogDestination } from '@serverless/platform-sdk'
+const { getAccessKeyForTenant, removeLogDestination } = require('@serverless/platform-sdk')
 
-export default async (ctx) => {
+module.exports = async (ctx) => {
   if (
     !ctx.sls.service.custom ||
     !ctx.sls.service.custom.enterprise ||

--- a/src/lib/removeDestination.test.js
+++ b/src/lib/removeDestination.test.js
@@ -1,5 +1,5 @@
-import { getAccessKeyForTenant, removeLogDestination } from '@serverless/platform-sdk'
-import removeDestination from './removeDestination'
+const { getAccessKeyForTenant, removeLogDestination } = require('@serverless/platform-sdk')
+const removeDestination = require('./removeDestination')
 
 jest.mock('@serverless/platform-sdk', () => ({
   removeLogDestination: jest.fn(),

--- a/src/lib/safeguards/index.js
+++ b/src/lib/safeguards/index.js
@@ -1,11 +1,11 @@
-import { readdir, readFile } from 'fs-extra'
-import yml from 'yamljs'
-import path from 'path'
-import { get, fromPairs, cloneDeep, omit } from 'lodash'
-import chalk from 'chalk'
+const { readdir, readFile } = require('fs-extra')
+const yml = require('yamljs')
+const path = require('path')
+const { get, fromPairs, cloneDeep, omit } = require('lodash')
+const chalk = require('chalk')
 
 // NOTE: not using path.join because it strips off the leading
-export const loadPolicy = (policyPath, safeguardName) =>
+const loadPolicy = (policyPath, safeguardName) =>
   require(`${policyPath || `./policies`}/${safeguardName}`)
 
 async function runPolicies(ctx) {
@@ -165,4 +165,5 @@ async function runPolicies(ctx) {
   ctx.sls.cli.log(summary, `\nServerless Enterprise`)
 }
 
-export default runPolicies
+module.exports = runPolicies
+module.exports.loadPolicy = loadPolicy

--- a/src/lib/safeguards/index.test.js
+++ b/src/lib/safeguards/index.test.js
@@ -1,7 +1,8 @@
-import { cloneDeep } from 'lodash'
-import chalk from 'chalk'
-import runPolicies, { loadPolicy } from './'
-import { getSafeguards } from '@serverless/platform-sdk'
+const { cloneDeep } = require('lodash')
+const chalk = require('chalk')
+const runPolicies = require('./')
+const { getSafeguards } = require('@serverless/platform-sdk')
+const { loadPolicy } = runPolicies
 
 jest.mock('@serverless/platform-sdk', () => ({
   getAccessKeyForTenant: jest.fn().mockReturnValue(Promise.resolve('access-key')),

--- a/src/lib/safeguards/policies/allowed-function-names.test.js
+++ b/src/lib/safeguards/policies/allowed-function-names.test.js
@@ -1,4 +1,4 @@
-import allowedFunctionNamesPolicy from './allowed-function-names'
+const allowedFunctionNamesPolicy = require('./allowed-function-names')
 
 describe('allowedFunctionNamesPolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/allowed-regions.test.js
+++ b/src/lib/safeguards/policies/allowed-regions.test.js
@@ -1,4 +1,4 @@
-import allowedRegionsPolicy from './allowed-regions'
+const allowedRegionsPolicy = require('./allowed-regions')
 
 describe('allowedRegionsPolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/allowed-runtimes.test.js
+++ b/src/lib/safeguards/policies/allowed-runtimes.test.js
@@ -1,4 +1,4 @@
-import allowedRuntimesPolicy from './allowed-runtimes'
+const allowedRuntimesPolicy = require('./allowed-runtimes')
 
 describe('allowedRuntimesPolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/allowed-stages.test.js
+++ b/src/lib/safeguards/policies/allowed-stages.test.js
@@ -1,4 +1,4 @@
-import allowedStagePolicy from './allowed-stages'
+const allowedStagePolicy = require('./allowed-stages')
 
 describe('allowedStagePolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/forbid-s3-http-access.js
+++ b/src/lib/safeguards/policies/forbid-s3-http-access.js
@@ -1,4 +1,4 @@
-import { entries } from 'lodash'
+const { entries } = require('lodash')
 
 module.exports = function forbidS3HttpAccessPolicy(policy, service) {
   let failed = false

--- a/src/lib/safeguards/policies/forbid-s3-http-access.test.js
+++ b/src/lib/safeguards/policies/forbid-s3-http-access.test.js
@@ -1,4 +1,4 @@
-import forbidS3HttpAccessPolicy from './forbid-s3-http-access'
+const forbidS3HttpAccessPolicy = require('./forbid-s3-http-access')
 
 describe('forbidS3HttpAccessPolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/framework-version.test.js
+++ b/src/lib/safeguards/policies/framework-version.test.js
@@ -1,4 +1,4 @@
-import frameworkVersionPolicy from './framework-version'
+const frameworkVersionPolicy = require('./framework-version')
 
 describe('frameworkVersionPolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/javascript.test.js
+++ b/src/lib/safeguards/policies/javascript.test.js
@@ -1,4 +1,4 @@
-import javascriptPolicy from './javascript'
+const javascriptPolicy = require('./javascript')
 
 const serviceData = { declaration: { provider: { stage: 'dev' } } }
 

--- a/src/lib/safeguards/policies/no-secret-env-vars.test.js
+++ b/src/lib/safeguards/policies/no-secret-env-vars.test.js
@@ -1,4 +1,4 @@
-import noSecretEnvVarsPolicy from './no-secret-env-vars'
+const noSecretEnvVarsPolicy = require('./no-secret-env-vars')
 
 describe('noSecretEnvVarsPolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/no-wild-iam-role-statements.js
+++ b/src/lib/safeguards/policies/no-wild-iam-role-statements.js
@@ -1,4 +1,4 @@
-import { values } from 'lodash'
+const { values } = require('lodash')
 
 module.exports = function noWildIamPolicy(policy, service) {
   let failed = false

--- a/src/lib/safeguards/policies/no-wild-iam-role-statements.test.js
+++ b/src/lib/safeguards/policies/no-wild-iam-role-statements.test.js
@@ -1,4 +1,4 @@
-import noWildIamPolicy from './no-wild-iam-role-statements'
+const noWildIamPolicy = require('./no-wild-iam-role-statements')
 
 describe('noWildIamPolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/require-cfn-role.test.js
+++ b/src/lib/safeguards/policies/require-cfn-role.test.js
@@ -1,4 +1,4 @@
-import requireCfnRolePolicy from './require-cfn-role'
+const requireCfnRolePolicy = require('./require-cfn-role')
 
 describe('requireCfnRolePolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/require-description.test.js
+++ b/src/lib/safeguards/policies/require-description.test.js
@@ -1,4 +1,4 @@
-import requireDescriptionPolicy from './require-description'
+const requireDescriptionPolicy = require('./require-description')
 
 describe('requireDescriptionPolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/require-dlq.test.js
+++ b/src/lib/safeguards/policies/require-dlq.test.js
@@ -1,4 +1,4 @@
-import requireDlq from './require-dlq'
+const requireDlq = require('./require-dlq')
 
 describe('requireDlq', () => {
   let policy

--- a/src/lib/safeguards/policies/require-global-vpc.test.js
+++ b/src/lib/safeguards/policies/require-global-vpc.test.js
@@ -1,4 +1,4 @@
-import requireGlobalVpcPolicy from './require-global-vpc'
+const requireGlobalVpcPolicy = require('./require-global-vpc')
 
 describe('requireGlobalVpcPolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/required-stack-tags.test.js
+++ b/src/lib/safeguards/policies/required-stack-tags.test.js
@@ -1,4 +1,4 @@
-import requiredStackTagsPolicy from './required-stack-tags'
+const requiredStackTagsPolicy = require('./required-stack-tags')
 
 describe('requiredStackTagsPolicy', () => {
   let policy

--- a/src/lib/safeguards/policies/restricted-deploy-times.test.js
+++ b/src/lib/safeguards/policies/restricted-deploy-times.test.js
@@ -1,4 +1,4 @@
-import restrictedDeployTimesPolicy from './restricted-deploy-times'
+const restrictedDeployTimesPolicy = require('./restricted-deploy-times')
 
 describe('restrictedDeployTimesPolicy', () => {
   const dateDotNow = Date.now

--- a/src/lib/serializeError.js
+++ b/src/lib/serializeError.js
@@ -1,7 +1,7 @@
 // coppied from https://github.com/sindresorhus/serialize-error/blob/master/index.js and converted
 // to use _.entries instead of Object.entries. and linted for our standards
 
-import { entries } from 'lodash'
+const { entries } = require('lodash')
 
 const destroyCircular = (from, seen) => {
   const to = Array.isArray(from) ? [] : {}

--- a/src/lib/setApiGatewayAccessLogFormat.js
+++ b/src/lib/setApiGatewayAccessLogFormat.js
@@ -1,6 +1,6 @@
 const { API_GATEWAY_LOG_FORMAT } = require('./utils.js')
 
-export default (ctx) => {
+module.exports = (ctx) => {
   if (
     ctx.sls.service.custom &&
     ctx.sls.service.custom.enterprise &&

--- a/src/lib/setApiGatewayAccessLogFormat.test.js
+++ b/src/lib/setApiGatewayAccessLogFormat.test.js
@@ -1,5 +1,5 @@
-import setApiGatewayAccessLogFormat from './setApiGatewayAccessLogFormat'
-import { API_GATEWAY_LOG_FORMAT } from './utils'
+const setApiGatewayAccessLogFormat = require('./setApiGatewayAccessLogFormat')
+const { API_GATEWAY_LOG_FORMAT } = require('./utils')
 
 describe('setApiGatewayAccessLogFormat', () => {
   let ctx

--- a/src/lib/test/errors.js
+++ b/src/lib/test/errors.js
@@ -1,4 +1,4 @@
-export class TestError extends Error {
+module.exports.TestError = class TestError extends Error {
   constructor(field, expected, received, resp, body) {
     super(
       `Test failed, expected: ${JSON.stringify(expected)}, received: ${JSON.stringify(received)}`

--- a/src/lib/test/index.js
+++ b/src/lib/test/index.js
@@ -1,11 +1,11 @@
-import { entries, find } from 'lodash'
-import fse from 'fs-extra'
-import chalk from 'chalk'
-import yaml from 'js-yaml'
+const { entries, find } = require('lodash')
+const fse = require('fs-extra')
+const chalk = require('chalk')
+const yaml = require('js-yaml')
 
-import runTest from './runTest'
+const runTest = require('./runTest')
 
-export const test = async (ctx) => {
+module.exports.test = async (ctx) => {
   if (!fse.exists('serverless.test.yml')) {
     ctx.sls.cli.log(`No serverless.test.yml file found`, `Serverless Enterprise`)
     return

--- a/src/lib/test/index.test.js
+++ b/src/lib/test/index.test.js
@@ -1,6 +1,6 @@
-import chalk from 'chalk'
-import runTest from './runTest'
-import { test as testFunc } from './'
+const chalk = require('chalk')
+const runTest = require('./runTest')
+const { test: testFunc } = require('./')
 
 const realStdoutWrite = process.stdout.write
 

--- a/src/lib/test/objectSubsetEquals.js
+++ b/src/lib/test/objectSubsetEquals.js
@@ -1,4 +1,4 @@
-import { entries } from 'lodash'
+const { entries } = require('lodash')
 
 const objectSubsetEquals = (subsetObj, obj) => {
   if (typeof subsetObj === 'object') {
@@ -23,4 +23,4 @@ const objectSubsetEquals = (subsetObj, obj) => {
   return subsetObj === obj
 }
 
-export default objectSubsetEquals
+module.exports = objectSubsetEquals

--- a/src/lib/test/objectSubsetEquals.test.js
+++ b/src/lib/test/objectSubsetEquals.test.js
@@ -1,4 +1,4 @@
-import objectSubsetEquals from './objectSubsetEquals'
+const objectSubsetEquals = require('./objectSubsetEquals')
 
 describe('objectSubsetEquals', () => {
   it('correctly compares equal primitives', () => {

--- a/src/lib/test/runTest.js
+++ b/src/lib/test/runTest.js
@@ -1,7 +1,7 @@
-import { entries } from 'lodash'
-import fetch from 'isomorphic-fetch'
-import { TestError } from './errors'
-import objectSubsetEquals from './objectSubsetEquals'
+const { entries } = require('lodash')
+const fetch = require('isomorphic-fetch')
+const { TestError } = require('./errors')
+const objectSubsetEquals = require('./objectSubsetEquals')
 
 const runTest = async (testSpec, path, method, baseApiUrl) => {
   let body
@@ -60,4 +60,4 @@ const runTest = async (testSpec, path, method, baseApiUrl) => {
   }
 }
 
-export default runTest
+module.exports = runTest

--- a/src/lib/test/runTest.test.js
+++ b/src/lib/test/runTest.test.js
@@ -1,6 +1,6 @@
-import fetch from 'isomorphic-fetch'
-import runTest from './runTest'
-import { TestError } from './errors'
+const fetch = require('isomorphic-fetch')
+const runTest = require('./runTest')
+const { TestError } = require('./errors')
 
 jest.mock('isomorphic-fetch', () =>
   jest.fn().mockImplementation((url) => {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -37,7 +37,7 @@ const API_GATEWAY_LOG_FORMAT = {
   version: '1.0.0'
 }
 
-export {
+module.exports = {
   upperFirst,
   pickResourceType,
   API_GATEWAY_FILTER_PATTERN,

--- a/src/lib/utils.test.js
+++ b/src/lib/utils.test.js
@@ -1,4 +1,4 @@
-import { upperFirst, pickResourceType } from './utils'
+const { upperFirst, pickResourceType } = require('./utils')
 
 describe('utils - upperFirst', () => {
   it('capitalizes the first letter if all lowercase', () => {

--- a/src/lib/variables.js
+++ b/src/lib/variables.js
@@ -1,7 +1,7 @@
-import _ from 'lodash'
-import { getStateVariable } from '@serverless/platform-sdk'
+const _ = require('lodash')
+const { getStateVariable } = require('@serverless/platform-sdk')
 
-export const hookIntoVariableGetter = (ctx, secrets, accessKey) => {
+module.exports.hookIntoVariableGetter = (ctx, secrets, accessKey) => {
   const { getValueFromSource } = ctx.sls.variables
 
   ctx.sls.variables.getValueFromSource = async (variableString) => {

--- a/src/lib/variables.test.js
+++ b/src/lib/variables.test.js
@@ -1,5 +1,5 @@
-import { hookIntoVariableGetter } from './variables'
-import { getStateVariable } from '@serverless/platform-sdk'
+const { hookIntoVariableGetter } = require('./variables')
+const { getStateVariable } = require('@serverless/platform-sdk')
 
 jest.mock('@serverless/platform-sdk', () => ({
   getStateVariable: jest.fn().mockImplementation(({ outputName }) => {

--- a/src/lib/wrap.js
+++ b/src/lib/wrap.js
@@ -4,17 +4,17 @@
  * - Wraps your function handlers with the ServerlessSDK
  */
 
-import fs from 'fs-extra'
-import path from 'path'
-import _ from 'lodash'
-import JSZip from 'jszip'
-import { addTree, writeZip } from './zipTree'
+const fs = require('fs-extra')
+const path = require('path')
+const _ = require('lodash')
+const JSZip = require('jszip')
+const { addTree, writeZip } = require('./zipTree')
 
 /*
  * Wrap Node.js Functions
  */
 
-export const wrapNodeJs = (fn, ctx) => {
+const wrapNodeJs = (fn, ctx) => {
   const newHandlerCode = `var serverlessSDK = require('./serverless-sdk/index.js')
 serverlessSDK = new serverlessSDK({
 tenantId: '${ctx.sls.service.tenant}',
@@ -37,7 +37,7 @@ try {
   fs.writeFileSync(path.join(ctx.sls.config.servicePath, `${fn.entryNew}.js`), newHandlerCode)
 }
 
-export default async (ctx) => {
+module.exports = async (ctx) => {
   // Check if we support the provider
   if (ctx.sls.service.provider.name !== 'aws') {
     ctx.sls.cli.log(
@@ -158,3 +158,5 @@ export default async (ctx) => {
     ctx.sls.service.package.include.push('serverless-sdk/**')
   }
 }
+
+module.exports.wrapNodeJs = wrapNodeJs

--- a/src/lib/wrap.test.js
+++ b/src/lib/wrap.test.js
@@ -1,7 +1,7 @@
-import fs from 'fs-extra'
-import wrap from './wrap'
-import { addTree, writeZip } from './zipTree'
-import JSZip from 'jszip'
+const fs = require('fs-extra')
+const wrap = require('./wrap')
+const { addTree, writeZip } = require('./zipTree')
+const JSZip = require('jszip')
 
 afterEach(() => jest.clearAllMocks())
 jest.mock('jszip', () => ({

--- a/src/lib/wrapClean.js
+++ b/src/lib/wrapClean.js
@@ -3,10 +3,10 @@
  * - Cleans up files create during wrapping
  */
 
-import fs from 'fs-extra'
-import path from 'path'
+const fs = require('fs-extra')
+const path = require('path')
 
-export default async (ctx) => {
+module.exports = async (ctx) => {
   // Clear assets (serverless-sdk)
   if (fs.pathExistsSync(ctx.state.pathAssets)) {
     fs.removeSync(ctx.state.pathAssets)

--- a/src/lib/wrapClean.test.js
+++ b/src/lib/wrapClean.test.js
@@ -1,5 +1,5 @@
-import wrapClean from './wrapClean'
-import fs from 'fs-extra'
+const wrapClean = require('./wrapClean')
+const fs = require('fs-extra')
 
 jest.mock('fs-extra', () => ({
   pathExistsSync: jest.fn().mockReturnValue(true),

--- a/src/lib/zipTree.js
+++ b/src/lib/zipTree.js
@@ -1,7 +1,7 @@
 // mostly copied from https://github.com/UnitedIncome/serverless-python-requirements/blob/master/lib/zipTree.js
 // modified to use native promises and fs-extra's promise support and use import/export
-import fs from 'fs-extra'
-import path from 'path'
+const fs = require('fs-extra')
+const path = require('path')
 
 /**
  * Add a directory recursively to a zip file. Files in src will be added to the top folder of zip.
@@ -9,7 +9,7 @@ import path from 'path'
  * @param {string} src the source folder.
  * @return {Promise} a promise offering the original JSZip object.
  */
-export async function addTree(zip, src) {
+module.exports.addTree = async function self(zip, src) {
   const srcN = path.normalize(src)
 
   const contents = await fs.readdir(srcN)
@@ -19,7 +19,7 @@ export async function addTree(zip, src) {
 
       return fs.stat(srcPath).then((stat) => {
         if (stat.isDirectory()) {
-          return addTree(zip.folder(name), srcPath)
+          return self(zip.folder(name), srcPath)
         }
         const opts = { date: 0, unixPermissions: stat.mode }
         return fs.readFile(srcPath).then((data) => zip.file(srcPath, data, opts))
@@ -35,7 +35,7 @@ export async function addTree(zip, src) {
  * @param {string} targetPath path to write the zip file to.
  * @return {Promise} a promise resolving to null.
  */
-export const writeZip = (zip, targetPath) =>
+module.exports.writeZip = (zip, targetPath) =>
   new Promise((resolve) =>
     zip
       .generateNodeStream({

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -1,3 +1,0 @@
-if (!global._babelPolyfill) {
-  require('@babel/polyfill')
-}


### PR DESCRIPTION
Release transpilation burden and open door to drop babel dependency.

Additionally cleaned up babel related configuration, so it builds for Node.js v6 (not v4), and removed unnecessary dependencies