### PR TITLE
Fix error regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 script:
   - npm test
   - cd sdk-js
-  - npm test
+  - if node --version|grep -v v6 ; then npm test; fi # skip sdk tests on node 6
   - cd ..
 
 # Ensure to fail build if deploy fails, Travis doesn't ensure that: https://github.com/travis-ci/travis-ci/issues/921

--- a/integration-testing/service3/handler.js
+++ b/integration-testing/service3/handler.js
@@ -22,7 +22,7 @@ module.exports.asyncError = async () => {
 };
 
 module.exports.callback = (event, context, callback) => {
-  callback(null, { statusCode: 200 });
+  setTimeout(() => callback(null, { statusCode: 200 }), 200);
 };
 
 module.exports.callbackError = (event, context, callback) => {

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -98,7 +98,7 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-doneError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":"Error!\$doneError"/);
+    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$doneError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('doneError');
   });
 
@@ -116,7 +116,7 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callbackError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":"Error!\$callbackError"/);
+    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$callbackError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('callbackError');
   });
 
@@ -125,7 +125,7 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-fail` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":"Error!\$failError"/);
+    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$failError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('failError');
   });
 

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -96,6 +96,11 @@ describe('integration', () => {
     expect(JSON.parse(Payload).errorMessage).toEqual('callbackError');
   });
 
+  it('can call wrapped fail handler', async () => {
+    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-fail` }).promise();
+    expect(JSON.parse(Payload).errorMessage).toEqual('failError');
+  });
+
   it('can call wrapped succeed handler', async () => {
     const { Payload } = await lambda
       .invoke({ FunctionName: `${serviceName}-dev-succeed` })

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -40,71 +40,101 @@ afterAll(() => {
 
 describe('integration', () => {
   it('can call wrapped sync handler', async () => {
-    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-sync` }).promise();
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-sync` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual(null); // why did i think this was possible?
   });
 
   it('can call wrapped syncError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-syncError` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-syncError` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":"Error!\$syncError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('syncError');
   });
 
   it('can call wrapped async handler', async () => {
-    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-async` }).promise();
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-async` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 
   it('can call wrapped asyncError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-asyncError` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncError` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":"Error!\$asyncError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('asyncError');
   });
 
   it('can call wrapped asyncDanglingCallback handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-asyncDanglingCallback` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncDanglingCallback` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 
   it('can call wrapped done handler', async () => {
-    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-done` }).promise();
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-done` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 
   it('can call wrapped doneError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-doneError` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-doneError` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":"Error!\$doneError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('doneError');
   });
 
   it('can call wrapped callback handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-callback` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callback` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 
   it('can call wrapped callbackError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-callbackError` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callbackError` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":"Error!\$callbackError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('callbackError');
   });
 
   it('can call wrapped fail handler', async () => {
-    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-fail` }).promise();
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-fail` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":"Error!\$failError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('failError');
   });
 
   it('can call wrapped succeed handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-succeed` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-succeed` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 });

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -13,6 +13,13 @@ const _ = require('lodash');
 const JSZip = require('jszip');
 const { addTree, writeZip } = require('./zipTree');
 
+const deprecatedNodes = ['nodejs', 'nodejs4.3', 'nodejs4.3-edge', 'nodejs6.10'];
+const supportedNodeRuntime = runtime =>
+  runtime.includes('nodejs') && !deprecatedNodes.includes(runtime);
+const supportedPythonRuntime = runtime => runtime.includes('python');
+const supportedRuntime = runtime =>
+  supportedNodeRuntime(runtime) || supportedPythonRuntime(runtime);
+
 /*
  * Wrap Node.js Functions
  */
@@ -88,7 +95,7 @@ const wrap = async ctx => {
     const runtime = functions[func].runtime
       ? functions[func].runtime
       : ctx.sls.service.provider.runtime;
-    if (!runtime.includes('nodejs') && !runtime.includes('python')) {
+    if (!supportedRuntime(runtime)) {
       unsupportedRuntimes.add(runtime);
       continue;
     }
@@ -151,12 +158,12 @@ const wrap = async ctx => {
 
   // Copy SDK
   const vals = Object.keys(ctx.state.functions).map(key => ctx.state.functions[key]);
-  if (vals.some(({ runtime }) => runtime.includes('nodejs'))) {
+  if (vals.some(({ runtime }) => supportedNodeRuntime(runtime))) {
     const pathSdk = path.resolve(__dirname, '../sdk-js/dist/index.js');
     const pathSdkDest = path.join(ctx.state.pathAssets, './index.js');
     fs.copySync(pathSdk, pathSdkDest);
   }
-  if (vals.some(({ runtime }) => runtime.includes('python'))) {
+  if (vals.some(({ runtime }) => supportedPythonRuntime(runtime))) {
     const pathSdk = path.resolve(__dirname, '../sdk-py/serverless_sdk.py');
     const pathSdkDest = path.join(ctx.state.pathAssets, './__init__.py');
     fs.copySync(pathSdk, pathSdkDest);
@@ -166,15 +173,15 @@ const wrap = async ctx => {
   for (const fn of Object.keys(ctx.state.functions)) {
     const func = ctx.state.functions[fn];
 
-    if (!func.runtime.includes('nodejs') && !func.runtime.includes('python')) {
+    if (!supportedRuntime(func.runtime)) {
       continue;
     }
 
     // Add the Serverless SDK wrapper around the function
 
-    if (func.runtime.includes('nodejs')) {
+    if (supportedNodeRuntime(func.runtime)) {
       wrapNodeJs(func, ctx);
-    } else if (func.runtime.includes('python')) {
+    } else if (supportedPythonRuntime(func.runtime)) {
       wrapPython(func, ctx);
     }
 
@@ -212,7 +219,7 @@ const wrap = async ctx => {
   // add include directives for handler file & sdk lib
   if (!_.get(ctx.sls.service, 'package.individually', false)) {
     let extension = 'js';
-    if (ctx.sls.service.provider.runtime.includes('python')) {
+    if (supportedPythonRuntime(ctx.sls.service.provider.runtime)) {
       extension = 'py';
     }
     if (ctx.sls.service.package === undefined) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "engines": {
     "node": ">=6.0"
   },

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -227,8 +227,6 @@ class ServerlessSDK {
               }
               if (res && typeof res.then === 'function') {
                 res.then(resolve);
-              } else {
-                resolve(null);
               }
             } catch (error) {
               reject(error);

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -228,7 +228,7 @@ class ServerlessSDK {
               if (res && typeof res.then === 'function') {
                 res.then(resolve);
               } else {
-                resolve(res);
+                resolve(null);
               }
             } catch (error) {
               reject(error);


### PR DESCRIPTION
I'd over looked that error parsing was an async action. For my first try to fix this I tried to make all the callback functions async to call it, but it didn't work with done/fail/callback with errors for some reason. As such, i converted my approach to having a minimal wrapper to turn the users' handler into a promise returning lambda. then that wrapped lambda is instrumented to do spans & transaction logging. 

confirmed working and added test coverage to the integration test for the log output too.

promise based lamdbas only work in node 8 or greater, but in only 11 days, you won't be able to upload node 6 lambdas, so i've disabled support for it in the plugin. https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html