### PR TITLE
PLAT-1576 - support for variables in stage

### DIFF
--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -2,9 +2,8 @@
 
 const _ = require('lodash');
 const { getAccessKeyForTenant, getDeployProfile } = require('@serverless/platform-sdk');
-const { hookIntoVariableGetter } = require('./variables');
 
-module.exports.configureDeployProfile = async (ctx, hook = false) => {
+module.exports.configureDeployProfile = async ctx => {
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant);
   const deploymentProfile = await getDeployProfile({
     accessKey,
@@ -16,16 +15,4 @@ module.exports.configureDeployProfile = async (ctx, hook = false) => {
     ctx.provider.cachedCredentials.region = ctx.provider.getRegion();
   }
   ctx.safeguards = deploymentProfile.safeguardsPolicies;
-  if (hook) {
-    hookIntoVariableGetter(
-      ctx,
-      _.fromPairs(
-        deploymentProfile.secretValues.map(({ secretName, secretProperties: { value } }) => [
-          secretName,
-          value,
-        ])
-      ),
-      accessKey
-    );
-  }
 };

--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const { getAccessKeyForTenant, getDeployProfile } = require('@serverless/platform-sdk');
 const { hookIntoVariableGetter } = require('./variables');
 
-module.exports.configureDeployProfile = async ctx => {
+module.exports.configureDeployProfile = async (ctx, hook = false) => {
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant);
   const deploymentProfile = await getDeployProfile({
     accessKey,
@@ -16,14 +16,16 @@ module.exports.configureDeployProfile = async ctx => {
     ctx.provider.cachedCredentials.region = ctx.provider.getRegion();
   }
   ctx.safeguards = deploymentProfile.safeguardsPolicies;
-  hookIntoVariableGetter(
-    ctx,
-    _.fromPairs(
-      deploymentProfile.secretValues.map(({ secretName, secretProperties: { value } }) => [
-        secretName,
-        value,
-      ])
-    ),
-    accessKey
-  );
+  if (hook) {
+    hookIntoVariableGetter(
+      ctx,
+      _.fromPairs(
+        deploymentProfile.secretValues.map(({ secretName, secretProperties: { value } }) => [
+          secretName,
+          value,
+        ])
+      ),
+      accessKey
+    );
+  }
 };

--- a/lib/deployProfile.test.js
+++ b/lib/deployProfile.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { getAccessKeyForTenant, getDeployProfile } = require('@serverless/platform-sdk');
-const { hookIntoVariableGetter } = require('./variables');
 const { configureDeployProfile } = require('./deployProfile');
 
 jest.mock('@serverless/platform-sdk', () => ({
@@ -15,10 +14,8 @@ jest.mock('@serverless/platform-sdk', () => ({
   ),
 }));
 
-jest.mock('./variables', () => ({ hookIntoVariableGetter: jest.fn() }));
-
 describe('configureDeployProfile', () => {
-  it('gets creds & secrets then sets safeguards and doesnt hook into variable system', async () => {
+  it('gets creds & secrets then sets safeguards', async () => {
     const getStage = jest.fn().mockReturnValue('stage');
     const getRegion = jest.fn().mockReturnValue('region');
     const ctx = {
@@ -37,34 +34,6 @@ describe('configureDeployProfile', () => {
       service: 'service',
       stage: 'stage',
     });
-    expect(hookIntoVariableGetter).toHaveBeenCalledTimes(0);
-    expect(ctx.provider.cachedCredentials).toEqual({
-      accessKeyId: 'id',
-      secretAccessKey: 'secret',
-      region: 'region',
-    });
-  });
-
-  it('gets creds & secrets then sets safeguards and hooks into variable system when hook=true', async () => {
-    const getStage = jest.fn().mockReturnValue('stage');
-    const getRegion = jest.fn().mockReturnValue('region');
-    const ctx = {
-      provider: { getStage, getRegion },
-      sls: {
-        service: { app: 'app', tenant: 'tenant', service: 'service', provider: { name: 'aws' } },
-      },
-    };
-    await configureDeployProfile(ctx, true);
-    expect(ctx.safeguards).toEqual([{ policy: 'name' }]);
-    expect(getAccessKeyForTenant).toBeCalledWith('tenant');
-    expect(getDeployProfile).toBeCalledWith({
-      accessKey: 'accessKey',
-      app: 'app',
-      tenant: 'tenant',
-      service: 'service',
-      stage: 'stage',
-    });
-    expect(hookIntoVariableGetter).toBeCalledWith(ctx, { name: 'value' }, 'accessKey');
     expect(ctx.provider.cachedCredentials).toEqual({
       accessKeyId: 'id',
       secretAccessKey: 'secret',

--- a/lib/deployProfile.test.js
+++ b/lib/deployProfile.test.js
@@ -18,7 +18,7 @@ jest.mock('@serverless/platform-sdk', () => ({
 jest.mock('./variables', () => ({ hookIntoVariableGetter: jest.fn() }));
 
 describe('configureDeployProfile', () => {
-  it('gets creds & secrets then sets safeguards and hooks into variable system', async () => {
+  it('gets creds & secrets then sets safeguards and doesnt hook into variable system', async () => {
     const getStage = jest.fn().mockReturnValue('stage');
     const getRegion = jest.fn().mockReturnValue('region');
     const ctx = {
@@ -28,6 +28,33 @@ describe('configureDeployProfile', () => {
       },
     };
     await configureDeployProfile(ctx);
+    expect(ctx.safeguards).toEqual([{ policy: 'name' }]);
+    expect(getAccessKeyForTenant).toBeCalledWith('tenant');
+    expect(getDeployProfile).toBeCalledWith({
+      accessKey: 'accessKey',
+      app: 'app',
+      tenant: 'tenant',
+      service: 'service',
+      stage: 'stage',
+    });
+    expect(hookIntoVariableGetter).toHaveBeenCalledTimes(0);
+    expect(ctx.provider.cachedCredentials).toEqual({
+      accessKeyId: 'id',
+      secretAccessKey: 'secret',
+      region: 'region',
+    });
+  });
+
+  it('gets creds & secrets then sets safeguards and hooks into variable system when hook=true', async () => {
+    const getStage = jest.fn().mockReturnValue('stage');
+    const getRegion = jest.fn().mockReturnValue('region');
+    const ctx = {
+      provider: { getStage, getRegion },
+      sls: {
+        service: { app: 'app', tenant: 'tenant', service: 'service', provider: { name: 'aws' } },
+      },
+    };
+    await configureDeployProfile(ctx, true);
     expect(ctx.safeguards).toEqual([{ policy: 'name' }]);
     expect(getAccessKeyForTenant).toBeCalledWith('tenant');
     expect(getDeployProfile).toBeCalledWith({

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -112,11 +112,18 @@ class ServerlessEnterprisePlugin {
       'test:test': this.route('test:test').bind(this),
       'dashboard:dashboard': this.route('dashboard:dashboard').bind(this),
     };
-    const secrets = variables.getValueFromDashboardSecrets(this);
-    secrets.dependentServiceName = 'Serverless Secrets';
-    const state = variables.getValueFromDashboardState(this);
-    state.dependentServiceName = 'Serverless Outputs';
-    this.variableGetters = { secrets, state };
+    this.variableResolvers = {
+      secrets: {
+        resolver: variables.getValueFromDashboardSecrets(this),
+        serviceName: 'Serverless Secrets',
+        isDisabledAtPrepopulation: true,
+      },
+      state: {
+        resolver: variables.getValueFromDashboardState(this),
+        serviceName: 'Serverless Outputs',
+        isDisabledAtPrepopulation: true,
+      },
+    };
 
     // Don't check any dashbaord stuff if using an unauthenticated command
     if (['login', 'logout', 'generate-event'].includes(currentCommand)) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -19,7 +19,7 @@ const getCredentials = require('./credentials');
 const getAppUids = require('./appUids');
 const removeDestination = require('./removeDestination');
 const { saveDeployment, createAndSetDeploymentUid } = require('./deployment');
-const { hookIntoVariableGetter } = require('./variables');
+const variables = require('./variables');
 const { generate, eventDict } = require('./generateEvent');
 const { configureDeployProfile } = require('./deployProfile');
 const { test } = require('./test');
@@ -112,6 +112,11 @@ class ServerlessEnterprisePlugin {
       'test:test': this.route('test:test').bind(this),
       'dashboard:dashboard': this.route('dashboard:dashboard').bind(this),
     };
+    const secrets = variables.getValueFromDashboardSecrets(this);
+    secrets.dependentServiceName = 'Serverless Secrets';
+    const state = variables.getValueFromDashboardState(this);
+    state.dependentServiceName = 'Serverless Outputs';
+    this.variableGetters = { secrets, state };
 
     // Don't check any dashbaord stuff if using an unauthenticated command
     if (['login', 'logout', 'generate-event'].includes(currentCommand)) {
@@ -162,6 +167,7 @@ class ServerlessEnterprisePlugin {
 
       // Set Plugin hooks for authenticated Enteprise Plugin features here
       Object.assign(this.hooks, {
+        'initialize': this.route('initialize').bind(this),
         'before:package:createDeploymentArtifacts': this.route(
           'before:package:createDeploymentArtifacts'
         ).bind(this),
@@ -210,6 +216,9 @@ class ServerlessEnterprisePlugin {
     const self = this;
     return async () => {
       switch (hook) {
+        case 'initialize':
+          await configureDeployProfile(self);
+          break;
         case 'before:package:createDeploymentArtifacts':
           Object.assign(
             self.sls.service,
@@ -316,11 +325,11 @@ class ServerlessEnterprisePlugin {
       this.sls.processedInput.commands[0] === 'login' ||
       this.sls.processedInput.commands[0] === 'logout'
     ) {
-      hookIntoVariableGetter(this, {});
+      variables.hookIntoVariableGetter(this, {});
       return;
     }
 
-    await configureDeployProfile(this);
+    await configureDeployProfile(this, true);
   }
 }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -318,19 +318,6 @@ class ServerlessEnterprisePlugin {
       }
     };
   }
-
-  async asyncInit() {
-    if (
-      !this.sls.enterpriseEnabled ||
-      this.sls.processedInput.commands[0] === 'login' ||
-      this.sls.processedInput.commands[0] === 'logout'
-    ) {
-      variables.hookIntoVariableGetter(this, {});
-      return;
-    }
-
-    await configureDeployProfile(this, true);
-  }
 }
 
 module.exports = ServerlessEnterprisePlugin;

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -216,13 +216,7 @@ describe('plugin', () => {
     expect(generate).toBeCalledWith(instance);
   });
 
-  it('it calls deploy profile config w/ hook=true in async initializer in asyncInit', async () => {
-    const instance = new ServerlessEnterprisePlugin(sls);
-    await instance.asyncInit();
-    expect(configureDeployProfile).toBeCalledWith(instance, true);
-  });
-
-  it('routes initialize hook to deploy profile config w/out 2nd arg', async () => {
+  it('routes initialize hook to deploy profile config', async () => {
     const instance = new ServerlessEnterprisePlugin(sls);
     await instance.route('initialize')();
     expect(configureDeployProfile).toBeCalledWith(instance);

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -72,7 +72,6 @@ jest.mock('./deployment', () => ({
   saveDeployment: jest.fn(),
   createAndSetDeploymentUid: jest.fn(),
 }));
-jest.mock('./variables', () => ({ hookIntoVariableGetter: jest.fn() }));
 jest.mock('./generateEvent', () => ({ eventDict: {}, generate: jest.fn() }));
 jest.mock('./injectLogsIamRole', () => jest.fn());
 jest.mock('./deployProfile', () => ({ configureDeployProfile: jest.fn() }));

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -106,10 +106,12 @@ describe('plugin', () => {
         'login:login',
         'logout:logout',
         'generate-event:generate-event',
+        'initialize',
         'test:test',
         'dashboard:dashboard',
       ])
     );
+    expect(new Set(Object.keys(instance.variableGetters))).toEqual(new Set(['secrets', 'state']));
     expect(sls.getProvider).toBeCalledWith('aws');
     expect(sls.cli.log).toHaveBeenCalledTimes(0);
   });
@@ -214,9 +216,15 @@ describe('plugin', () => {
     expect(generate).toBeCalledWith(instance);
   });
 
-  it('it calls deploy profile config in async initializer', async () => {
+  it('it calls deploy profile config w/ hook=true in async initializer in asyncInit', async () => {
     const instance = new ServerlessEnterprisePlugin(sls);
     await instance.asyncInit();
+    expect(configureDeployProfile).toBeCalledWith(instance, true);
+  });
+
+  it('routes initialize hook to deploy profile config w/out 2nd arg', async () => {
+    const instance = new ServerlessEnterprisePlugin(sls);
+    await instance.route('initialize')();
     expect(configureDeployProfile).toBeCalledWith(instance);
   });
 

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -110,7 +110,7 @@ describe('plugin', () => {
         'dashboard:dashboard',
       ])
     );
-    expect(new Set(Object.keys(instance.variableGetters))).toEqual(new Set(['secrets', 'state']));
+    expect(new Set(Object.keys(instance.variableResolvers))).toEqual(new Set(['secrets', 'state']));
     expect(sls.getProvider).toBeCalledWith('aws');
     expect(sls.cli.log).toHaveBeenCalledTimes(0);
   });

--- a/lib/safeguards/index.js
+++ b/lib/safeguards/index.js
@@ -43,7 +43,7 @@ async function runPolicies(ctx) {
 
   const policyConfigs = [
     ...localPolicies,
-    ...ctx.safeguards, // fetched during asyncInit in deployment profile
+    ...ctx.safeguards, // fetched during initialize lifeCycle hook in deployment profile
   ];
 
   if (policyConfigs.length === 0) {

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -1,9 +1,67 @@
 'use strict';
 
 const _ = require('lodash');
-const { getStateVariable } = require('@serverless/platform-sdk');
+const {
+  getStateVariable,
+  getAccessKeyForTenant,
+  getDeployProfile,
+} = require('@serverless/platform-sdk');
 
-module.exports.hookIntoVariableGetter = (ctx, secrets, accessKey) => {
+// functions for new way of getting variables
+const getValueFromDashboardSecrets = ctx => async variableString => {
+  ctx.state.secretsUsed.add(variableString.substring(8));
+  if (
+    ctx.sls.processedInput.commands[0] === 'login' ||
+    ctx.sls.processedInput.commands[0] === 'logout'
+  ) {
+    return {};
+  }
+  const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant);
+  const deploymentProfile = await getDeployProfile({
+    accessKey,
+    stage: ctx.provider.getStage(),
+    ..._.pick(ctx.sls.service, ['tenant', 'app', 'service']),
+  });
+  const secrets = _.fromPairs(
+    deploymentProfile.secretValues.map(({ secretName, secretProperties: { value } }) => [
+      secretName,
+      value,
+    ])
+  );
+  if (!secrets[variableString.split('secrets:')[1]]) {
+    throw new Error(`$\{${variableString}} not defined`);
+  }
+  return secrets[variableString.split('secrets:')[1]];
+};
+const getValueFromDashboardState = ctx => async variableString => {
+  const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant);
+  if (
+    ctx.sls.processedInput.commands[0] === 'login' ||
+    ctx.sls.processedInput.commands[0] === 'logout'
+  ) {
+    return {};
+  }
+  const service = variableString.substring(6).split('.', 1)[0];
+  const key = variableString.substring(6).substr(service.length);
+  const outputName = key.split('.')[1];
+  const subkey = key.substr(outputName.length + 2);
+  const { value } = await getStateVariable({
+    accessKey,
+    outputName,
+    service,
+    app: ctx.sls.service.app,
+    tenant: ctx.sls.service.tenant,
+    stage: ctx.provider.getStage(),
+    region: ctx.provider.getRegion(),
+  });
+  if (subkey) {
+    return _.get(value, subkey);
+  }
+  return value;
+};
+
+// Old (asyncInit, bfore initialize hook & real variable getter support) way of hooking in
+const hookIntoVariableGetter = (ctx, secrets, accessKey) => {
   const { getValueFromSource } = ctx.sls.variables;
 
   ctx.sls.variables.getValueFromSource = async variableString => {
@@ -53,4 +111,10 @@ module.exports.hookIntoVariableGetter = (ctx, secrets, accessKey) => {
   return () => {
     ctx.sls.variables.getValueFromSource = getValueFromSource;
   };
+};
+
+module.exports = {
+  getValueFromDashboardSecrets,
+  getValueFromDashboardState,
+  hookIntoVariableGetter,
 };

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -61,8 +61,6 @@ const getValueFromDashboardState = ctx => async variableString => {
   return value;
 };
 
-// Old (asyncInit, bfore initialize hook & real variable getter support) way of hooking in
-
 module.exports = {
   getValueFromDashboardSecrets,
   getValueFromDashboardState,

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -33,6 +33,7 @@ const getValueFromDashboardSecrets = ctx => async variableString => {
   }
   return secrets[variableString.split('secrets:')[1]];
 };
+
 const getValueFromDashboardState = ctx => async variableString => {
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant);
   if (
@@ -61,60 +62,8 @@ const getValueFromDashboardState = ctx => async variableString => {
 };
 
 // Old (asyncInit, bfore initialize hook & real variable getter support) way of hooking in
-const hookIntoVariableGetter = (ctx, secrets, accessKey) => {
-  const { getValueFromSource } = ctx.sls.variables;
-
-  ctx.sls.variables.getValueFromSource = async variableString => {
-    if (variableString.startsWith('secrets:')) {
-      ctx.state.secretsUsed.add(variableString.substring(8));
-      if (
-        ctx.sls.processedInput.commands[0] === 'login' ||
-        ctx.sls.processedInput.commands[0] === 'logout'
-      ) {
-        return {};
-      }
-      if (!secrets[variableString.split('secrets:')[1]]) {
-        throw new Error(`$\{${variableString}} not defined`);
-      }
-      return secrets[variableString.split('secrets:')[1]];
-    } else if (variableString.startsWith('state:')) {
-      if (
-        ctx.sls.processedInput.commands[0] === 'login' ||
-        ctx.sls.processedInput.commands[0] === 'logout'
-      ) {
-        return {};
-      }
-      const service = variableString.substring(6).split('.', 1)[0];
-      const key = variableString.substring(6).substr(service.length);
-      const outputName = key.split('.')[1];
-      const subkey = key.substr(outputName.length + 2);
-      const { value } = await getStateVariable({
-        accessKey,
-        outputName,
-        service,
-        app: ctx.sls.service.app,
-        tenant: ctx.sls.service.tenant,
-        stage: ctx.provider.getStage(),
-        region: ctx.provider.getRegion(),
-      });
-      if (subkey) {
-        return _.get(value, subkey);
-      }
-      return value;
-    }
-
-    const value = getValueFromSource.bind(ctx.sls.variables)(variableString);
-    return value;
-  };
-
-  // return a restore function (mostly for testing)
-  return () => {
-    ctx.sls.variables.getValueFromSource = getValueFromSource;
-  };
-};
 
 module.exports = {
   getValueFromDashboardSecrets,
   getValueFromDashboardState,
-  hookIntoVariableGetter,
 };

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -1,9 +1,20 @@
 'use strict';
 
-const { hookIntoVariableGetter } = require('./variables');
-const { getStateVariable } = require('@serverless/platform-sdk');
+const { getValueFromDashboardSecrets, getValueFromDashboardState } = require('./variables');
+const { getStateVariable, getDeployProfile } = require('@serverless/platform-sdk');
 
 jest.mock('@serverless/platform-sdk', () => ({
+  getAccessKeyForTenant: jest.fn().mockReturnValue(Promise.resolve('accessKey')),
+  getDeployProfile: jest.fn().mockReturnValue(
+    Promise.resolve({
+      secretValues: [
+        {
+          secretName: 'name',
+          secretProperties: { value: 'secretValue' },
+        },
+      ],
+    })
+  ),
   getStateVariable: jest.fn().mockImplementation(({ outputName }) => {
     if (outputName === 'withsubkey') {
       return Promise.resolve({ value: { subkey: 'seeeeeccrreeeetttt' } });
@@ -13,11 +24,11 @@ jest.mock('@serverless/platform-sdk', () => ({
 }));
 
 afterEach(() => {
+  getDeployProfile.mockClear();
   getStateVariable.mockClear();
 });
 
-describe('variables - hookIntoVariableGetter', () => {
-  const getValueFromSource = jest.fn().mockReturnValue('frameworkVariableValue');
+describe('variables - getValueFromDashboardSecrets', () => {
   const ctx = {
     sls: {
       service: {
@@ -25,7 +36,6 @@ describe('variables - hookIntoVariableGetter', () => {
         service: 'service',
         tenant: 'tenant',
       },
-      variables: { getValueFromSource },
       processedInput: {
         commands: [],
       },
@@ -37,97 +47,75 @@ describe('variables - hookIntoVariableGetter', () => {
     state: { secretsUsed: new Set() },
   };
 
-  afterAll(() => {
-    getValueFromSource.mockClear();
-  });
-
-  it('overrides the default variable getter and can use secrets vars', async () => {
-    const restore = hookIntoVariableGetter(ctx, { name: 'secretValue' }, 'accessKey');
-    expect(ctx.sls.variables.getValueFromSource).not.toEqual(getValueFromSource);
-    const value = await ctx.sls.variables.getValueFromSource('secrets:name');
+  it('gets a secret from dashboard', async () => {
+    const value = await getValueFromDashboardSecrets(ctx)('secrets:name');
     expect(value).toEqual('secretValue');
     expect(ctx.state.secretsUsed).toEqual(new Set(['name']));
-    restore();
-    expect(ctx.sls.variables.getValueFromSource).toEqual(getValueFromSource);
-  });
-
-  it('overrides the default variable getter and can fetch state vars with subkey', async () => {
-    const restore = hookIntoVariableGetter(ctx, { name: 'secretValue' }, 'accessKey');
-    expect(ctx.sls.variables.getValueFromSource).not.toEqual(getValueFromSource);
-    const value = await ctx.sls.variables.getValueFromSource('state:service.withsubkey.subkey');
-    expect(value).toEqual('seeeeeccrreeeetttt');
-    expect(getStateVariable).toBeCalledWith({
-      outputName: 'withsubkey',
-      service: 'service',
+    expect(getDeployProfile).toBeCalledWith({
       accessKey: 'accessKey',
-      app: 'app',
-      tenant: 'tenant',
-      region: 'region',
       stage: 'stage',
+      tenant: 'tenant',
+      app: 'app',
+      service: 'service',
     });
-    restore();
-    expect(ctx.sls.variables.getValueFromSource).toEqual(getValueFromSource);
   });
 
-  it('overrides the default variable getter and can fetch state vars without subkey', async () => {
-    const restore = hookIntoVariableGetter(ctx, { name: 'secretValue' }, 'accessKey');
-    expect(ctx.sls.variables.getValueFromSource).not.toEqual(getValueFromSource);
-    const value = await ctx.sls.variables.getValueFromSource('state:service.name');
+  it('doesnt break during login command', async () => {
+    const value = await getValueFromDashboardSecrets({
+      ...ctx,
+      sls: {
+        ...ctx.sls,
+        processedInput: { commands: ['login'] },
+      },
+    })('secrets:name');
+    expect(value).toEqual({});
+    expect(ctx.state.secretsUsed).toEqual(new Set(['name']));
+    expect(getDeployProfile).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('variables - getValueFromDashboardState', () => {
+  const ctx = {
+    sls: {
+      service: {
+        app: 'app',
+        service: 'service',
+        tenant: 'tenant',
+      },
+      processedInput: {
+        commands: [],
+      },
+    },
+    provider: {
+      getStage: jest.fn().mockReturnValue('stage'),
+      getRegion: jest.fn().mockReturnValue('region'),
+    },
+    state: { secretsUsed: new Set() },
+  };
+
+  it('gets a state output from dashboard', async () => {
+    const value = await getValueFromDashboardState(ctx)('state:service.name');
     expect(value).toEqual('simple seeeeeccrreeeetttt');
     expect(getStateVariable).toBeCalledWith({
-      outputName: 'name',
-      service: 'service',
       accessKey: 'accessKey',
-      app: 'app',
-      tenant: 'tenant',
-      region: 'region',
       stage: 'stage',
+      tenant: 'tenant',
+      app: 'app',
+      service: 'service',
+      outputName: 'name',
+      region: 'region',
     });
-    restore();
-    expect(ctx.sls.variables.getValueFromSource).toEqual(getValueFromSource);
   });
 
-  it('overrides the default variable getter and doesnt break during logout command', async () => {
-    const restore = hookIntoVariableGetter(
-      {
-        ...ctx,
-        sls: {
-          ...ctx.sls,
-          processedInput: { commands: ['logout'] },
-        },
+  it('doesnt break during login command', async () => {
+    const value = await getValueFromDashboardState({
+      ...ctx,
+      sls: {
+        ...ctx.sls,
+        processedInput: { commands: ['login'] },
       },
-      {},
-      'accessKey'
-    );
-    expect(ctx.sls.variables.getValueFromSource).not.toEqual(getValueFromSource);
-    let value = await ctx.sls.variables.getValueFromSource('secrets:foobar');
-    expect(value).toEqual({});
-    value = await ctx.sls.variables.getValueFromSource('state:service.name');
+    })('state:service.name');
     expect(value).toEqual({});
     expect(getStateVariable).toHaveBeenCalledTimes(0);
-    restore();
-    expect(ctx.sls.variables.getValueFromSource).toEqual(getValueFromSource);
-  });
-
-  it('overrides the default variable getter and doesnt break during login command', async () => {
-    const restore = hookIntoVariableGetter(
-      {
-        ...ctx,
-        sls: {
-          ...ctx.sls,
-          processedInput: { commands: ['login'] },
-        },
-      },
-      {},
-      'accessKey'
-    );
-    expect(ctx.sls.variables.getValueFromSource).not.toEqual(getValueFromSource);
-    let value = await ctx.sls.variables.getValueFromSource('secrets:foobar');
-    expect(value).toEqual({});
-    value = await ctx.sls.variables.getValueFromSource('state:service.name');
-    expect(value).toEqual({});
-    expect(getStateVariable).toHaveBeenCalledTimes(0);
-    restore();
-    expect(ctx.sls.variables.getValueFromSource).toEqual(getValueFromSource);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@serverless/enterprise-plugin",
-  "version": "1.3.8",
+  "name": "@serverless/dashboard-plugin",
+  "version": "2.0.0",
   "engines": {
     "node": ">=6.0"
   },
-  "description": "The Serverless Enterprise plugin",
+  "description": "The Serverless Dashboard plugin",
   "scripts": {
     "build": "./scripts/build.sh",
     "cover": "jest --coverage --testPathIgnorePatterns=\"^<rootDir>/(?:coverage|dist|node_modules|sdk-js|integration-testing)/\"",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@serverless/dashboard-plugin",
+  "name": "@serverless/enterprise-plugin",
   "version": "2.0.0",
   "engines": {
     "node": ">=6.0"
   },
-  "description": "The Serverless Dashboard plugin",
+  "description": "The Serverless Enterprise plugin",
   "scripts": {
     "build": "./scripts/build.sh",
     "cover": "jest --coverage --testPathIgnorePatterns=\"^<rootDir>/(?:coverage|dist|node_modules|sdk-js|integration-testing)/\"",


### PR DESCRIPTION
implemented by using serverless/serverless#6566 which adds support for:
 * an `initialize` lifecycle hook
 * real support for adding variable getters via the `variableGetters` property
   on plugins

backwards compatibility is maintained by virtue of keeping the old way, which is
entirely configured in the `asyncInit` funciton. This does not cause forwards
compatibility problems because the above PR removes the call to `asyncInit` in
plugins as it was only ever meant for use with this plugin.