### PR TITLE
Ignore SFO custom resource lambdas in dlq safegaurd

### DIFF
--- a/integration-testing/safeguards.test.js
+++ b/integration-testing/safeguards.test.js
@@ -24,12 +24,12 @@ describe('integration', () => {
 
   it('deploys blocks deploy on illegal stage name', async () => {
     try {
-      await sls(['deploy', '-s', 'illegal-stage-name']);
+      await sls(['deploy', '-s', 'bad-stage']);
     } catch (error) {
       const stdout = stripAnsi(String(error.stdoutBuffer));
       expect(stdout).toMatch('failed - allowed-stages');
       expect(stdout).toMatch(
-        'Failed - Stage name "illegal-stage-name" not in list of permitted names: ["dev","qa","prod"]'
+        'Failed - Stage name "bad-stage" not in list of permitted names: ["dev","qa","prod"]'
       );
       return;
     }

--- a/integration-testing/setup.js
+++ b/integration-testing/setup.js
@@ -58,7 +58,7 @@ module.exports = async function(templateName) {
   const randomPostfix = crypto.randomBytes(2).toString('hex');
   const serviceTmpDir = path.join(tmpDir, `serverless-enterprise-plugin-test-${randomPostfix}`);
 
-  const serviceName = `enterprise-plugin-test-${randomPostfix}`;
+  const serviceName = `plugin-test-${randomPostfix}`;
   console.info(
     `Setup '${serviceName}' service from '${templateName}' template at ${serviceTmpDir}`
   );

--- a/lib/safeguards/policies/require-dlq.js
+++ b/lib/safeguards/policies/require-dlq.js
@@ -25,19 +25,22 @@ module.exports = function dlqPolicy(policy, service) {
     Object.keys(functions || {}).map(funcName => [naming.getLambdaLogicalId(funcName), funcName])
   );
 
-  const customResourceNames = [
-    naming.getCustomResourceS3HandlerFunctionName &&
-      naming.getCustomResourceS3HandlerFunctionName(),
-    naming.getCustomResourceCognitoUserPoolHandlerFunctionName &&
-      naming.getCustomResourceCognitoUserPoolHandlerFunctionName(),
-    naming.getCustomResourceEventBridgeHandlerFunctionName &&
-      naming.getCustomResourceEventBridgeHandlerFunctionName(),
-    naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName &&
-      naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName(),
-  ].filter(x => x);
+  const customResourceFuncIdentifier = 'custom-resource-';
+  const customResourceNames = new Set(
+    [
+      naming.getCustomResourceS3HandlerFunctionName &&
+        naming.getCustomResourceS3HandlerFunctionName(),
+      naming.getCustomResourceCognitoUserPoolHandlerFunctionName &&
+        naming.getCustomResourceCognitoUserPoolHandlerFunctionName(),
+      naming.getCustomResourceEventBridgeHandlerFunctionName &&
+        naming.getCustomResourceEventBridgeHandlerFunctionName(),
+      naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName &&
+        naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName(),
+    ].filter(x => x)
+  );
 
   // for (const [name, { events, onError }] of entries(functions)) {
-  for (const [funcName, { Properties, Type, FunctionName }] of entries(Resources)) {
+  for (const [funcName, { Properties, Type }] of entries(Resources)) {
     if (
       Type !== 'AWS::Lambda::Function' ||
       (Properties.DeadLetterConfig && Properties.DeadLetterConfig.TargetArn)
@@ -46,7 +49,8 @@ module.exports = function dlqPolicy(policy, service) {
     }
 
     // ignore functions injected for custom resources by SFO
-    if (customResourceNames.includes(FunctionName)) continue;
+    if ([...customResourceNames].find(name => name.includes(customResourceFuncIdentifier)))
+      {continue;}
 
     const events = (functions[logicalFuncNamesToConfigFuncName[funcName]] || {}).events || [];
     const eventTypes = new Set(events.map(ev => Object.keys(ev)[0]));

--- a/lib/safeguards/policies/require-dlq.js
+++ b/lib/safeguards/policies/require-dlq.js
@@ -25,14 +25,29 @@ module.exports = function dlqPolicy(policy, service) {
     Object.keys(functions || {}).map(funcName => [naming.getLambdaLogicalId(funcName), funcName])
   );
 
+  const customResourceNames = [
+    naming.getCustomResourceS3HandlerFunctionName &&
+      naming.getCustomResourceS3HandlerFunctionName(),
+    naming.getCustomResourceCognitoUserPoolHandlerFunctionName &&
+      naming.getCustomResourceCognitoUserPoolHandlerFunctionName(),
+    naming.getCustomResourceEventBridgeHandlerFunctionName &&
+      naming.getCustomResourceEventBridgeHandlerFunctionName(),
+    naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName &&
+      naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName(),
+  ].filter(x => x);
+
   // for (const [name, { events, onError }] of entries(functions)) {
-  for (const [funcName, { Properties, Type }] of entries(Resources)) {
+  for (const [funcName, { Properties, Type, FunctionName }] of entries(Resources)) {
     if (
       Type !== 'AWS::Lambda::Function' ||
       (Properties.DeadLetterConfig && Properties.DeadLetterConfig.TargetArn)
     ) {
       continue;
     }
+
+    // ignore functions injected for custom resources by SFO
+    if (customResourceNames.includes(FunctionName)) continue;
+
     const events = (functions[logicalFuncNamesToConfigFuncName[funcName]] || {}).events || [];
     const eventTypes = new Set(events.map(ev => Object.keys(ev)[0]));
     const eventIntersection = new Set([...asyncEvents].filter(x => eventTypes.has(x)));

--- a/lib/safeguards/policies/require-dlq.js
+++ b/lib/safeguards/policies/require-dlq.js
@@ -26,18 +26,6 @@ module.exports = function dlqPolicy(policy, service) {
   );
 
   const customResourceFuncIdentifier = 'custom-resource-';
-  const customResourceNames = new Set(
-    [
-      naming.getCustomResourceS3HandlerFunctionName &&
-        naming.getCustomResourceS3HandlerFunctionName(),
-      naming.getCustomResourceCognitoUserPoolHandlerFunctionName &&
-        naming.getCustomResourceCognitoUserPoolHandlerFunctionName(),
-      naming.getCustomResourceEventBridgeHandlerFunctionName &&
-        naming.getCustomResourceEventBridgeHandlerFunctionName(),
-      naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName &&
-        naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionName(),
-    ].filter(x => x)
-  );
 
   // for (const [name, { events, onError }] of entries(functions)) {
   for (const [funcName, { Properties, Type }] of entries(Resources)) {
@@ -49,8 +37,7 @@ module.exports = function dlqPolicy(policy, service) {
     }
 
     // ignore functions injected for custom resources by SFO
-    if ([...customResourceNames].find(name => name.includes(customResourceFuncIdentifier)))
-      {continue;}
+    if (Properties.FunctionName.includes(customResourceFuncIdentifier)) continue;
 
     const events = (functions[logicalFuncNamesToConfigFuncName[funcName]] || {}).events || [];
     const eventTypes = new Set(events.map(ev => Object.keys(ev)[0]));

--- a/lib/safeguards/policies/require-dlq.test.js
+++ b/lib/safeguards/policies/require-dlq.test.js
@@ -23,7 +23,6 @@ describe('requireDlq', () => {
     service.compiled['cloudformation-template-update-stack.json'].Resources.funcLambda = {
       Type: 'AWS::IAM::Function',
       Properties: {
-        FunctionName: 'func',
         DeadLetterConfig: { TargetArn: 'arn' },
       },
     };
@@ -52,7 +51,7 @@ describe('requireDlq', () => {
   it('blocks functions with out a DLQ', () => {
     service.compiled['cloudformation-template-update-stack.json'].Resources.funcLambda = {
       Type: 'AWS::Lambda::Function',
-      Properties: { FunctionName: 'func' },
+      Properties: {},
     };
     requireDlq(policy, service);
 
@@ -65,7 +64,7 @@ describe('requireDlq', () => {
   it('doesnt barf on functions not in the config & blocks', () => {
     service.compiled['cloudformation-template-update-stack.json'].Resources.duncLambda = {
       Type: 'AWS::Lambda::Function',
-      Properties: { FunctionName: 'func' },
+      Properties: {},
     };
     requireDlq(policy, service);
 

--- a/lib/safeguards/policies/require-dlq.test.js
+++ b/lib/safeguards/policies/require-dlq.test.js
@@ -23,6 +23,7 @@ describe('requireDlq', () => {
     service.compiled['cloudformation-template-update-stack.json'].Resources.funcLambda = {
       Type: 'AWS::IAM::Function',
       Properties: {
+        FunctionName: 'func',
         DeadLetterConfig: { TargetArn: 'arn' },
       },
     };
@@ -51,7 +52,7 @@ describe('requireDlq', () => {
   it('blocks functions with out a DLQ', () => {
     service.compiled['cloudformation-template-update-stack.json'].Resources.funcLambda = {
       Type: 'AWS::Lambda::Function',
-      Properties: {},
+      Properties: { FunctionName: 'func' },
     };
     requireDlq(policy, service);
 
@@ -64,7 +65,7 @@ describe('requireDlq', () => {
   it('doesnt barf on functions not in the config & blocks', () => {
     service.compiled['cloudformation-template-update-stack.json'].Resources.duncLambda = {
       Type: 'AWS::Lambda::Function',
-      Properties: {},
+      Properties: { FunctionName: 'func' },
     };
     requireDlq(policy, service);
 

--- a/lib/safeguards/policies/require-dlq.test.js
+++ b/lib/safeguards/policies/require-dlq.test.js
@@ -23,7 +23,25 @@ describe('requireDlq', () => {
     service.compiled['cloudformation-template-update-stack.json'].Resources.funcLambda = {
       Type: 'AWS::IAM::Function',
       Properties: {
+        FunctionName: 'func',
         DeadLetterConfig: { TargetArn: 'arn' },
+      },
+    };
+    requireDlq(policy, service);
+    expect(policy.approve).toHaveBeenCalledTimes(1);
+    expect(policy.fail).toHaveBeenCalledTimes(0);
+  });
+
+  it('allows SFO custom cfn resource functions without a DLQ', () => {
+    service.compiled['cloudformation-template-update-stack.json'].Resources.funcLambda = {
+      Type: 'AWS::IAM::Function',
+      Properties: {
+        FunctionName: 'custom-resource-existing-s3',
+      },
+      provider: {
+        naming: {
+          getCustomResourceS3HandlerFunctionName: () => 'custom-resource-existing-s3',
+        },
       },
     };
     requireDlq(policy, service);
@@ -34,7 +52,7 @@ describe('requireDlq', () => {
   it('blocks functions with out a DLQ', () => {
     service.compiled['cloudformation-template-update-stack.json'].Resources.funcLambda = {
       Type: 'AWS::Lambda::Function',
-      Properties: {},
+      Properties: { FunctionName: 'func' },
     };
     requireDlq(policy, service);
 
@@ -47,7 +65,7 @@ describe('requireDlq', () => {
   it('doesnt barf on functions not in the config & blocks', () => {
     service.compiled['cloudformation-template-update-stack.json'].Resources.duncLambda = {
       Type: 'AWS::Lambda::Function',
-      Properties: {},
+      Properties: { FunctionName: 'func' },
     };
     requireDlq(policy, service);
 


### PR DESCRIPTION
Also included fixes to integration tests caused by too long service+stage names