### PR TITLE
add an export including the sdk versio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "engines": {
     "node": ">=6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "engines": {
     "node": ">=6.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
 require('./runtime')
+const { version } = require('@serverless/platform-sdk/package.json')
 
 module.exports = require('./lib/plugin').default
+module.exports.sdkVersion = version


### PR DESCRIPTION
this is in support of serverless/serverless#6344 to avoid having to import it
directly since it may not be guaranteed to be importable (see yarn, etc)