### PR TITLE
Add support for Python module strings as handlers #255

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -112,9 +112,11 @@ const wrap = async ctx => {
     }
 
     // Process handler
-    const entry = functions[func].handler.split('.')[0];
-    const handler = functions[func].handler.split('.')[1];
-
+    const entry = functions[func].handler
+      .split('.')
+      .slice(0, -1)
+      .join('.');
+    const handler = functions[func].handler.split('.').slice(-1)[0];
     let extension = 'js';
     if (runtime.includes('python')) {
       extension = 'py';

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -53,6 +53,10 @@ describe('wrap - wrap', () => {
               runtime: 'nodejs8.10',
               handler: 'handlerFile.handlerFunc',
             },
+            punc: {
+              runtime: 'python3.6',
+              handler: 'path.to.some.handlerFunc',
+            },
             zunc: {
               runtime: 'unsupported6.66',
               handler: 'handlerFile.handlerFunc',
@@ -88,6 +92,17 @@ describe('wrap - wrap', () => {
         timeout: 6,
         runtime: 'nodejs8.10',
       },
+      punc: {
+        entryNew: 's_punc',
+        entryOrig: 'path.to.some',
+        extension: 'py',
+        handlerNew: 'handler',
+        handlerOrig: 'handlerFunc',
+        key: 'punc',
+        name: 'service-dev-punc',
+        timeout: 6,
+        runtime: 'python3.6',
+      },
     });
     expect(ctx.sls.service.functions).toEqual({
       dunc: {
@@ -97,6 +112,10 @@ describe('wrap - wrap', () => {
       func: {
         runtime: 'nodejs8.10',
         handler: 's_func.handler',
+      },
+      punc: {
+        runtime: 'python3.6',
+        handler: 's_punc.handler',
       },
       zunc: {
         runtime: 'unsupported6.66',
@@ -109,7 +128,7 @@ describe('wrap - wrap', () => {
         "Warning the Serverless Dashboard doesn't support the following runtime: unsupported6.66"
       )
     );
-    expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
     expect(fs.writeFileSync).toBeCalledWith(
       'path/s_func.js',
       `var serverlessSDK = require('./serverless_sdk/index.js')


### PR DESCRIPTION
Fully qualified module strings are now supported for feature parity with the
Serverless Framework.