### PR TITLE
remove `Serverless Enterprise:` prefix from logs

### DIFF
--- a/lib/archiveService.js
+++ b/lib/archiveService.js
@@ -10,7 +10,7 @@ module.exports = async function(ctx) {
   // Defaults
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant);
 
-  ctx.sls.cli.log('Archiving this service in the Enterprise Dashboard...');
+  ctx.sls.cli.log('Archiving this service in the Serverless Dashboard...');
 
   const data = {
     name: ctx.sls.service.service,
@@ -23,10 +23,10 @@ module.exports = async function(ctx) {
 
   return archiveService(data)
     .then(() => {
-      ctx.sls.cli.log('Successfully archived this service in the Enterprise Dashboard...');
+      ctx.sls.cli.log('Successfully archived this service in the Serverless Dashboard...');
     })
     .catch(err => {
-      ctx.sls.cli.log('Failed to archive this service in the Enterprise Dashboard...');
+      ctx.sls.cli.log('Failed to archive this service in the Serverless Dashboard...');
       throw new Error(err);
     });
 };

--- a/lib/archiveService.js
+++ b/lib/archiveService.js
@@ -10,7 +10,7 @@ module.exports = async function(ctx) {
   // Defaults
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant);
 
-  ctx.sls.cli.log('Archiving this service in the Enterprise Dashboard...', 'Serverless Enterprise');
+  ctx.sls.cli.log('Archiving this service in the Enterprise Dashboard...');
 
   const data = {
     name: ctx.sls.service.service,
@@ -23,16 +23,10 @@ module.exports = async function(ctx) {
 
   return archiveService(data)
     .then(() => {
-      ctx.sls.cli.log(
-        'Successfully archived this service in the Enterprise Dashboard...',
-        'Serverless Enterprise'
-      );
+      ctx.sls.cli.log('Successfully archived this service in the Enterprise Dashboard...');
     })
     .catch(err => {
-      ctx.sls.cli.log(
-        'Failed to archive this service in the Enterprise Dashboard...',
-        'Serverless Enterprise'
-      );
+      ctx.sls.cli.log('Failed to archive this service in the Enterprise Dashboard...');
       throw new Error(err);
     });
 };

--- a/lib/deployment/save.js
+++ b/lib/deployment/save.js
@@ -8,13 +8,13 @@
 const parseDeploymentData = require('./parse');
 
 module.exports = async function(ctx, archived = false) {
-  ctx.sls.cli.log('Publishing service to the Enterprise Dashboard...');
+  ctx.sls.cli.log('Publishing service to the Serverless Dashboard...');
 
   const deployment = await parseDeploymentData(ctx, undefined, undefined, archived);
 
   const result = await deployment.save();
 
   ctx.sls.cli.log(
-    `Successfully published your service to the Enterprise Dashboard: ${result.dashboardUrl}` // eslint-disable-line
+    `Successfully published your service to the Serverless Dashboard: ${result.dashboardUrl}` // eslint-disable-line
   );
 };

--- a/lib/deployment/save.js
+++ b/lib/deployment/save.js
@@ -8,14 +8,13 @@
 const parseDeploymentData = require('./parse');
 
 module.exports = async function(ctx, archived = false) {
-  ctx.sls.cli.log('Publishing service to the Enterprise Dashboard...', 'Serverless Enterprise');
+  ctx.sls.cli.log('Publishing service to the Enterprise Dashboard...');
 
   const deployment = await parseDeploymentData(ctx, undefined, undefined, archived);
 
   const result = await deployment.save();
 
   ctx.sls.cli.log(
-    `Successfully published your service to the Enterprise Dashboard: ${result.dashboardUrl}`, // eslint-disable-line
-    'Serverless Enterprise'
+    `Successfully published your service to the Enterprise Dashboard: ${result.dashboardUrl}` // eslint-disable-line
   );
 };

--- a/lib/deployment/save.js
+++ b/lib/deployment/save.js
@@ -15,6 +15,6 @@ module.exports = async function(ctx, archived = false) {
   const result = await deployment.save();
 
   ctx.sls.cli.log(
-    `Successfully published your service to the Serverless Dashboard: ${result.dashboardUrl}`;
+    `Successfully published your service to the Serverless Dashboard: ${result.dashboardUrl}`
   );
 };

--- a/lib/deployment/save.test.js
+++ b/lib/deployment/save.test.js
@@ -28,8 +28,7 @@ describe('saveDeployment', () => {
     expect(parseDeploymentData).toBeCalledWith(ctx, undefined, undefined, false);
     expect((await parseDeploymentData()).save).toHaveBeenCalledTimes(1);
     expect(log).toBeCalledWith(
-      'Successfully published your service to the Enterprise Dashboard: https://dashboard.serverless.com/foo',
-      'Serverless Enterprise'
+      'Successfully published your service to the Enterprise Dashboard: https://dashboard.serverless.com/foo'
     );
   });
 });

