### PR TITLE
Workaround Babel bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
-    "@babel/cli": "^7.1.0",
-    "@babel/core": "^7.1.0",
+    "@babel/cli": "7.6.2",
+    "@babel/core": "7.6.2",
     "@babel/preset-env": "^7.1.0",
     "@babel/register": "^7.6.0",
     "@serverless/eslint-config": "^1.0.1",


### PR DESCRIPTION
After upgrade to babel @7.6.3 build step stopped working -> https://travis-ci.com/serverless/enterprise-plugin/jobs/244182734

It's due to: https://github.com/babel/babel/issues/10533

Fix babel to 7.6.2 for a meantime