### PR TITLE
Actually fix node wrapper, all edgecases considered

### DIFF
--- a/integration-testing/service3/handler.js
+++ b/integration-testing/service3/handler.js
@@ -22,7 +22,7 @@ module.exports.asyncError = async () => {
 };
 
 module.exports.callback = (event, context, callback) => {
-  callback(null, { statusCode: 200 });
+  setTimeout(() => callback(null, { statusCode: 200 }, 10));
 };
 
 module.exports.callbackError = (event, context, callback) => {

--- a/integration-testing/service3/handler.js
+++ b/integration-testing/service3/handler.js
@@ -22,7 +22,7 @@ module.exports.asyncError = async () => {
 };
 
 module.exports.callback = (event, context, callback) => {
-  setTimeout(() => callback(null, { statusCode: 200 }), 10);
+  setTimeout(() => callback(null, { statusCode: 200 }), 5000);
 };
 
 module.exports.callbackError = (event, context, callback) => {

--- a/integration-testing/service3/handler.js
+++ b/integration-testing/service3/handler.js
@@ -22,7 +22,7 @@ module.exports.asyncError = async () => {
 };
 
 module.exports.callback = (event, context, callback) => {
-  setTimeout(() => callback(null, { statusCode: 200 }, 10));
+  setTimeout(() => callback(null, { statusCode: 200 }), 10);
 };
 
 module.exports.callbackError = (event, context, callback) => {

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -108,7 +108,7 @@ describe('integration', () => {
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 
-  it('gets SFE log msg from wrapped sync handler', async () => {
+  xit('gets SFE log msg from wrapped sync handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-sync` })
       .promise();

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -202,6 +202,6 @@ describe('integration', () => {
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
     const duration = parseFloat(logResult.match(/"duration":(\d+\.\d+)/)[1]);
-    expect(duration).toBeGreatherThan(5);
+    expect(duration).toBeGreaterThan(5);
   });
 });

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -201,7 +201,7 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callback` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    const duration = logResult.parseFloat('"duration":13.242'.match(/"duration":(\d+\.\d+)/)[1]);
+    const duration = parseFloat(logResult.match(/"duration":(\d+\.\d+)/)[1]);
     expect(duration).toBeGreatherThan(5);
   });
 });

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -44,8 +44,8 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-sync` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual(null); // why did i think this was possible?
+    expect(logResult).toMatch(/"errorId":null/);
   });
 
   it('can call wrapped syncError handler', async () => {
@@ -53,8 +53,8 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-syncError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":"Error!\$syncError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('syncError');
+    expect(logResult).toMatch(/"errorId":"Error!\$syncError"/);
   });
 
   it('can call wrapped async handler', async () => {
@@ -62,8 +62,8 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-async` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+    expect(logResult).toMatch(/"errorId":null/);
   });
 
   it('can call wrapped asyncError handler', async () => {
@@ -71,8 +71,8 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":"Error!\$asyncError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('asyncError');
+    expect(logResult).toMatch(/"errorId":"Error!\$asyncError"/);
   });
 
   it('can call wrapped asyncDanglingCallback handler', async () => {
@@ -80,8 +80,8 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncDanglingCallback` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+    expect(logResult).toMatch(/"errorId":null/);
   });
 
   it('can call wrapped done handler', async () => {
@@ -89,8 +89,8 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-done` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+    expect(logResult).toMatch(/"errorId":null/);
   });
 
   it('can call wrapped doneError handler', async () => {
@@ -98,8 +98,8 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-doneError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$doneError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('doneError');
+    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$doneError"/);
   });
 
   it('can call wrapped callback handler', async () => {
@@ -107,8 +107,8 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callback` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+    expect(logResult).toMatch(/"errorId":null/);
   });
 
   it('can call wrapped callbackError handler', async () => {
@@ -116,8 +116,8 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callbackError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$callbackError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('callbackError');
+    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$callbackError"/);
   });
 
   it('can call wrapped fail handler', async () => {
@@ -125,8 +125,8 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-fail` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$failError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('failError');
+    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$failError"/);
   });
 
   it('can call wrapped succeed handler', async () => {
@@ -134,7 +134,7 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-succeed` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+    expect(logResult).toMatch(/"errorId":null/);
   });
 });

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -40,66 +40,101 @@ afterAll(() => {
 
 describe('integration', () => {
   it('can call wrapped sync handler', async () => {
-    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-sync` }).promise();
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-sync` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual(null); // why did i think this was possible?
   });
 
   it('can call wrapped syncError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-syncError` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-syncError` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":"Error!\$syncError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('syncError');
   });
 
   it('can call wrapped async handler', async () => {
-    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-async` }).promise();
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-async` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 
   it('can call wrapped asyncError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-asyncError` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncError` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":"Error!\$asyncError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('asyncError');
   });
 
   it('can call wrapped asyncDanglingCallback handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-asyncDanglingCallback` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncDanglingCallback` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 
   it('can call wrapped done handler', async () => {
-    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-done` }).promise();
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-done` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 
   it('can call wrapped doneError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-doneError` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-doneError` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$doneError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('doneError');
   });
 
   it('can call wrapped callback handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-callback` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callback` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 
   it('can call wrapped callbackError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-callbackError` })
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callbackError` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$callbackError"/);
     expect(JSON.parse(Payload).errorMessage).toEqual('callbackError');
   });
 
-  it('can call wrapped succeed handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-succeed` })
+  it('can call wrapped fail handler', async () => {
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-fail` })
       .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$failError"/);
+    expect(JSON.parse(Payload).errorMessage).toEqual('failError');
+  });
+
+  it('can call wrapped succeed handler', async () => {
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-succeed` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).toMatch(/"errorId":null/);
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 });

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -210,6 +210,6 @@ describe('integration', () => {
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
     const duration = logResult.parseFloat('"duration":13.242'.match(/"duration":(\d+\.\d+)/)[1])
-    expect(duration).toBeGreatherThan(10);
+    expect(duration).toBeGreatherThan(5);
   });
 });

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -40,9 +40,7 @@ afterAll(() => {
 
 describe('integration', () => {
   it('gets right return value from  wrapped sync handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-sync` })
-      .promise();
+    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-sync` }).promise();
     expect(JSON.parse(Payload)).toEqual(null); // why did i think this was possible?
   });
 
@@ -54,9 +52,7 @@ describe('integration', () => {
   });
 
   it('gets right return value from  wrapped async handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-async` })
-      .promise();
+    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-async` }).promise();
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 
@@ -75,9 +71,7 @@ describe('integration', () => {
   });
 
   it('gets right return value from  wrapped done handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-done` })
-      .promise();
+    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-done` }).promise();
     expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
   });
 
@@ -103,9 +97,7 @@ describe('integration', () => {
   });
 
   it('gets right return value from  wrapped fail handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-fail` })
-      .promise();
+    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-fail` }).promise();
     expect(JSON.parse(Payload).errorMessage).toEqual('failError');
   });
 
@@ -209,7 +201,7 @@ describe('integration', () => {
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callback` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    const duration = logResult.parseFloat('"duration":13.242'.match(/"duration":(\d+\.\d+)/)[1])
+    const duration = logResult.parseFloat('"duration":13.242'.match(/"duration":(\d+\.\d+)/)[1]);
     expect(duration).toBeGreatherThan(5);
   });
 });

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -39,102 +39,177 @@ afterAll(() => {
 });
 
 describe('integration', () => {
-  it('can call wrapped sync handler', async () => {
+  it('gets right return value from  wrapped sync handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-sync` })
+      .promise();
+    expect(JSON.parse(Payload)).toEqual(null); // why did i think this was possible?
+  });
+
+  it('gets right return value from  wrapped syncError handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-syncError` })
+      .promise();
+    expect(JSON.parse(Payload).errorMessage).toEqual('syncError');
+  });
+
+  it('gets right return value from  wrapped async handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-async` })
+      .promise();
+    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+  });
+
+  it('gets right return value from  wrapped asyncError handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-asyncError` })
+      .promise();
+    expect(JSON.parse(Payload).errorMessage).toEqual('asyncError');
+  });
+
+  it('gets right return value from  wrapped asyncDanglingCallback handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-asyncDanglingCallback` })
+      .promise();
+    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+  });
+
+  it('gets right return value from  wrapped done handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-done` })
+      .promise();
+    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+  });
+
+  it('gets right return value from  wrapped doneError handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-doneError` })
+      .promise();
+    expect(JSON.parse(Payload).errorMessage).toEqual('doneError');
+  });
+
+  it('gets right return value from  wrapped callback handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-callback` })
+      .promise();
+    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+  });
+
+  it('gets right return value from  wrapped callbackError handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-callbackError` })
+      .promise();
+    expect(JSON.parse(Payload).errorMessage).toEqual('callbackError');
+  });
+
+  it('gets right return value from  wrapped fail handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-fail` })
+      .promise();
+    expect(JSON.parse(Payload).errorMessage).toEqual('failError');
+  });
+
+  it('gets right return value from  wrapped succeed handler', async () => {
+    const { Payload } = await lambda
+      .invoke({ FunctionName: `${serviceName}-dev-succeed` })
+      .promise();
+    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
+  });
+
+  it('gets SFE log msg from wrapped sync handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-sync` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(JSON.parse(Payload)).toEqual(null); // why did i think this was possible?
     expect(logResult).toMatch(/"errorId":null/);
   });
 
