### PR TITLE
version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "engines": {
     "node": ">=6.0"
   },


### PR DESCRIPTION
changes: https://github.com/serverless/enterprise-plugin/compare/v1.3.9...master

changelog that'll be added to the release:

* support for deployment engine
* don't generate insight logs greater than CW log limits
* set plugin version in insight payloads
* support `foo.bar.baz` style python handler specifications
* fix the stacktrace for non-error errors