### PR TITLE
PLAT-1080 Fix reporting for not deployed service

### DIFF
--- a/lib/deployment/parse.js
+++ b/lib/deployment/parse.js
@@ -42,6 +42,7 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
       } catch (requestError) {
         const { providerError } = requestError;
         if (providerError) {
+          // 400 means stack was not deployed yet (first deployment failed)
           if (providerError.statusCode === 400) return null;
         }
 

--- a/lib/deployment/parse.js
+++ b/lib/deployment/parse.js
@@ -34,26 +34,43 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
    */
 
   if (!archived) {
-    const cfnStack = await ctx.provider.request('CloudFormation', 'describeStacks', {
-      StackName: ctx.provider.naming.getStackName(),
-    });
+    const cfnStack = await (async () => {
+      try {
+        return await ctx.provider.request('CloudFormation', 'describeStacks', {
+          StackName: ctx.provider.naming.getStackName(),
+        });
+      } catch (requestError) {
+        const { providerError } = requestError;
+        if (providerError) {
+          if (providerError.statusCode === 400) return null;
+        }
+
+        throw requestError;
+      }
+    })();
 
     // get log access role info
-    const logsRole = _.find(
-      cfnStack.Stacks[0].Outputs,
-      ({ OutputKey }) => OutputKey === 'EnterpriseLogAccessIamRole'
-    );
+    const logsRole =
+      cfnStack &&
+      _.find(
+        cfnStack.Stacks[0].Outputs,
+        ({ OutputKey }) => OutputKey === 'EnterpriseLogAccessIamRole'
+      );
     const logsRoleArn = logsRole && logsRole.OutputValue;
 
     // get any CFN outputs
     const outputs = service.outputs || {};
     for (const [outputKey, outputValue] of _.entries(outputs)) {
       if (outputValue.startsWith('CFN!?')) {
-        const cfnOutput = _.find(
-          cfnStack.Stacks[0].Outputs,
-          ({ OutputKey }) => OutputKey === `${outputValue.slice(5)}`
-        );
-        outputs[outputKey] = cfnOutput.OutputValue;
+        if (cfnStack) {
+          const cfnOutput = _.find(
+            cfnStack.Stacks[0].Outputs,
+            ({ OutputKey }) => OutputKey === `${outputValue.slice(5)}`
+          );
+          outputs[outputKey] = cfnOutput.OutputValue;
+        } else {
+          delete outputs[outputKey];
+        }
       }
     }
 
@@ -156,7 +173,7 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
           type = sub;
         } else {
           type = Object.keys(sub)[0];
-          if (type === 'http') {
+          if (type === 'http' && cfnStack) {
             const apigResource = _.find(
               cfnStack.Stacks[0].Outputs,
               ({ OutputKey }) =>
@@ -177,7 +194,7 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
           } else {
             Object.assign(subDetails, { [type]: sub[type] });
           }
-          if (type === 'websocket') {
+          if (type === 'websocket' && cfnStack) {
             const apigResource = _.find(
               cfnStack.Stacks[0].Outputs,
               ({ OutputKey }) =>

--- a/lib/deployment/parse.test.js
+++ b/lib/deployment/parse.test.js
@@ -44,7 +44,7 @@ describe('parseDeploymentData', () => {
 
   beforeEach(() => {
     getAccountId = jest.fn().mockReturnValue('account-id');
-    request = jest.fn().mockReturnValue(
+    request = jest.fn().mockReturnValueOnce(
       Promise.resolve({
         Stacks: [
           {
@@ -755,6 +755,134 @@ describe('parseDeploymentData', () => {
       stageName: 'dev',
       status: 'success',
       subscriptions: [],
+      tenantName: 'tenant',
+      tenantUid: 'txxx',
+      vcs: {
+        branch: 'master',
+        commit: 'DEADBEEF',
+        commitMessage: 'commit message',
+        committerEmail: 'user@example.com',
+        originUrl: 'http://example.com',
+        relativePath: '',
+        type: 'git',
+      },
+      versionEnterprisePlugin: pluginVersion,
+      versionFramework: frameworkVersion,
+      versionSDK: sdkVersion,
+    });
+  });
+
+  it('creates a deployment object correctly on deployment fail of not yet deployed', async () => {
+    request = jest.fn().mockReturnValueOnce(
+      Promise.reject(
+        Object.assign(new Error('ServerlessError: Stack with id test-4-dev does not exist'), {
+          providerError: { statusCode: 400 },
+        })
+      )
+    );
+    const serverless = {
+      processedInput: { options: {} },
+      version: frameworkVersion,
+      config: { servicePath: '.' },
+      service: {
+        tenantUid: 'txxx',
+        tenant: 'tenant',
+        appUid: 'axxx',
+        app: 'app',
+        service: 'service',
+        provider: { stage: 'prod', region: 'us-est-2' },
+        layers: {},
+        functions: {
+          func: {
+            handler: 'func.handler',
+            events: [{ http: { path: '/', method: 'get' } }, { schedule: 'rate(10 minutes)' }],
+          },
+        },
+        outputs: { foo: 'bar', apig: 'CFN!?SFEOutputapig' },
+      },
+    };
+    const provider = {
+      getAccountId,
+      request,
+      naming: {
+        getStackName,
+        getServiceEndpointRegex,
+      },
+      getStage: jest.fn().mockReturnValue('dev'),
+      getRegion: jest.fn().mockReturnValue('us-est-1'),
+    };
+    const state = {
+      safeguardsResults: [],
+      secretsUsed: new Set(['secret']),
+    };
+
+    const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
+
+    expect(deployment.get()).toEqual({
+      serverlessFile: 'service: foobar',
+      serverlessFileName: 'serverless.yml',
+      appName: 'app',
+      appUid: 'axxx',
+      archived: false,
+      custom: {},
+      error: null,
+      logsRoleArn: null,
+      functions: {
+        'service-dev-func': {
+          custom: {
+            awsKmsKeyArn: undefined,
+            environment: [],
+            handler: 'func.handler',
+            layers: [],
+            memorySize: undefined,
+            name: 'func',
+            onError: undefined,
+            role: undefined,
+            runtime: undefined,
+            tags: {},
+            vpc: {
+              securityGroupIds: [],
+              subnetIds: [],
+            },
+          },
+          description: null,
+          arn: 'arn:aws:lambda:us-est-1:account-id:function:service-dev-func',
+          name: 'service-dev-func',
+          timeout: undefined,
+          type: 'awsLambda',
+        },
+      },
+      layers: {},
+      plugins: [],
+      provider: {
+        aws: { accountId: 'account-id' },
+        type: 'aws',
+      },
+      regionName: 'us-est-1',
+      resources: {},
+      safeguards: [],
+      secrets: ['secret'],
+      outputs: { foo: 'bar' },
+      serviceName: 'service',
+      stageName: 'dev',
+      status: 'success',
+      subscriptions: [
+        {
+          cors: undefined,
+          custom: {},
+          function: 'service-dev-func',
+          integration: undefined,
+          method: 'get',
+          path: '/',
+          type: 'http',
+        },
+        {
+          custom: {},
+          function: 'service-dev-func',
+          schedule: 'rate(10 minutes)',
+          type: 'schedule',
+        },
+      ],
       tenantName: 'tenant',
       tenantUid: 'txxx',
       vcs: {


### PR DESCRIPTION
Deployment reported crashes when trying to report on not yet deployed stack (which e.g. fails on first deployment).

This patch ensures it treats stack not existence as valid case