### PR TITLE
Configure update notifier (moved from serverless repo)

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,11 +1,13 @@
 'use strict';
 
 const chalk = require('chalk');
+const updateNotifier = require('update-notifier');
 const {
   configureFetchDefaults,
   getLoggedInUser,
   openBrowser,
 } = require('@serverless/platform-sdk');
+const sfePkgJson = require('../package');
 const errorHandler = require('./errorHandler');
 const logsCollection = require('./logsCollection');
 const login = require('./login');
@@ -331,7 +333,15 @@ class ServerlessEnterprisePlugin {
     // in serverless, which will discard plugin when command not run in service context:
     // https://github.com/serverless/serverless/blob/f0ccf6441ace7b5cc524e774f025a39c3c0667f2/lib/classes/PluginManager.js#L78
     this.provider = this.sls.getProvider('aws');
-    if (this.sls.enterpriseEnabled && (process.env.SERVERLESS_ACCESS_KEY || getLoggedInUser())) {
+    if (!this.sls.enterpriseEnabled) return;
+    const updates = updateNotifier({ pkg: sfePkgJson, interval: 1 });
+    if (updates.update) {
+      this.sls.cli.log(
+        'An updated version of the Serverless Dashboard is available. ' +
+          'Please upgrade by running `npm i -g serverless`'
+      );
+    }
+    if (process.env.SERVERLESS_ACCESS_KEY || getLoggedInUser()) {
       await configureDeployProfile(this);
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "semver": "^5.6.0",
     "simple-git": "^1.118.0",
     "source-map-support": "^0.5.12",
+    "update-notifier": "^3.0.1",
     "uuid": "^3.3.2",
     "yamljs": "^0.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "semver": "^5.6.0",
     "simple-git": "^1.118.0",
     "source-map-support": "^0.5.12",
-    "update-notifier": "^3.0.1",
+    "update-notifier": "^2.5.0",
     "uuid": "^3.3.2",
     "yamljs": "^0.3.0"
   },


### PR DESCRIPTION
It belongs to this repository, and will be removed from serverless project with https://github.com/serverless/serverless/pull/6814

Taking this in, in scope of current major, may create a situation where old version of serverless (one that checks for version update), and new version of this plugin (which will now also check for version update) would still be run, but with the way update notifier works, it's safe (it's configured to check once per day, not matter how many processes or instances are querying for it)
