### PR TITLE
Update node handler wrapper to not cause timeouts

### DIFF
--- a/integration-testing/service3/handler.js
+++ b/integration-testing/service3/handler.js
@@ -1,0 +1,46 @@
+'use strict';
+
+module.exports.sync = () => {
+  return { statusCode: 200 };
+};
+
+module.exports.syncError = () => {
+  throw new Error('syncError');
+};
+
+module.exports.async = async () => {
+  return { statusCode: 200 };
+};
+
+module.exports.asyncDanglingCallback = async () => {
+  setTimeout(() => true, 1000000);
+  return { statusCode: 200 };
+};
+
+module.exports.asyncError = async () => {
+  throw new Error('asyncError');
+};
+
+module.exports.callback = (event, context, callback) => {
+  callback(null, { statusCode: 200 });
+};
+
+module.exports.callbackError = (event, context, callback) => {
+  callback('callbackError');
+};
+
+module.exports.done = (event, context) => {
+  context.done(null, { statusCode: 200 });
+};
+
+module.exports.doneError = (event, context) => {
+  context.done('doneError');
+};
+
+module.exports.fail = (event, context) => {
+  context.fail('failError');
+};
+
+module.exports.succeed = (event, context) => {
+  context.succeed({ statusCode: 200 });
+};

