### PR TITLE
Include Python SDK in dist

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,4 +12,4 @@ cd ..
 mkdir -p dist/sdk-js/dist
 cp -a sdk-js/dist/index.js dist/sdk-js/dist/index.js
 mkdir -p dist/sdk-py
-cp -a sdk-py/serverless_sdk.py dist/sdk-py/serverless_sdk.py
+cp -a sdk-py/ dist/sdk-py

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,3 +11,5 @@ npm run build
 cd ..
 mkdir -p dist/sdk-js/dist
 cp -a sdk-js/dist/index.js dist/sdk-js/dist/index.js
+mkdir -p dist/sdk-py
+cp -a sdk-py/serverless_sdk.py dist/sdk-py/serverless_sdk.py


### PR DESCRIPTION
The Python SDK was missing from the plugin install. I *think* this is the fix but would appreciate a double-check.