### PR TITLE
Support local serverless installation in integration testing

### DIFF
--- a/integration-testing/setup.js
+++ b/integration-testing/setup.js
@@ -73,7 +73,7 @@ const retrieveServerless = memoize(async () => {
   console.info('... npm install');
   await spawn('npm', ['install', '--production'], { cwd: serverlessTmpDir });
 
-  return path.join(serverlessTmpDir, 'bin/serverless');
+  return path.join(serverlessTmpDir, 'bin/serverless.js');
 });
 
 module.exports = async function(templateName) {

--- a/lib/interactiveCli/index.js
+++ b/lib/interactiveCli/index.js
@@ -8,9 +8,6 @@ const register = require('./register');
 const setApp = require('./set-app');
 
 module.exports = ctx => {
-  // Doubled check due to SLS bug: https://github.com/serverless/serverless/pull/6367
-  // TODO: Remove with next major
-  if (!ctx.sls.processedInput.commands.includes('interactiveCli')) return null;
   if (!ctx.sls.interactiveCli) return null;
   const user = getLoggedInUser();
 


### PR DESCRIPTION
It's good to be able to run integration tests against local `serverless` installation (which should have given plugin instance linked in its `node_modules`).

I've introduced a support for `LOCAL_SERVERLESS_LINK_PATH` env variable, which enables that.

Additionally I've done some minor cleanup which is safe now to do, as we shifted major.