### PR TITLE
Improve precommit hook settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,9 +101,7 @@
   "license": "Apache-2.0",
   "lint-staged": {
     "*.js": [
-      "eslint --fix .",
-      "eslint --fix sdk-js/src",
-      "git add -A"
+      "eslint"
     ]
   },
   "pre-commit": [

--- a/package.json
+++ b/package.json
@@ -102,6 +102,9 @@
   "lint-staged": {
     "*.js": [
       "eslint"
+    ],
+    "*.{css,html,js,json,md,yaml,yml}": [
+      "prettier -c"
     ]
   },
   "pre-commit": [


### PR DESCRIPTION
- Fix eslint validation. So far setting initialized cross project lint check for each commit.
I've improved it, so only changes that are about to be committed are validated (`lint-staged` is smart as it also knows how to seclude patches when partial commit is involved, it'll be great to take advantage of that).
- Add prettier formatting validation