### PR TITLE
Enable node https spans!

### DIFF
--- a/integration-testing/service3/handler.js
+++ b/integration-testing/service3/handler.js
@@ -56,16 +56,28 @@ module.exports.spans = async () => {
   const sts = new AWS.STS();
   await sts.getCallerIdentity().promise();
   await new Promise((resolve, reject) => {
-    https
-      .get('https://httpbin.org/get', resp => {
-        let data = '';
-        resp.on('data', chunk => {
-          data += chunk;
-        });
-        resp.on('end', () => {
-          resolve(data);
-        });
-      })
-      .on('error', reject);
+    const req = https.request({host: 'httpbin.org', path: '/post', method: 'POST'},resp => {
+      let data = '';
+      resp.on('data', chunk => {
+        data += chunk;
+      });
+      resp.on('end', () => {
+        resolve(data);
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+  await new Promise((resolve, reject) => {
+    const req = https.get({host: 'example.com', path: '/', method: 'get'}, resp => {
+      let data = '';
+      resp.on('data', chunk => {
+        data += chunk;
+      });
+      resp.on('end', () => {
+        resolve(data);
+      });
+    });
+    req.on('error', reject);
   });
 };

--- a/integration-testing/service3/handler.js
+++ b/integration-testing/service3/handler.js
@@ -56,7 +56,7 @@ module.exports.spans = async () => {
   const sts = new AWS.STS();
   await sts.getCallerIdentity().promise();
   await new Promise((resolve, reject) => {
-    const req = https.request({host: 'httpbin.org', path: '/post', method: 'POST'},resp => {
+    const req = https.request({ host: 'httpbin.org', path: '/post', method: 'POST' }, resp => {
       let data = '';
       resp.on('data', chunk => {
         data += chunk;
@@ -69,7 +69,7 @@ module.exports.spans = async () => {
     req.end();
   });
   await new Promise((resolve, reject) => {
-    const req = https.get({host: 'example.com', path: '/', method: 'get'}, resp => {
+    const req = https.get({ host: 'example.com', path: '/', method: 'get' }, resp => {
       let data = '';
       resp.on('data', chunk => {
         data += chunk;

--- a/integration-testing/service3/handler.js
+++ b/integration-testing/service3/handler.js
@@ -1,4 +1,6 @@
 'use strict';
+const https = require('https');
+const AWS = require('aws-sdk');
 
 module.exports.sync = () => {
   return 'syncReturn';
@@ -48,4 +50,22 @@ module.exports.succeed = (event, context) => {
 module.exports.promiseAndCallbackRace = async (event, context, callback) => {
   callback(null, 'callbackEarlyReturn');
   return 'asyncReturn';
+};
+
+module.exports.spans = async () => {
+  const sts = new AWS.STS();
+  await sts.getCallerIdentity().promise();
+  await new Promise((resolve, reject) => {
+    https
+      .get('https://httpbin.org/get', resp => {
+        let data = '';
+        resp.on('data', chunk => {
+          data += chunk;
+        });
+        resp.on('end', () => {
+          resolve(data);
+        });
+      })
+      .on('error', reject);
+  });
 };

--- a/integration-testing/service3/serverless.yml
+++ b/integration-testing/service3/serverless.yml
@@ -4,7 +4,7 @@ service: CHANGEME
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs10.x
 
 functions:
   sync:
@@ -33,3 +33,6 @@ functions:
     handler: handler.promiseAndCallbackRace
   spans:
     handler: handler.spans
+  spans8:
+    handler: handler.spans
+    runtime: nodejs8.10

--- a/integration-testing/service3/serverless.yml
+++ b/integration-testing/service3/serverless.yml
@@ -4,7 +4,7 @@ service: CHANGEME
 
 provider:
   name: aws
-  runtime: nodejs10.x
+  runtime: nodejs8.10
 
 functions:
   sync:

--- a/integration-testing/service3/serverless.yml
+++ b/integration-testing/service3/serverless.yml
@@ -31,3 +31,5 @@ functions:
     handler: handler.succeed
   promise-and-callback-race:
     handler: handler.promiseAndCallbackRace
+  spans:
+    handler: handler.spans

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -242,7 +242,7 @@ describe('integration', () => {
       type: 'http',
       requestHostname: 'httpbin.org',
       httpMethod: 'POST',
-      httpStatus: 200
+      httpStatus: 200,
     });
     // second http span (https.get)
     expect(new Set(Object.keys(payload.payload.spans[2]))).toEqual(
@@ -252,7 +252,7 @@ describe('integration', () => {
       type: 'http',
       requestHostname: 'example.com',
       httpMethod: 'GET',
-      httpStatus: 200
+      httpStatus: 200,
     });
   });
 
@@ -286,7 +286,7 @@ describe('integration', () => {
       type: 'http',
       requestHostname: 'httpbin.org',
       httpMethod: 'POST',
-      httpStatus: 200
+      httpStatus: 200,
     });
     // second http span (https.get)
     expect(new Set(Object.keys(payload.payload.spans[2]))).toEqual(
@@ -296,7 +296,7 @@ describe('integration', () => {
       type: 'http',
       requestHostname: 'example.com',
       httpMethod: 'GET',
-      httpStatus: 200
+      httpStatus: 200,
     });
   });
 });

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -212,7 +212,7 @@ describe('integration', () => {
     expect(JSON.parse(Payload)).toEqual('callbackEarlyReturn');
   });
 
-  it('gets an http span', async () => {
+  it('gets spans', async () => {
     const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-spans` })
       .promise();
@@ -256,7 +256,7 @@ describe('integration', () => {
     });
   });
 
-  it('gets an http span in node 8', async () => {
+  it('gets spans in node 8', async () => {
     const { LogResult } = await lambda
       .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-spans8` })
       .promise();


### PR DESCRIPTION
* If no hosts specified by env var, default to all hosts
* Ignore aws-sdk requests by checking user agent, optionally disable the feature with the `SERVERLESS_ENTERPRISE_SPANS_CAPTURE_AWS_SDK_HTTP` env var
* added integration test coverage
* in doing so found two bugs that are  now fixed:
  * use of `https.get` in node 10 was not being captured. Fixed by replacing `get` with a version that uses our monkey patched `request`. This is:
    * the same as io-pipe does: https://github.com/iopipe/iopipe-js-trace/blob/master/src/plugins/https.js#L27-L33
    * virtually identical the the actual std library implementation: https://github.com/nodejs/node/blob/v10.x/lib/https.js#L292-L296
  * use of `https` resulted in duplicate spans in node 8 bc in node 8 `https.request` calls `http.request`. Fixed by setting a flag on the callback function to detect that requests have already been captured. This is the same technique as used by io-pip as well: https://github.com/iopipe/iopipe-js-trace/blob/master/src/plugins/https.js#L141-L146