### PR TITLE
check if outputValue is string before calling startsWith

### DIFF
--- a/lib/deployment/parse.js
+++ b/lib/deployment/parse.js
@@ -63,7 +63,7 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
     // get any CFN outputs
     const outputs = service.outputs || {};
     for (const [outputKey, outputValue] of _.entries(outputs)) {
-      if (outputValue.startsWith('CFN!?')) {
+      if (typeof outputValue === 'string' && outputValue.startsWith('CFN!?')) {
         if (cfnStack) {
           const cfnOutput = _.find(
             cfnStack.Stacks[0].Outputs,


### PR DESCRIPTION
The outputs defined in `serverless.yml` may be any type supported by YAML, not just a string. The parser calls `startsWith` on the output value causing an unhandled exception if the outputValue type is anything other than a string. This checks the type to be a string before calling `startsWith`.