### PR TITLE
diasble variable resolution in interactive cli and change retval

### DIFF
--- a/lib/variables.js
+++ b/lib/variables.js
@@ -13,9 +13,10 @@ const getValueFromDashboardSecrets = ctx => async variableString => {
   ctx.state.secretsUsed.add(variableName);
   if (
     ctx.sls.processedInput.commands[0] === 'login' ||
-    ctx.sls.processedInput.commands[0] === 'logout'
+    ctx.sls.processedInput.commands[0] === 'logout' ||
+    ctx.sls.interactiveCli
   ) {
-    return {};
+    return '';
   }
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant);
   const deploymentProfile = await getDeployProfile({
@@ -39,9 +40,10 @@ const getValueFromDashboardState = ctx => async variableString => {
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant);
   if (
     ctx.sls.processedInput.commands[0] === 'login' ||
-    ctx.sls.processedInput.commands[0] === 'logout'
+    ctx.sls.processedInput.commands[0] === 'logout' ||
+    ctx.sls.interactiveCli
   ) {
-    return {};
+    return '';
   }
   const service = variableString.substring(6).split('.', 1)[0];
   const key = variableString.substring(6).substr(service.length);

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -94,7 +94,7 @@ describe('variables', () => {
           processedInput: { commands: ['login'] },
         },
       })('secrets:name');
-      expect(value).to.deep.equal({});
+      expect(value).to.deep.equal('');
       expect(ctx.state.secretsUsed).to.deep.equal(new Set(['name']));
       expect(getDeployProfile.callCount).to.equal(0);
     });
@@ -146,7 +146,7 @@ describe('variables', () => {
           processedInput: { commands: ['login'] },
         },
       })('state:service.name');
-      expect(value).to.deep.equal({});
+      expect(value).to.deep.equal('');
       expect(getStateVariable.callCount).to.equal(0);
     });
   });


### PR DESCRIPTION
This avoids certain issues @ac360 ran into.

the change to string is for if the user uses it in an environment variable, it won't complain that it's not a string.