--- a/integration-testing/service3/serverless.yml
+++ b/integration-testing/service3/serverless.yml
@@ -1,0 +1,31 @@
+tenant: integration
+app: integration
+service: CHANGEME
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+
+functions:
+  sync:
+    handler: handler.sync
+  syncError:
+    handler: handler.syncError
+  async:
+    handler: handler.async
+  asyncError:
+    handler: handler.asyncError
+  asyncDanglingCallback:
+    handler: handler.asyncDanglingCallback
+  callback:
+    handler: handler.callback
+  callbackError:
+    handler: handler.callbackError
+  done:
+    handler: handler.done
+  doneError:
+    handler: handler.doneError
+  fail:
+    handler: handler.fail
+  succeed:
+    handler: handler.succeed

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const stripAnsi = require('strip-ansi');
+const setup = require('./setup');
+const AWS = require('aws-sdk');
+
+const lambda = new AWS.Lambda({ region: 'us-east-1' });
+
+let sls;
+let teardown;
+let serviceName;
+
+jest.setTimeout(1000 * 60 * 5);
+
+beforeAll(async () => {
+  ({ sls, teardown } = await setup('service3'));
+  await sls(['deploy']);
+  serviceName = stripAnsi(
+    String((await sls(['print', '--path', 'service'], { env: { SLS_DEBUG: '' } })).stdoutBuffer)
+  ).trim();
+});
+
+afterAll(() => {
+  if (teardown) return teardown();
+  return null;
+});
+
+describe('integration', () => {
+  it('can call wrapped sync handler', async () => {
+    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-sync` }).promise();
+    expect(JSON.parse(Payload)).toEqual(null); // why did i think this was possible?
+  });
+
+  it('can call wrapped syncError handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-syncError` })
+      .promise();
+    expect(JSON.parse(Payload).errorMessage).toEqual('syncError');
+  });
+
+  it('can call wrapped async handler', async () => {
+    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-async` }).promise();
+    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+  });
+
+  it('can call wrapped asyncError handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-asyncError` })
+      .promise();
+    expect(JSON.parse(Payload).errorMessage).toEqual('asyncError');
+  });
+
+  it('can call wrapped asyncDanglingCallback handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-asyncDanglingCallback` })
+      .promise();
+    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+  });
+
+  it('can call wrapped done handler', async () => {
+    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-done` }).promise();
+    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+  });
+
+  it('can call wrapped doneError handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-doneError` })
+      .promise();
+    expect(JSON.parse(Payload).errorMessage).toEqual('doneError');
+  });
+
+  it('can call wrapped callback handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-callback` })
+      .promise();
+    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+  });
+
+  it('can call wrapped callbackError handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-callbackError` })
+      .promise();
+    expect(JSON.parse(Payload).errorMessage).toEqual('callbackError');
+  });
+
+  it('can call wrapped succeed handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-succeed` })
+      .promise();
+    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@babel/core": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@serverless/eslint-config": "^1.0.1",
+    "aws-sdk": "^2.503.0",
     "child-process-ext": "^2.0.0",
     "eslint": "^6.0.1",
     "eslint-plugin-import": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "engines": {
     "node": ">=6.0"
   },

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -199,11 +199,12 @@ class ServerlessSDK {
           if (finalized) return;
           try {
             if (capturedError) {
-              return trans.error(capturedError, false);
+              trans.error(capturedError, false);
             } else if (error) {
-              return trans.error(error, true);
+              trans.error(error, true);
+            } else {
+              trans.end();
             }
-            return trans.end();
           } finally {
             finalized = true;
             // Remove the span listeners

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -194,7 +194,7 @@ class ServerlessSDK {
          */
 
         let capturedError = null;
-        let finalized = false
+        let finalized = false;
         const finalize = error => {
           if (finalized) return;
           try {

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -255,15 +255,16 @@ class ServerlessSDK {
         // If promise was returned, handle it
         if (result && typeof result.then === 'function') {
           return result
-            .then(data => {
+            .then(res => {
               // In a AWS Lambda 'async' handler, an error can be returned directly
               // This makes it look like a valid response, which it's not.
               // The SDK needs to look out for this here, so it can still log/report the error like all others.
-              if (data instanceof Error) {
-                finalize(data, null);
+              if (res instanceof Error) {
+                finalize(res, null);
               } else {
-                finalize(null, data);
+                finalize(null, res);
               }
+              return res;
             })
             .catch(err => {
               finalize(err, null);

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -194,7 +194,9 @@ class ServerlessSDK {
          */
 
         let capturedError = null;
+        let finalized = false
         const finalize = error => {
+          if (finalized) return;
           try {
             if (capturedError) {
               return trans.error(capturedError, false);
@@ -203,6 +205,7 @@ class ServerlessSDK {
             }
             return trans.end();
           } finally {
+            finalized = true;
             // Remove the span listeners
             spanEmitter.removeAllListeners('span');
           }

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -260,14 +260,14 @@ class ServerlessSDK {
               // This makes it look like a valid response, which it's not.
               // The SDK needs to look out for this here, so it can still log/report the error like all others.
               if (res instanceof Error) {
-                finalize(res, null);
+                finalize(res);
               } else {
-                finalize(null, res);
+                finalize(null);
               }
               return res;
             })
             .catch(err => {
-              finalize(err, null);
+              finalize(err);
               throw err;
             });
         }

--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -150,7 +150,7 @@ class Transaction {
    * - Sends the error and ends the transaction
    */
 
-  error(error, fatal, cb) {
+  error(error, fatal) {
     const self = this;
     if (isError(error)) {
       // Create Error ID
@@ -172,7 +172,7 @@ class Transaction {
 
         // End transaction
         this.buildOutput(ERROR); // set this to transaction for now.
-        self.end(cb);
+        self.end();
       });
     } else {
       // Create Error ID
@@ -190,7 +190,7 @@ class Transaction {
 
       // End transaction
       this.buildOutput(ERROR); // set this to transaction for now.
-      self.end(cb);
+      self.end();
     }
   }
 
@@ -198,12 +198,10 @@ class Transaction {
    * End
    */
 
-  end(cb) {
+  end() {
     if (this.$.schema.error.id === null) {
       this.buildOutput(TRANSACTION);
     }
-
-    return cb ? setImmediate(cb) : true;
   }
 
   buildOutput(type) {


### PR DESCRIPTION
The main change is that the wrapper more closely mimics user behavior. EG:
* if they return a promise, the wrapper returns a promise and does not call `callback`
* if they call `callback`, so does the wrapper (only thing that isn't new)
* if they return/error in a synchronous fashion, so does the wrapper
* if they call `context.succeed`, call the original `context.succeed`, not `callback` (or, as it turns out, when lambda does so internally on a successful promise resolution. This is the real cause of most cases where this bug surfaces afaict). And similarly for `done` & `fail`.

given the interesting behavior between use of async/promises and `context.succeed`, there's also a new boolean var to ensure we don't log duplicate transactions.

Also included version bump to be able to release this along with #228 

To reproduce the bug and test the fix, use this handler:
```javascript
module.exports.hello = async event => {
  const returnObj = setTimeout(() => {
    console.log('Timeout complete');
  }, 60000)

  return { statusCode: 200 };
};
```
Then (full setup incase you don't have plugin/sfo setup for development on your box):
```bash
cd $PATH_TO_SLS_REPO
npm i
npm link
cd $SOME_RANDOM_DIR
sls create -t aws-nodejs
# paste the above into `handler.js`
sls deploy
sls invoke -f hello # will succeed
sls # setup SFE
sls deploy
sls invoke -f hello # will timeout
cd $PATH_TO_SFE_PLUGIN_REPO
git fetch && git checkout fix-wrapper-bugs
npm i && npm run build && npm link
cd $PATH_TO_SLS_REPO
npm link @serverless/enterprise-plugin
cd $SOME_RANDOM_DIR # the same one as before
sls deploy
sls invoke -f hello # will succeed!
```

### Update:
I've added integration tests, they should help prove it all works.
results with SFE disabled:
```
 PASS  integration-testing/wrapper.test.js (119.856s)
  integration
    ✓ can call wrapped sync handler (374ms)
    ✓ can call wrapped syncError handler (325ms)
    ✓ can call wrapped async handler (311ms)
    ✓ can call wrapped asyncError handler (304ms)
    ✓ can call wrapped asyncDanglingCallback handler (361ms)
    ✓ can call wrapped done handler (326ms)
    ✓ can call wrapped doneError handler (323ms)
    ✓ can call wrapped callback handler (330ms)
    ✓ can call wrapped callbackError handler (326ms)
    ✓ can call wrapped succeed handler (373ms)

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        119.914s
```
results with SFE on master enabled:
```
 FAIL  integration-testing/wrapper.test.js (130.548s)
  integration
    ✓ can call wrapped sync handler (439ms)
    ✓ can call wrapped syncError handler (413ms)
    ✓ can call wrapped async handler (409ms)
    ✓ can call wrapped asyncError handler (411ms)
    ✕ can call wrapped asyncDanglingCallback handler (6400ms)
    ✓ can call wrapped done handler (415ms)
    ✓ can call wrapped doneError handler (390ms)
    ✓ can call wrapped callback handler (394ms)
    ✓ can call wrapped callbackError handler (394ms)
    ✓ can call wrapped succeed handler (379ms)

  ● integration › can call wrapped asyncDanglingCallback handler

    expect(received).toEqual(expected) // deep equality

    - Expected
    + Received

      Object {
    -   "statusCode": 200,
    +   "errorMessage": "2019-07-30T19:51:09.815Z 0e2222d8-853d-402a-a2d1-90a054dba028 Task timed out after 6.01 seconds",
      }



      at Object.<anonymous> (integration-testing/wrapper.test.js:89:33)
      at asyncGeneratorStep (integration-testing/wrapper.test.js:3:103)
      at _next (integration-testing/wrapper.test.js:5:194)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 9 passed, 10 total
Snapshots:   0 total
Time:        130.601s
```
results with SFE on this branch:
```
 PASS  integration-testing/wrapper.test.js (123.537s)
  integration
    ✓ can call wrapped sync handler (480ms)
    ✓ can call wrapped syncError handler (409ms)
    ✓ can call wrapped async handler (372ms)
    ✓ can call wrapped asyncError handler (408ms)
    ✓ can call wrapped asyncDanglingCallback handler (390ms)
    ✓ can call wrapped done handler (389ms)
    ✓ can call wrapped doneError handler (392ms)
    ✓ can call wrapped callback handler (350ms)
    ✓ can call wrapped callbackError handler (408ms)
    ✓ can call wrapped succeed handler (389ms)

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        123.6s, estimated 131s
```

Also, swapping reviewers since Mariusz is on vacation and Jeremy's busy trying to wrap up his work before vacation. tag. you're it, @astuyve @alexdebrie 