### PR TITLE
Emit a payload when timeout is imminent

### DIFF
--- a/integration-testing/wrapper-service/handler.js
+++ b/integration-testing/wrapper-service/handler.js
@@ -92,3 +92,5 @@ module.exports.noWaitForEmptyLoop = (event, context, callback) => {
   https.get({ host: 'httpbin.org', path: '/delay/10' });
   callback(null, 'noWaitForEmptyLoop');
 };
+
+module.exports.timeout = async () => await new Promise(resolve => setTimeout(resolve, 10000));

--- a/integration-testing/wrapper-service/handler.py
+++ b/integration-testing/wrapper-service/handler.py
@@ -1,3 +1,4 @@
+import time
 import boto3
 from botocore.vendored import requests
 
@@ -17,3 +18,6 @@ def http_error(event, context):
     except:
         pass
     return 'http_erroO'
+
+def timeout(event, context):
+    time.sleep(10)

--- a/integration-testing/wrapper-service/serverless.yml
+++ b/integration-testing/wrapper-service/serverless.yml
@@ -39,6 +39,8 @@ functions:
   spans8:
     handler: handler.spans
     runtime: nodejs8.10
+  timeout:
+    handler: handler.timeout
 
   # Python handlers
   pythonSuccess:
@@ -53,3 +55,5 @@ functions:
   pythonHttpError:
     handler: handler.http_error
     runtime: python3.7
+  pythonTimeout:
+    handler: handler.timeout

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -343,6 +343,21 @@ describe('integration: wrapper', function() {
     });
   });
 
+  it('gets SFE log msg from wrapped node timeout handler', async () => {
+    const { LogResult } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-timeout` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
+    const payload = JSON.parse(
+      logResult
+        .split('\n')
+        .filter(line => line.includes('SERVERLESS_ENTERPRISE'))[0]
+        .split('SERVERLESS_ENTERPRISE')[1]
+    );
+    expect(payload.type).to.equal('timeout');
+  });
+
   it('gets the return value when calling python', async () => {
     const { Payload } = await lambda
       .invoke({ FunctionName: `${serviceName}-dev-pythonSuccess` })
@@ -491,5 +506,20 @@ describe('integration: wrapper', function() {
         .slice(22)
     );
     expect(payload.type).to.equal('error');
+  });
+
+  it('gets SFE log msg from wrapped python timeout handler', async () => {
+    const { LogResult } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-pythonTimeout` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
+    const payload = JSON.parse(
+      logResult
+        .split('\n')
+        .filter(line => line.includes('SERVERLESS_ENTERPRISE'))[0]
+        .split('SERVERLESS_ENTERPRISE')[1]
+    );
+    expect(payload.type).to.equal('timeout');
   });
 });

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { spawn } = require('child_process');
+
 /*
  * Spans and Monkey Patching
  */
@@ -145,6 +147,12 @@ class ServerlessSDK {
           eventType,
         });
 
+        // SIGTERM self shortly before timeout & catch and print transaction
+        const timeoutHandler = spawn(`sleep ${(config.timeout || 6) - 0.05} && kill $PPID`, {
+          shell: true,
+        });
+        process.on('SIGTERM', () => trans.report());
+
         // Capture Compute Data: aws.lambda
         trans.set('compute.runtime', `aws.lambda.nodejs.${process.versions.node}`);
         trans.set('compute.region', process.env.AWS_REGION);
@@ -201,6 +209,7 @@ class ServerlessSDK {
         let finalized = false;
         const finalize = (error, cb) => {
           if (finalized) return;
+          timeoutHandler.kill('SIGKILL'); // kill the timeout handler
           try {
             if (capturedError) {
               trans.error(capturedError, false, cb);

--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -12,6 +12,7 @@ const isError = require('type/error/is');
 
 const TRANSACTION = 'transaction';
 const ERROR = 'error';
+const TIMEOUT = 'timeout';
 
 let transactionCount = 0;
 
@@ -209,6 +210,27 @@ class Transaction {
   }
 
   /*
+   * report (on SIGTERM)
+   */
+
+  report() {
+    this.set(
+      'error.id',
+      'TimeoutError!$Function execution duration going to exceeded configured timeout limit.'
+    );
+    this.set('error.culprit', 'timeout');
+    this.set('error.fatal', true);
+    this.set('error.exception.type', 'TimeoutError');
+    this.set(
+      'error.exception.message',
+      'Function execution duration going to exceeded configured timeout limit.'
+    );
+    this.set('error.exception.stacktrace', '[]');
+    this.buildOutput(TIMEOUT);
+    this.end();
+  }
+
+  /*
    * End
    */
 
@@ -263,7 +285,7 @@ class Transaction {
       envelope.payload.spans = this.$.spans;
 
       console.info('SERVERLESS_ENTERPRISE', JSON.stringify(envelope));
-      this.processed = true;
+      this.processed = this.$.schema.error.type !== 'TimeoutError';
     }
   }
 }


### PR DESCRIPTION
In NodeJS, a subprocess is `spawn`'d that sleeps for the duration of the timeout then calls `kill $PPID` to send the main lambda process a `SIGTERM`.

In Python, a `threading.Timer` is used to spawn a thread that waits until the timeout, and then calls `SIGTERM` on the process.

In both, a `SIGTERM` handler is registered and upon receiving it, a `timeout` transaction is written.

On succesful execution, in NodeJS, the subprocess is killed and, in Python, the timer is canceled.