--- a/lib/deployment/save.test.js
+++ b/lib/deployment/save.test.js
@@ -28,7 +28,7 @@ describe('saveDeployment', () => {
     expect(parseDeploymentData).toBeCalledWith(ctx, undefined, undefined, false);
     expect((await parseDeploymentData()).save).toHaveBeenCalledTimes(1);
     expect(log).toBeCalledWith(
-      'Successfully published your service to the Enterprise Dashboard: https://dashboard.serverless.com/foo'
+      'Successfully published your service to the Serverless Dashboard: https://dashboard.serverless.com/foo'
     );
   });
 });

--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -14,15 +14,14 @@ module.exports = function(ctx) {
      * - Handle failed deployments
      */
 
-    ctx.sls.cli.log('Publishing service to the Enterprise Dashboard...', 'Serverless Enterprise');
+    ctx.sls.cli.log('Publishing service to the Enterprise Dashboard...');
 
     const deployment = await parseDeploymentData(ctx, 'error', serializeError(error));
 
     const result = await deployment.save();
 
     ctx.sls.cli.log(
-      `Successfully published your service to the Enterprise Dashboard: ${result.dashboardUrl}`, // eslint-disable-line
-      'Serverless Enterprise'
+      `Successfully published your service to the Enterprise Dashboard: ${result.dashboardUrl}` // eslint-disable-line
     );
     if (!ctx.state.deployment) {
       ctx.state.deployment = {};

--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -14,14 +14,14 @@ module.exports = function(ctx) {
      * - Handle failed deployments
      */
 
-    ctx.sls.cli.log('Publishing service to the Enterprise Dashboard...');
+    ctx.sls.cli.log('Publishing service to the Serverless Dashboard...');
 
     const deployment = await parseDeploymentData(ctx, 'error', serializeError(error));
 
     const result = await deployment.save();
 
     ctx.sls.cli.log(
-      `Successfully published your service to the Enterprise Dashboard: ${result.dashboardUrl}` // eslint-disable-line
+      `Successfully published your service to the Serverless Dashboard: ${result.dashboardUrl}` // eslint-disable-line
     );
     if (!ctx.state.deployment) {
       ctx.state.deployment = {};

--- a/lib/errorHandler.test.js
+++ b/lib/errorHandler.test.js
@@ -21,14 +21,9 @@ describe('errorHandler', () => {
       name: 'Error',
       stack: expect.any(String),
     });
+    expect(ctx.sls.cli.log).toBeCalledWith('Publishing service to the Enterprise Dashboard...');
     expect(ctx.sls.cli.log).toBeCalledWith(
-      'Publishing service to the Enterprise Dashboard...',
-      'Serverless Enterprise'
-    );
-    expect(ctx.sls.cli.log).toBeCalledWith(
-      'Successfully published your service to the Enterprise Dashboard: URL',
-
-      'Serverless Enterprise'
+      'Successfully published your service to the Enterprise Dashboard: URL'
     );
   });
 });

--- a/lib/errorHandler.test.js
+++ b/lib/errorHandler.test.js
@@ -21,9 +21,9 @@ describe('errorHandler', () => {
       name: 'Error',
       stack: expect.any(String),
     });