-  it('can call wrapped syncError handler', async () => {
+  it('gets SFE log msg from wrapped syncError handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-syncError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(JSON.parse(Payload).errorMessage).toEqual('syncError');
     expect(logResult).toMatch(/"errorId":"Error!\$syncError"/);
   });
 
-  it('can call wrapped async handler', async () => {
+  it('gets SFE log msg from wrapped async handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-async` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
     expect(logResult).toMatch(/"errorId":null/);
   });
 
-  it('can call wrapped asyncError handler', async () => {
+  it('gets SFE log msg from wrapped asyncError handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(JSON.parse(Payload).errorMessage).toEqual('asyncError');
     expect(logResult).toMatch(/"errorId":"Error!\$asyncError"/);
   });
 
-  it('can call wrapped asyncDanglingCallback handler', async () => {
+  it('gets SFE log msg from wrapped asyncDanglingCallback handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncDanglingCallback` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
     expect(logResult).toMatch(/"errorId":null/);
   });
 
-  it('can call wrapped done handler', async () => {
+  it('gets SFE log msg from wrapped done handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-done` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
     expect(logResult).toMatch(/"errorId":null/);
   });
 
-  it('can call wrapped doneError handler', async () => {
+  it('gets SFE log msg from wrapped doneError handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-doneError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(JSON.parse(Payload).errorMessage).toEqual('doneError');
     expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$doneError"/);
   });
 
-  it('can call wrapped callback handler', async () => {
+  it('gets SFE log msg from wrapped callback handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callback` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
     expect(logResult).toMatch(/"errorId":null/);
   });
 
-  it('can call wrapped callbackError handler', async () => {
+  it('gets SFE log msg from wrapped callbackError handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callbackError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(JSON.parse(Payload).errorMessage).toEqual('callbackError');
     expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$callbackError"/);
   });
 
-  it('can call wrapped fail handler', async () => {
+  it('gets SFE log msg from wrapped fail handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-fail` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(JSON.parse(Payload).errorMessage).toEqual('failError');
     expect(logResult).toMatch(/"errorId":"NotAnErrorType!\$failError"/);
   });
 
-  it('can call wrapped succeed handler', async () => {
+  it('gets SFE log msg from wrapped succeed handler', async () => {
     const { LogResult, Payload } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-succeed` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(JSON.parse(Payload)).toEqual({ statusCode: 200 });
     expect(logResult).toMatch(/"errorId":null/);
+  });
+
+  it('gets right duration value from  wrapped callback handler', async () => {
+    const { LogResult, Payload } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callback` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    const duration = logResult.parseFloat('"duration":13.242'.match(/"duration":(\d+\.\d+)/)[1])
+    expect(duration).toBeGreatherThan(10);
   });
 });

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -109,7 +109,7 @@ describe('integration', () => {
   });
 
   xit('gets SFE log msg from wrapped sync handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-sync` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
@@ -117,7 +117,7 @@ describe('integration', () => {
   });
 
   it('gets SFE log msg from wrapped syncError handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-syncError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
@@ -125,7 +125,7 @@ describe('integration', () => {
   });
 
   it('gets SFE log msg from wrapped async handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-async` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
@@ -133,7 +133,7 @@ describe('integration', () => {
   });
 
   it('gets SFE log msg from wrapped asyncError handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
@@ -141,7 +141,7 @@ describe('integration', () => {
   });
 
   it('gets SFE log msg from wrapped asyncDanglingCallback handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncDanglingCallback` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
@@ -149,7 +149,7 @@ describe('integration', () => {
   });
 
   it('gets SFE log msg from wrapped done handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-done` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
@@ -157,7 +157,7 @@ describe('integration', () => {
   });
 
   it('gets SFE log msg from wrapped doneError handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-doneError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
@@ -165,7 +165,7 @@ describe('integration', () => {
   });
 
   it('gets SFE log msg from wrapped callback handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callback` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
@@ -173,7 +173,7 @@ describe('integration', () => {
   });
 
   it('gets SFE log msg from wrapped callbackError handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callbackError` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
@@ -181,7 +181,7 @@ describe('integration', () => {
   });
 
   it('gets SFE log msg from wrapped fail handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-fail` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
@@ -189,7 +189,7 @@ describe('integration', () => {
   });
 
   it('gets SFE log msg from wrapped succeed handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-succeed` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();
@@ -197,7 +197,7 @@ describe('integration', () => {
   });
 
   it('gets right duration value from  wrapped callback handler', async () => {
-    const { LogResult, Payload } = await lambda
+    const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callback` })
       .promise();
     const logResult = new Buffer(LogResult, 'base64').toString();

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -265,6 +265,7 @@ class ServerlessSDK {
               });
             });
         }
+        return result;
       };
     }
     throw new Error(

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -265,8 +265,6 @@ class ServerlessSDK {
               });
             });
         }
-        finalize(null, () => null);
-        return result;
       };
     }
     throw new Error(

--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -150,7 +150,7 @@ class Transaction {
    * - Sends the error and ends the transaction
    */
 
-  error(error, fatal) {
+  error(error, fatal, cb) {
     const self = this;
     if (isError(error)) {
       // Create Error ID
@@ -173,6 +173,7 @@ class Transaction {
         // End transaction
         this.buildOutput(ERROR); // set this to transaction for now.
         self.end();
+        cb();
       });
     } else {
       // Create Error ID
@@ -191,6 +192,7 @@ class Transaction {
       // End transaction
       this.buildOutput(ERROR); // set this to transaction for now.
       self.end();
+      cb();
     }
   }
 


### PR DESCRIPTION
ok.. well i hope i considered all edgecases, but theres way more test covg now for all
the cases i can think of.

the solution was a combination of 3 approaches:
 * pass a cb func in to transaction.error (from the initial implementation)
 * mimic user lambda behavior much more closesly (async timeout issue bug fix, caused the error logging regression)
 * dont pollute lambdas context object, create a new one to pass to the user (initially from #235)