### PR TITLE
PLAT-1347 - allow sls login to work outside of service directories

### DIFF
--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -4,10 +4,12 @@ const { urls } = require('@serverless/platform-sdk');
 
 module.exports.getDashboardUrl = ctx => {
   let dashboardUrl = urls.frontendUrl;
-  dashboardUrl += `tenants/${ctx.sls.service.tenant}/`;
-  dashboardUrl += `applications/${ctx.sls.service.app}/`;
-  dashboardUrl += `services/${ctx.sls.service.service}/`;
-  dashboardUrl += `stage/${ctx.provider.getStage()}/`;
-  dashboardUrl += `region/${ctx.provider.getRegion()}`;
+  if (ctx.sls.enterpriseEnabled) {
+    dashboardUrl += `tenants/${ctx.sls.service.tenant}/`;
+    dashboardUrl += `applications/${ctx.sls.service.app}/`;
+    dashboardUrl += `services/${ctx.sls.service.service}/`;
+    dashboardUrl += `stage/${ctx.provider.getStage()}/`;
+    dashboardUrl += `region/${ctx.provider.getRegion()}`;
+  }
   return dashboardUrl;
 };

--- a/lib/interactiveCli/set-app.js
+++ b/lib/interactiveCli/set-app.js
@@ -54,7 +54,7 @@ module.exports = {
   async check(serverless) {
     if (!serverless.config.servicePath) return false;
     if (serverless.service.provider.name !== 'aws') return false;
-    if (serverless.service.app) return false;
+    if (serverless.service.tenant && serverless.service.app) return false;
     let user = getLoggedInUser();
     let tenants = new Set();
     if (!user) {
@@ -83,8 +83,8 @@ module.exports = {
 
     const tenantName = await (async () => {
       if (tenants.size === 1) return tenants.values().next().value;
-      if (serverless.service.tenant) {
-        if (tenants.has(serverless.service.tenant)) return serverless.service.tenant;
+      if (serverless.service.tenant && tenants.has(serverless.service.tenant)) {
+        return serverless.service.tenant;
       }
       return tenantsChoice(inquirer, tenants);
     })();
@@ -102,6 +102,9 @@ module.exports = {
 
     const appName = await (async () => {
       const appNames = apps.map(app => app.appName);
+      if (serverless.service.app && appNames.includes(serverless.service.app)) {
+        return serverless.service.app;
+      }
       if (apps.length) {
         const chosenAppName = await appNameChoice(inquirer, appNames);
         if (chosenAppName !== '_create_') return chosenAppName;

--- a/lib/login.js
+++ b/lib/login.js
@@ -11,16 +11,14 @@ module.exports = async function(ctx) {
   } catch (err) {
     if (err === 'Complete sign-up before logging in.') {
       ctx.sls.cli.log(
-        "Please complete sign-up at dashboard.serverless.com, configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again"
+        "Please complete sign-up at dashboard.serverless.com, then run 'serverless' to configure your service"
       );
       process.exit(1);
     }
   }
   ctx.sls.cli.log('You sucessfully logged in to Serverless.');
   if (!ctx.sls.service.tenant || !ctx.sls.service.app) {
-    ctx.sls.cli.log(
-      "Please configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again"
-    );
+    ctx.sls.cli.log("Please run 'serverless' to configure your service");
   }
   process.exit(0);
 };

--- a/lib/login.test.js
+++ b/lib/login.test.js
@@ -39,9 +39,7 @@ describe('login', () => {
     await login(ctx);
     expect(sdk.login).toBeCalledWith(undefined);
     expect(log).toBeCalledWith('You sucessfully logged in to Serverless.');
-    expect(log).toBeCalledWith(
-      "Please configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again"
-    );
+    expect(log).toBeCalledWith("Please run 'serverless' to configure your service");
     expect(process.exit).toBeCalledWith(0);
   });
 
@@ -51,7 +49,7 @@ describe('login', () => {
     await login(ctx);
     expect(sdk.login).toBeCalledWith('signup');
     expect(log).toBeCalledWith(
-      "Please complete sign-up at dashboard.serverless.com, configure your service with the tenant and application (documentation - https://git.io/fjl3F) and run 'serverless login' again"
+      "Please complete sign-up at dashboard.serverless.com, then run 'serverless' to configure your service"
     );
     expect(process.exit).toBeCalledWith(1);
   });

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -84,11 +84,33 @@ class ServerlessEnterprisePlugin {
         },
         enterprise: true,
       },
+      'test': {
+        usage: 'Run HTTP tests',
+        lifecycleEvents: ['test'],
+        options: {
+          function: {
+            usage: 'Specify the function to test',
+            shortcut: 'f',
+          },
+          test: {
+            usage: 'Specify a specific test to run',
+            shortcut: 't',
+          },
+        },
+        enterprise: true,
+      },
+      'dashboard': {
+        usage: 'Open the Serverless dashboard',
+        lifecycleEvents: ['dashboard'],
+        enterprise: true,
+      },
     };
     this.hooks = {
       'login:login': this.route('login:login').bind(this),
       'logout:logout': this.route('logout:logout').bind(this),
       'generate-event:generate-event': this.route('generate-event:generate-event').bind(this),
+      'test:test': this.route('test:test').bind(this),
+      'dashboard:dashboard': this.route('dashboard:dashboard').bind(this),
     };
 
     // Don't check any dashbaord stuff if using an unauthenticated command
@@ -126,30 +148,6 @@ class ServerlessEnterprisePlugin {
 
       this.provider = this.sls.getProvider('aws');
       sls.enterpriseEnabled = true;
-
-      // Add authenticated commands
-      Object.assign(this.commands, {
-        test: {
-          usage: 'Run HTTP tests',
-          lifecycleEvents: ['test'],
-          options: {
-            function: {
-              usage: 'Specify the function to test',
-              shortcut: 'f',
-            },
-            test: {
-              usage: 'Specify a specific test to run',
-              shortcut: 't',
-            },
-          },
-          enterprise: true,
-        },
-        dashboard: {
-          usage: 'Open the Serverless dashboard',
-          lifecycleEvents: ['dashboard'],
-          enterprise: true,
-        },
-      });
 
       // Set Plugin hooks for authenticated Enteprise Plugin features here
       Object.assign(this.hooks, {
@@ -189,8 +187,6 @@ class ServerlessEnterprisePlugin {
         'before:step-functions-offline:start': this.route(
           'before:step-functions-offline:start'
         ).bind(this),
-        'test:test': this.route('test:test').bind(this),
-        'dashboard:dashboard': this.route('dashboard:dashboard').bind(this),
       });
     }
   }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -103,7 +103,8 @@ class ServerlessEnterprisePlugin {
     this.state = {}; // Useful for storing data across hooks
     this.state.secretsUsed = new Set();
 
-    if (missing.length > 0) { // user isn't configured to use SFE
+    if (missing.length > 0) {
+      // user isn't configured to use SFE
       Object.assign(this.hooks, {
         'after:aws:deploy:finalize:cleanup': () =>
           sls.cli.log(

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -87,6 +87,10 @@ class ServerlessEnterprisePlugin {
       'generate-event:generate-event': this.route('generate-event:generate-event').bind(this),
     };
 
+    // Defaults
+    this.state = {}; // Useful for storing data across hooks
+    this.state.secretsUsed = new Set();
+
     // Check if Enterprise is configured
     const missing = [];
     if (!sls.service.tenant) {
@@ -98,11 +102,6 @@ class ServerlessEnterprisePlugin {
     if (!sls.service.service) {
       missing.push('service');
     }
-
-    // Defaults
-    this.state = {}; // Useful for storing data across hooks
-    this.state.secretsUsed = new Set();
-
     if (missing.length > 0) {
       // user isn't configured to use SFE
       Object.assign(this.hooks, {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -52,51 +52,7 @@ class ServerlessEnterprisePlugin {
     const user = getLoggedInUser();
     const currentCommand = sls.processedInput.commands[0];
 
-    // default hook, only applies if user isn't using SFE. gets overridden if they are
-    this.hooks = {
-      'after:aws:deploy:finalize:cleanup': () =>
-        sls.cli.log(
-          'Run the "serverless" command to setup monitoring, troubleshooting and testing.'
-        ),
-    };
-
-    // Check if Enterprise is configured
-    const missing = [];
-    if (!sls.service.tenant) {
-      missing.push('tenant');
-    }
-    if (!sls.service.app) {
-      missing.push('app');
-    }
-    if (!sls.service.service) {
-      missing.push('service');
-    }
-
-    // Skip everything if user is not logged in and not trying to log in or out...
-    if (
-      !user &&
-      (currentCommand !== 'login' &&
-        currentCommand !== 'logout' &&
-        !process.env.SERVERLESS_ACCESS_KEY)
-    ) {
-      if (missing.includes('tenant') && missing.includes('app')) {
-        return; // user isn't trying to use SFE
-      }
-      const errorMessage = 'You are not currently logged in. To log in, use: $ serverless login';
-      console.log(''); // eslint-disable-line no-console
-      sls.cli.log(errorMessage);
-      throw new Error(errorMessage);
-    }
-    if (currentCommand !== 'login' && currentCommand !== 'logout' && missing.length > 0) return;
-
-    sls.enterpriseEnabled = true;
-
-    // Defaults
-    this.state = {}; // Useful for storing data across hooks
-    this.state.secretsUsed = new Set();
-    this.provider = this.sls.getProvider('aws');
-
-    // Add commands
+    // Configure commands available to logged out users
     this.commands = {
       'login': {
         usage: 'Login or sign up for Serverless',
@@ -124,72 +80,119 @@ class ServerlessEnterprisePlugin {
         },
         enterprise: true,
       },
-      'test': {
-        usage: 'Run HTTP tests',
-        lifecycleEvents: ['test'],
-        options: {
-          function: {
-            usage: 'Specify the function to test',
-            shortcut: 'f',
-          },
-          test: {
-            usage: 'Specify a specific test to run',
-            shortcut: 't',
-          },
-        },
-        enterprise: true,
-      },
-      'dashboard': {
-        usage: 'Open the Serverless dashboard',
-        lifecycleEvents: ['dashboard'],
-        enterprise: true,
-      },
     };
-
-    // Set Plugin hooks for all Enteprise Plugin features here
     this.hooks = {
-      'before:package:createDeploymentArtifacts': this.route(
-        'before:package:createDeploymentArtifacts'
-      ).bind(this),
-      'after:package:createDeploymentArtifacts': this.route(
-        'after:package:createDeploymentArtifacts'
-      ).bind(this),
-      'before:deploy:function:packageFunction': this.route(
-        'before:deploy:function:packageFunction'
-      ).bind(this),
-      'after:deploy:function:packageFunction': this.route(
-        'after:deploy:function:packageFunction'
-      ).bind(this),
-      'before:invoke:local:invoke': this.route('before:invoke:local:invoke').bind(this),
-      'before:aws:package:finalize:saveServiceState': this.route(
-        'before:aws:package:finalize:saveServiceState'
-      ).bind(this),
-      'before:deploy:deploy': this.route('before:deploy:deploy').bind(this),
-      'before:aws:deploy:deploy:createStack': this.route(
-        'before:aws:deploy:deploy:createStack'
-      ).bind(this),
-      'after:aws:deploy:finalize:cleanup': this.route('after:aws:deploy:finalize:cleanup').bind(
-        this
-      ),
-      'after:deploy:finalize': this.route('after:deploy:finalize').bind(this),
-      'after:deploy:deploy': this.route('after:deploy:deploy').bind(this),
-      'before:info:info': this.route('before:info:info').bind(this),
-      'after:info:info': this.route('after:info:info').bind(this),
-      'before:logs:logs': this.route('before:logs:logs').bind(this),
-      'before:metrics:metrics': this.route('before:metrics:metrics').bind(this),
-      'before:remove:remove': this.route('before:remove:remove').bind(this),
-      'after:remove:remove': this.route('after:remove:remove').bind(this),
-      'after:invoke:local:invoke': this.route('after:invoke:local:invoke').bind(this),
-      'before:offline:start:init': this.route('before:offline:start:init').bind(this),
-      'before:step-functions-offline:start': this.route('before:step-functions-offline:start').bind(
-        this
-      ),
       'login:login': this.route('login:login').bind(this),
       'logout:logout': this.route('logout:logout').bind(this),
       'generate-event:generate-event': this.route('generate-event:generate-event').bind(this),
-      'test:test': this.route('test:test').bind(this),
-      'dashboard:dashboard': this.route('dashboard:dashboard').bind(this),
     };
+
+    // Check if Enterprise is configured
+    const missing = [];
+    if (!sls.service.tenant) {
+      missing.push('tenant');
+    }
+    if (!sls.service.app) {
+      missing.push('app');
+    }
+    if (!sls.service.service) {
+      missing.push('service');
+    }
+
+    // Defaults
+    this.state = {}; // Useful for storing data across hooks
+    this.state.secretsUsed = new Set();
+
+    if (missing.length > 0) { // user isn't configured to use SFE
+      Object.assign(this.hooks, {
+        'after:aws:deploy:finalize:cleanup': () =>
+          sls.cli.log(
+            'Run the "serverless" command to setup monitoring, troubleshooting and testing.'
+          ),
+      });
+    } else {
+      // throw an error if there is no user, no access key, and
+      // user isn't using an unauthenticated command
+      if (
+        !user &&
+        !process.env.SERVERLESS_ACCESS_KEY &&
+        !Object.keys(this.commands).includes(currentCommand)
+      ) {
+        const errorMessage = 'You are not currently logged in. To log in, use: $ serverless login';
+        console.log(''); // eslint-disable-line no-console
+        sls.cli.log(errorMessage);
+        throw new Error(errorMessage);
+      }
+
+      this.provider = this.sls.getProvider('aws');
+      sls.enterpriseEnabled = true;
+
+      // Add authenticated commands
+      Object.assign(this.commands, {
+        test: {
+          usage: 'Run HTTP tests',
+          lifecycleEvents: ['test'],
+          options: {
+            function: {
+              usage: 'Specify the function to test',
+              shortcut: 'f',
+            },
+            test: {
+              usage: 'Specify a specific test to run',
+              shortcut: 't',
+            },
+          },
+          enterprise: true,
+        },
+        dashboard: {
+          usage: 'Open the Serverless dashboard',
+          lifecycleEvents: ['dashboard'],
+          enterprise: true,
+        },
+      });
+
+      // Set Plugin hooks for authenticated Enteprise Plugin features here
+      Object.assign(this.hooks, {
+        'before:package:createDeploymentArtifacts': this.route(
+          'before:package:createDeploymentArtifacts'
+        ).bind(this),
+        'after:package:createDeploymentArtifacts': this.route(
+          'after:package:createDeploymentArtifacts'
+        ).bind(this),
+        'before:deploy:function:packageFunction': this.route(
+          'before:deploy:function:packageFunction'
+        ).bind(this),
+        'after:deploy:function:packageFunction': this.route(
+          'after:deploy:function:packageFunction'
+        ).bind(this),
+        'before:invoke:local:invoke': this.route('before:invoke:local:invoke').bind(this),
+        'before:aws:package:finalize:saveServiceState': this.route(
+          'before:aws:package:finalize:saveServiceState'
+        ).bind(this),
+        'before:deploy:deploy': this.route('before:deploy:deploy').bind(this),
+        'before:aws:deploy:deploy:createStack': this.route(
+          'before:aws:deploy:deploy:createStack'
+        ).bind(this),
+        'after:aws:deploy:finalize:cleanup': this.route('after:aws:deploy:finalize:cleanup').bind(
+          this
+        ),
+        'after:deploy:finalize': this.route('after:deploy:finalize').bind(this),
+        'after:deploy:deploy': this.route('after:deploy:deploy').bind(this),
+        'before:info:info': this.route('before:info:info').bind(this),
+        'after:info:info': this.route('after:info:info').bind(this),
+        'before:logs:logs': this.route('before:logs:logs').bind(this),
+        'before:metrics:metrics': this.route('before:metrics:metrics').bind(this),
+        'before:remove:remove': this.route('before:remove:remove').bind(this),
+        'after:remove:remove': this.route('after:remove:remove').bind(this),
+        'after:invoke:local:invoke': this.route('after:invoke:local:invoke').bind(this),
+        'before:offline:start:init': this.route('before:offline:start:init').bind(this),
+        'before:step-functions-offline:start': this.route(
+          'before:step-functions-offline:start'
+        ).bind(this),
+        'test:test': this.route('test:test').bind(this),
+        'dashboard:dashboard': this.route('dashboard:dashboard').bind(this),
+      });
+    }
   }
 
   /*

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -35,6 +35,10 @@ class ServerlessEnterprisePlugin {
   constructor(sls) {
     this.sls = sls;
 
+    // Defaults
+    this.state = {}; // Useful for storing data across hooks
+    this.state.secretsUsed = new Set();
+
     // forward compatibility with org
     sls.service.tenant = sls.service.org || sls.service.tenant;
 
@@ -87,11 +91,12 @@ class ServerlessEnterprisePlugin {
       'generate-event:generate-event': this.route('generate-event:generate-event').bind(this),
     };
 
-    // Defaults
-    this.state = {}; // Useful for storing data across hooks
-    this.state.secretsUsed = new Set();
+    // Don't check any dashbaord stuff if using an unauthenticated command
+    if (Object.keys(this.commands).includes(currentCommand)) {
+      return;
+    }
 
-    // Check if Enterprise is configured
+    // Check if dashboard is configured
     const missing = [];
     if (!sls.service.tenant) {
       missing.push('tenant');
@@ -111,13 +116,8 @@ class ServerlessEnterprisePlugin {
           ),
       });
     } else {
-      // throw an error if there is no user, no access key, and
-      // user isn't using an unauthenticated command
-      if (
-        !user &&
-        !process.env.SERVERLESS_ACCESS_KEY &&
-        !Object.keys(this.commands).includes(currentCommand)
-      ) {
+      // throw an error if there is no user or access key
+      if (!user && !process.env.SERVERLESS_ACCESS_KEY) {
         const errorMessage = 'You are not currently logged in. To log in, use: $ serverless login';
         console.log(''); // eslint-disable-line no-console
         sls.cli.log(errorMessage);

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -81,7 +81,7 @@ jest.mock('./setApiGatewayAccessLogFormat', () => jest.fn());
 describe('plugin', () => {
   it('constructs and sets hooks', () => {
     const instance = new ServerlessEnterprisePlugin(sls);
-    expect(Object.keys(instance.hooks)).toEqual([
+    expect(new Set(Object.keys(instance.hooks))).toEqual(new Set([
       'before:package:createDeploymentArtifacts',
       'after:package:createDeploymentArtifacts',
       'before:deploy:function:packageFunction',
@@ -107,7 +107,7 @@ describe('plugin', () => {
       'generate-event:generate-event',
       'test:test',
       'dashboard:dashboard',
-    ]);
+    ]));
     expect(sls.getProvider).toBeCalledWith('aws');
     expect(sls.cli.log).toHaveBeenCalledTimes(0);
   });

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -81,33 +81,35 @@ jest.mock('./setApiGatewayAccessLogFormat', () => jest.fn());
 describe('plugin', () => {
   it('constructs and sets hooks', () => {
     const instance = new ServerlessEnterprisePlugin(sls);
-    expect(new Set(Object.keys(instance.hooks))).toEqual(new Set([
-      'before:package:createDeploymentArtifacts',
-      'after:package:createDeploymentArtifacts',
-      'before:deploy:function:packageFunction',
-      'after:deploy:function:packageFunction',
-      'before:invoke:local:invoke',
-      'before:aws:package:finalize:saveServiceState',
-      'before:deploy:deploy',
-      'before:aws:deploy:deploy:createStack',
-      'after:aws:deploy:finalize:cleanup',
-      'after:deploy:finalize',
-      'after:deploy:deploy',
-      'before:info:info',
-      'after:info:info',
-      'before:logs:logs',
-      'before:metrics:metrics',
-      'before:remove:remove',
-      'after:remove:remove',
-      'after:invoke:local:invoke',
-      'before:offline:start:init',
-      'before:step-functions-offline:start',
-      'login:login',
-      'logout:logout',
-      'generate-event:generate-event',
-      'test:test',
-      'dashboard:dashboard',
-    ]));
+    expect(new Set(Object.keys(instance.hooks))).toEqual(
+      new Set([
+        'before:package:createDeploymentArtifacts',
+        'after:package:createDeploymentArtifacts',
+        'before:deploy:function:packageFunction',
+        'after:deploy:function:packageFunction',
+        'before:invoke:local:invoke',
+        'before:aws:package:finalize:saveServiceState',
+        'before:deploy:deploy',
+        'before:aws:deploy:deploy:createStack',
+        'after:aws:deploy:finalize:cleanup',
+        'after:deploy:finalize',
+        'after:deploy:deploy',
+        'before:info:info',
+        'after:info:info',
+        'before:logs:logs',
+        'before:metrics:metrics',
+        'before:remove:remove',
+        'after:remove:remove',
+        'after:invoke:local:invoke',
+        'before:offline:start:init',
+        'before:step-functions-offline:start',
+        'login:login',
+        'logout:logout',
+        'generate-event:generate-event',
+        'test:test',
+        'dashboard:dashboard',
+      ])
+    );
     expect(sls.getProvider).toBeCalledWith('aws');
     expect(sls.cli.log).toHaveBeenCalledTimes(0);
   });

--- a/lib/test/index.js
+++ b/lib/test/index.js
@@ -8,6 +8,10 @@ const yaml = require('js-yaml');
 const runTest = require('./runTest');
 
 module.exports.test = async ctx => {
+  if (!ctx.sls.enterpriseEnabled) {
+    ctx.sls.cli.log('Run "serverless" to configure your service for testing.');
+    return;
+  }
   if (!fse.exists('serverless.test.yml')) {
     ctx.sls.cli.log('No serverless.test.yml file found');
     return;

--- a/lib/test/index.test.js
+++ b/lib/test/index.test.js
@@ -36,6 +36,7 @@ describe('test', () => {
   it('calls runTest', async () => {
     const ctx = {
       sls: {
+        enterpriseEnabled: true,
         processedInput: { options: {} },
         cli: { log: jest.fn() },
         service: { functions: [] },
@@ -78,5 +79,14 @@ describe('test', () => {
       [`\r   ${chalk.green('passed')} - POST blah - foobar\n`],
       ['\n'],
     ]);
+  });
+
+  it('logs message if sfe not enabled', async () => {
+    const ctx = { sls: { cli: { log: jest.fn() } } };
+    await testFunc(ctx);
+    expect(ctx.sls.cli.log).toBeCalledWith(
+      'Run "serverless" to configure your service for testing.'
+    );
+    expect(process.stdout.write.mock.calls).toEqual([]);
   });
 });


### PR DESCRIPTION
In doing this, I cleaned up the constructor. Now there is a clear separation between logged in commands/hooks and always allowed ones and the provider isnot set till we know the user is using sls, because when not in a service dir, only non-provider plugins are loaded

Also, updated messaging to use new interactive command and update interactive command to be robust enough to handle having an app but no tenant set