-    expect(ctx.sls.cli.log).toBeCalledWith('Publishing service to the Enterprise Dashboard...');
+    expect(ctx.sls.cli.log).toBeCalledWith('Publishing service to the Serverless Dashboard...');
     expect(ctx.sls.cli.log).toBeCalledWith(
-      'Successfully published your service to the Enterprise Dashboard: URL'
+      'Successfully published your service to the Serverless Dashboard: URL'
     );
   });
 });

--- a/lib/login.js
+++ b/lib/login.js
@@ -3,7 +3,7 @@
 const { login } = require('@serverless/platform-sdk');
 
 module.exports = async function(ctx) {
-  ctx.sls.cli.log('Logging you in via your default browser...', 'Serverless Enterprise');
+  ctx.sls.cli.log('Logging you in via your default browser...');
   // Include a "tenant" in "login()"...
   // This will create a new accessKey for that tenant on every login.
   try {
@@ -11,17 +11,15 @@ module.exports = async function(ctx) {
   } catch (err) {
     if (err === 'Complete sign-up before logging in.') {
       ctx.sls.cli.log(
-        "Please complete sign-up at dashboard.serverless.com, configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again",
-        'Serverless Enterprise'
+        "Please complete sign-up at dashboard.serverless.com, configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again"
       );
       process.exit(1);
     }
   }
-  ctx.sls.cli.log('You sucessfully logged in to Serverless Enterprise.', 'Serverless Enterprise');
+  ctx.sls.cli.log('You sucessfully logged in to Serverless Enterprise.');
   if (!ctx.sls.service.tenant || !ctx.sls.service.app) {
     ctx.sls.cli.log(
-      "Please configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again",
-      'Serverless Enterprise'
+      "Please configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again"
     );
   }
   process.exit(0);

--- a/lib/login.js
+++ b/lib/login.js
@@ -16,7 +16,7 @@ module.exports = async function(ctx) {
       process.exit(1);
     }
   }
-  ctx.sls.cli.log('You sucessfully logged in to Serverless Enterprise.');
+  ctx.sls.cli.log('You sucessfully logged in to Serverless.');
   if (!ctx.sls.service.tenant || !ctx.sls.service.app) {
     ctx.sls.cli.log(
       "Please configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again"

--- a/lib/login.test.js
+++ b/lib/login.test.js
@@ -29,7 +29,7 @@ describe('login', () => {
     const ctx = { sls: { service: { tenant: 'tenant', app: 'app' }, cli: { log } } };
     await login(ctx);
     expect(sdk.login).toBeCalledWith('tenant');
-    expect(log).toBeCalledWith('You sucessfully logged in to Serverless Enterprise.');
+    expect(log).toBeCalledWith('You sucessfully logged in to Serverless.');
     expect(process.exit).toBeCalledWith(0);
   });
 
@@ -38,7 +38,7 @@ describe('login', () => {
     const ctx = { sls: { service: {}, cli: { log } } };
     await login(ctx);
     expect(sdk.login).toBeCalledWith(undefined);
-    expect(log).toBeCalledWith('You sucessfully logged in to Serverless Enterprise.');
+    expect(log).toBeCalledWith('You sucessfully logged in to Serverless.');
     expect(log).toBeCalledWith(
       "Please configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again"
     );

--- a/lib/login.test.js
+++ b/lib/login.test.js
@@ -29,10 +29,7 @@ describe('login', () => {
     const ctx = { sls: { service: { tenant: 'tenant', app: 'app' }, cli: { log } } };
     await login(ctx);
     expect(sdk.login).toBeCalledWith('tenant');
-    expect(log).toBeCalledWith(
-      'You sucessfully logged in to Serverless Enterprise.',
-      'Serverless Enterprise'
-    );
+    expect(log).toBeCalledWith('You sucessfully logged in to Serverless Enterprise.');
     expect(process.exit).toBeCalledWith(0);
   });
 
@@ -41,13 +38,9 @@ describe('login', () => {
     const ctx = { sls: { service: {}, cli: { log } } };
     await login(ctx);
     expect(sdk.login).toBeCalledWith(undefined);
+    expect(log).toBeCalledWith('You sucessfully logged in to Serverless Enterprise.');
     expect(log).toBeCalledWith(
-      'You sucessfully logged in to Serverless Enterprise.',
-      'Serverless Enterprise'
-    );
-    expect(log).toBeCalledWith(
-      "Please configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again",
-      'Serverless Enterprise'
+      "Please configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again"
     );
     expect(process.exit).toBeCalledWith(0);
   });
@@ -58,8 +51,7 @@ describe('login', () => {
     await login(ctx);
     expect(sdk.login).toBeCalledWith('signup');
     expect(log).toBeCalledWith(
-      "Please complete sign-up at dashboard.serverless.com, configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again",
-      'Serverless Enterprise'
+      "Please complete sign-up at dashboard.serverless.com, configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again"
     );
     expect(process.exit).toBeCalledWith(1);
   });

--- a/lib/logout.js
+++ b/lib/logout.js
@@ -4,7 +4,7 @@ const { logout } = require('@serverless/platform-sdk');
 
 module.exports = async function(ctx) {
   return logout().then(() => {
-    ctx.sls.cli.log('You sucessfully logged out of Serverless Enterprise.');
+    ctx.sls.cli.log('You sucessfully logged out of Serverless.');
     process.exit(0);
   });
 };

--- a/lib/logout.js
+++ b/lib/logout.js
@@ -4,10 +4,7 @@ const { logout } = require('@serverless/platform-sdk');
 
 module.exports = async function(ctx) {
   return logout().then(() => {
-    ctx.sls.cli.log(
-      'You sucessfully logged out of Serverless Enterprise.',
-      'Serverless Enterprise'
-    );
+    ctx.sls.cli.log('You sucessfully logged out of Serverless Enterprise.');
     process.exit(0);
   });
 };

--- a/lib/logsCollection.js
+++ b/lib/logsCollection.js
@@ -21,10 +21,7 @@ module.exports = async ctx => {
     ctx.sls.service.custom.enterprise &&
     ctx.sls.service.custom.enterprise.collectLambdaLogs === false
   ) {
-    ctx.sls.cli.log(
-      'Info: This plugin is not configured to collect AWS Lambda Logs.',
-      'Serverless Enterprise'
-    );
+    ctx.sls.cli.log('Info: This plugin is not configured to collect AWS Lambda Logs.');
     return;
   }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -99,12 +99,12 @@ class ServerlessEnterprisePlugin {
     // Add commands
     this.commands = {
       'login': {
-        usage: 'Login or sign up for Serverless Enterprise',
+        usage: 'Login or sign up for Serverless',
         lifecycleEvents: ['login'],
         enterprise: true,
       },
       'logout': {
-        usage: 'Logout from Serverless Enterprise',
+        usage: 'Logout from Serverless',
         lifecycleEvents: ['logout'],
         enterprise: true,
       },
@@ -140,7 +140,7 @@ class ServerlessEnterprisePlugin {
         enterprise: true,
       },
       'dashboard': {
-        usage: 'Open the Serverless Enterprise dashboard',
+        usage: 'Open the Serverless dashboard',
         lifecycleEvents: ['dashboard'],
         enterprise: true,
       },

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -56,8 +56,7 @@ class ServerlessEnterprisePlugin {
     this.hooks = {
       'after:aws:deploy:finalize:cleanup': () =>
         sls.cli.log(
-          'Run the "serverless" command to setup monitoring, troubleshooting and testing.',
-          'Serverless Enterprise'
+          'Run the "serverless" command to setup monitoring, troubleshooting and testing.'
         ),
     };
 
@@ -85,7 +84,7 @@ class ServerlessEnterprisePlugin {
       }
       const errorMessage = 'You are not currently logged in. To log in, use: $ serverless login';
       console.log(''); // eslint-disable-line
-      sls.cli.log(errorMessage, 'Serverless Enterprise'); // eslint-disable-line
+      sls.cli.log(errorMessage); // eslint-disable-line
       throw new Error(errorMessage); // eslint-disable-line
     }
     if (currentCommand !== 'login' && currentCommand !== 'logout' && missing.length > 0) return;

--- a/lib/safeguards/index.js
+++ b/lib/safeguards/index.js
@@ -157,7 +157,7 @@ async function runPolicies(ctx) {
     process.stdout.write(`${details}\n\n`);
     if (!markedPolicies.every(res => res.approved || res.policy.enforcementLevel === 'warning')) {
       ctx.sls.cli.log(summary, '\nServerless');
-      throw new Error('Deployment blocked by Serverless Enterprise Safeguards');
+      throw new Error('Deployment blocked by Serverless Safeguards');
     }
   }
   ctx.sls.cli.log(summary, '\nServerless');

--- a/lib/safeguards/index.js
+++ b/lib/safeguards/index.js
@@ -50,7 +50,7 @@ async function runPolicies(ctx) {
     return;
   }
 
-  ctx.sls.cli.log('Safeguards Processing...', 'Serverless Enterprise');
+  ctx.sls.cli.log('Safeguards Processing...');
 
   const policies = policyConfigs.map(policy => ({
     ...policy,
@@ -78,8 +78,7 @@ async function runPolicies(ctx) {
           return [filename, yml.parse(content)];
         } catch (error) {
           ctx.sls.cli.log(
-            `(Safeguards) Failed to parse file ${filename} in the artifacts directory.`,
-            'Serverless Enterprise'
+            `(Safeguards) Failed to parse file ${filename} in the artifacts directory.`
           );
           throw error;
         }
@@ -90,8 +89,7 @@ async function runPolicies(ctx) {
     `Safeguards Results:
 
    Summary --------------------------------------------------
-`,
-    'Serverless Enterprise'
+`
   );
 
   service.compiled = fromPairs(jsonYamlArtifacts);
@@ -123,8 +121,7 @@ async function runPolicies(ctx) {
     await policy.function(policyHandle, service, policy.safeguardConfig);
     if (!result.approved && !result.failed) {
       ctx.sls.cli.log(
-        `Safeguard Policy "${policy.title}" finished running, but did not explicitly approve the deployment. This is likely a problem in the policy itself. If this problem persists, contact the policy author.`,
-        'Serverless Enterprise'
+        `Safeguard Policy "${policy.title}" finished running, but did not explicitly approve the deployment. This is likely a problem in the policy itself. If this problem persists, contact the policy author.`
       );
     }
     return result;
@@ -159,11 +156,11 @@ async function runPolicies(ctx) {
 
     process.stdout.write(`${details}\n\n`);
     if (!markedPolicies.every(res => res.approved || res.policy.enforcementLevel === 'warning')) {
-      ctx.sls.cli.log(summary, '\nServerless Enterprise');
+      ctx.sls.cli.log(summary, '\nServerless');
       throw new Error('Deployment blocked by Serverless Enterprise Safeguards');
     }
   }
-  ctx.sls.cli.log(summary, '\nServerless Enterprise');
+  ctx.sls.cli.log(summary, '\nServerless');
 }
 
 module.exports = runPolicies;

--- a/lib/safeguards/index.test.js
+++ b/lib/safeguards/index.test.js
@@ -214,9 +214,7 @@ describe('safeguards', () => {
         description: 'wtf yo? no secrets!',
       },
     ];
-    await expect(runPolicies(ctx)).rejects.toThrow(
-      'Deployment blocked by Serverless Safeguards'
-    );
+    await expect(runPolicies(ctx)).rejects.toThrow('Deployment blocked by Serverless Safeguards');
     expect(log.mock.calls).toEqual([
       ['Safeguards Processing...'],
       [

--- a/lib/safeguards/index.test.js
+++ b/lib/safeguards/index.test.js
@@ -134,19 +134,18 @@ describe('safeguards', () => {
     ];
     await runPolicies(ctx);
     expect(log.mock.calls).toEqual([
-      ['Safeguards Processing...', 'Serverless Enterprise'],
+      ['Safeguards Processing...'],
       [
         `Safeguards Results:
 
    Summary --------------------------------------------------
 `,
-        'Serverless Enterprise',
       ],
       [
         `Safeguards Summary: ${chalk.green('2 passed')}, ${chalk.keyword('orange')(
           '0 warnings'
         )}, ${chalk.red('0 errors')}`,
-        '\nServerless Enterprise',
+        '\nServerless',
       ],
     ]);
     expect(process.stdout.write.mock.calls).toEqual([
@@ -173,19 +172,18 @@ describe('safeguards', () => {
     ];
     await runPolicies(ctx);
     expect(log.mock.calls).toEqual([
-      ['Safeguards Processing...', 'Serverless Enterprise'],
+      ['Safeguards Processing...'],
       [
         `Safeguards Results:
 
    Summary --------------------------------------------------
 `,
-        'Serverless Enterprise',
       ],
       [
         `Safeguards Summary: ${chalk.green('0 passed')}, ${chalk.keyword('orange')(
           '1 warnings'
         )}, ${chalk.red('0 errors')}`,
-        '\nServerless Enterprise',
+        '\nServerless',
       ],
     ]);
     expect(process.stdout.write.mock.calls).toEqual([
@@ -220,19 +218,18 @@ describe('safeguards', () => {
       'Deployment blocked by Serverless Enterprise Safeguards'
     );
     expect(log.mock.calls).toEqual([
-      ['Safeguards Processing...', 'Serverless Enterprise'],
+      ['Safeguards Processing...'],
       [
         `Safeguards Results:
 
    Summary --------------------------------------------------
 `,
-        'Serverless Enterprise',
       ],
       [
         `Safeguards Summary: ${chalk.green('0 passed')}, ${chalk.keyword('orange')(
           '0 warnings'
         )}, ${chalk.red('1 errors')}`,
-        '\nServerless Enterprise',
+        '\nServerless',
       ],
     ]);
     expect(process.stdout.write.mock.calls).toEqual([

--- a/lib/safeguards/index.test.js
+++ b/lib/safeguards/index.test.js
@@ -215,7 +215,7 @@ describe('safeguards', () => {
       },
     ];
     await expect(runPolicies(ctx)).rejects.toThrow(
-      'Deployment blocked by Serverless Enterprise Safeguards'
+      'Deployment blocked by Serverless Safeguards'
     );
     expect(log.mock.calls).toEqual([
       ['Safeguards Processing...'],

--- a/lib/test/index.js
+++ b/lib/test/index.js
@@ -9,7 +9,7 @@ const runTest = require('./runTest');
 
 module.exports.test = async ctx => {
   if (!fse.exists('serverless.test.yml')) {
-    ctx.sls.cli.log('No serverless.test.yml file found', 'Serverless Enterprise');
+    ctx.sls.cli.log('No serverless.test.yml file found');
     return;
   }
   let tests = yaml.safeLoad(await fse.readFile('serverless.test.yml'));
@@ -37,8 +37,7 @@ module.exports.test = async ctx => {
     `Test Results:
 
    Summary --------------------------------------------------
-`,
-    'Serverless Enterprise'
+`
   );
 
   const errors = [];
@@ -98,5 +97,5 @@ module.exports.test = async ctx => {
 
   const passed = chalk.green(`${numTests - errors.length} passed`);
   const failed = chalk.red(`${errors.length} failed`);
-  ctx.sls.cli.log(`Test Summary: ${passed}, ${failed}`, 'Serverless Enterprise');
+  ctx.sls.cli.log(`Test Summary: ${passed}, ${failed}`);
 };

--- a/lib/test/index.test.js
+++ b/lib/test/index.test.js
@@ -70,12 +70,8 @@ describe('test', () => {
 
    Summary --------------------------------------------------
 `,
-        'Serverless Enterprise',
       ],
-      [
-        `Test Summary: ${chalk.green('1 passed')}, ${chalk.red('0 failed')}`,
-        'Serverless Enterprise',
-      ],
+      [`Test Summary: ${chalk.green('1 passed')}, ${chalk.red('0 failed')}`],
     ]);
     expect(process.stdout.write.mock.calls).toEqual([
       ['  running - POST blah - foobar'],


### PR DESCRIPTION
@skierkowski do we want to only update the prefixes(as I have in this PR) or ALL mentions of `Enterprise`?