### PR TITLE
Increase timeout setting for integration tests

### DIFF
--- a/integration-testing/outputs.test.js
+++ b/integration-testing/outputs.test.js
@@ -7,7 +7,7 @@ let sls1;
 let sls2;
 let teardown;
 
-jest.setTimeout(1000 * 60 * 3);
+jest.setTimeout(1000 * 60 * 5);
 
 beforeAll(
   async () =>

--- a/integration-testing/safeguards.test.js
+++ b/integration-testing/safeguards.test.js
@@ -6,7 +6,7 @@ const setup = require('./setup');
 let sls;
 let teardown;
 
-jest.setTimeout(1000 * 60 * 3);
+jest.setTimeout(1000 * 60 * 5);
 
 beforeAll(async () => ({ sls, teardown } = await setup('service')));
 


### PR DESCRIPTION
There was a scenario when 3 minutes turned to not be enough: https://travis-ci.com/serverless/enterprise-plugin/jobs/214938056

Increased to 5 minutes