### PR TITLE
call refreshToken before using idToken

### DIFF
--- a/lib/interactiveCli/set-app.js
+++ b/lib/interactiveCli/set-app.js
@@ -6,6 +6,7 @@ const {
   getApps,
   getLoggedInUser,
   listTenants,
+  refreshToken,
   writeConfigFile,
 } = require('@serverless/platform-sdk');
 const enableConfirm = require('./enableConfirm');
@@ -54,8 +55,10 @@ module.exports = {
     if (!serverless.config.servicePath) return false;
     if (serverless.service.provider.name !== 'aws') return false;
     if (serverless.service.app) return false;
-    const user = getLoggedInUser();
+    let user = getLoggedInUser();
     if (!user || !user.idToken) return false;
+    await refreshToken();
+    user = getLoggedInUser();
     const tenants = new Set(
       (await listTenants({ username: user.username, idToken: user.idToken })).map(
         tenant => tenant.tenantName


### PR DESCRIPTION
Fixes https://serverlessteam.atlassian.net/browse/PLAT-1377

not 100% sure that using an expired idToken is the cause of my error. we need some one who has an old login to test this. I don't have one since i deleted my `.serverlessrc` when I first ran into this error, I assume you don't have one @plfx  bc you went through the registration flow recently. @alexdebrie maybe you can test this? To test, run `sls` in an empty dir with the `master` branch to confirm you get the same error as in the JIRA ticket,  then run it with this branch and hopefully there won't be an error. Don't delete sls rc or anything like that like i did ;)