### PR TITLE
use aws-sdk's builtin support for instrumentation rather than using Proxy

### DIFF
--- a/sdk-js/src/lib/spanHooks/hookAwsSdk.js
+++ b/sdk-js/src/lib/spanHooks/hookAwsSdk.js
@@ -5,24 +5,14 @@ const { captureAwsRequestSpan } = require('../parsers');
 
 module.exports = emitter => {
   requireHook(['aws-sdk'], awsSdk => {
-    // Skip patching for extremely old version of aws-sdk that lack the necessary events
-    if (!awsSdk.Request || !awsSdk.Request.prototype.send || !awsSdk.Request.prototype.on) {
-      return awsSdk;
-    }
-
-    // Monkey patch the send method with a proxy
-    awsSdk.Request.prototype.send = new Proxy(awsSdk.Request.prototype.send, {
-      apply: (_send, _thisRequest, _args) => {
-        // When the request is complete, capture span info
-        _thisRequest.on('complete', _resp => {
-          const span = captureAwsRequestSpan(_resp);
-          emitter.emit('span', span);
+    for (const Service of Object.values(awsSdk)) {
+      if (Service.serviceIdentifier) {
+        Service.prototype.customizeRequests(req => {
+          req.on('complete', res => emitter.emit('span', captureAwsRequestSpan(res)));
+          return req;
         });
-        // Send the request as usual
-        return _send.apply(_thisRequest, _args);
-      },
-    });
-
+      }
+    }
     return awsSdk;
   });
 };


### PR DESCRIPTION
Fixes PLAT-1197 & PLAT-1199

This is the technique the AWS XRay SDK uses:
https://github.com/aws/aws-xray-sdk-node/blob/master/packages/core/lib/patchers/aws_p.js#L38