### PR TITLE
fix bug with python handlers more than 1 directory deep

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -116,7 +116,7 @@ const wrap = async ctx => {
       extension,
       entryOrig: entry,
       handlerOrig: handler,
-      entryNew: `s_${func}`,
+      entryNew: `s_${func.replace(/-/g, '_')}`,
       handlerNew: 'handler',
     };
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "engines": {
     "node": ">=6.0"
   },

--- a/sdk-py/serverless_sdk.py
+++ b/sdk-py/serverless_sdk.py
@@ -15,7 +15,7 @@ module_start_time = time.time()
 def get_user_handler(user_handler_value):
     orig_path = sys.path
     if "/" in user_handler_value:
-        user_module_path, user_module_and_handler = user_handler_value.rsplit("/")
+        user_module_path, user_module_and_handler = user_handler_value.rsplit("/", 1)
         sys.path.append(user_module_path)
     else:
         user_module_and_handler = user_handler_value


### PR DESCRIPTION
did it by making it max split once. Also made the injected python modules more likely to have valid python filenames (even tho AWS works with weird ones)