### PR TITLE
extended & renamed outputs variables support

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -106,22 +106,22 @@ class ServerlessEnterprisePlugin {
     };
     this.variableResolvers = {
       param: {
-        resolver: variables.getValueFromDashboardSecrets(this),
+        resolver: variables.getValueFromDashboardParams(this),
         serviceName: 'Serverless Parameters',
         isDisabledAtPrepopulation: true,
       },
       secrets: {
-        resolver: variables.getValueFromDashboardSecrets(this),
+        resolver: variables.getValueFromDashboardParams(this),
         serviceName: 'Serverless Secrets',
         isDisabledAtPrepopulation: true,
       },
       state: {
-        resolver: variables.getValueFromDashboardState(this),
+        resolver: variables.getValueFromDashboardOutputs(this),
         serviceName: 'Serverless Outputs',
         isDisabledAtPrepopulation: true,
       },
       output: {
-        resolver: variables.getValueFromDashboardState(this),
+        resolver: variables.getValueFromDashboardOutputs(this),
         serviceName: 'Serverless Outputs',
         isDisabledAtPrepopulation: true,
       },

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -120,6 +120,11 @@ class ServerlessEnterprisePlugin {
         serviceName: 'Serverless Outputs',
         isDisabledAtPrepopulation: true,
       },
+      output: {
+        resolver: variables.getValueFromDashboardState(this),
+        serviceName: 'Serverless Outputs',
+        isDisabledAtPrepopulation: true,
+      },
     };
 
     // Don't check any dashbaord stuff if using an unauthenticated command

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -131,7 +131,7 @@ describe('plugin', () => {
       ])
     );
     expect(new Set(Object.keys(instance.variableResolvers))).to.deep.equal(
-      new Set(['param', 'secrets', 'state'])
+      new Set(['param', 'secrets', 'state', 'output'])
     );
     expect(sls.getProvider.calledWith('aws')).to.be.true;
     expect(sls.cli.log.callCount).to.equal(0);

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -45,18 +45,42 @@ const getValueFromDashboardState = ctx => async variableString => {
   ) {
     return '';
   }
-  const service = variableString.substring(6).split('.', 1)[0];
-  const key = variableString.substring(6).substr(service.length);
+  const variableParts = variableString.split(':').slice(1);
+  let service;
+  let key;
+  let app = ctx.sls.service.app;
+  let stage = ctx.provider.getStage();
+  let region = ctx.provider.getRegion();
+  if (variableParts.length === 1) {
+    service = variableParts[0].split('.', 1)[0];
+    key = variableParts[0].substr(service.length);
+  } else if (variableParts.length === 4) {
+    service = variableParts[3].split('.', 1)[0];
+    key = variableParts[3].substr(service.length);
+    if (variableParts[0]) {
+      app = variableParts[0];
+    }
+    if (variableParts[1]) {
+      stage = variableParts[1];
+    }
+    if (variableParts[2]) {
+      region = variableParts[2];
+    }
+  } else {
+    throw new Error(
+      '`${${variableString}}` does not conform to syntax ${outputs:service.key} or ${outputs:app:stage:region:service.key}'
+    );
+  }
   const outputName = key.split('.')[1];
   const subkey = key.substr(outputName.length + 2);
   const { value } = await getStateVariable({
     accessKey,
     outputName,
     service,
-    app: ctx.sls.service.app,
+    app,
     tenant: ctx.sls.service.tenant,
-    stage: ctx.provider.getStage(),
-    region: ctx.provider.getRegion(),
+    stage,
+    region,
   });
   if (subkey) {
     return _.get(value, subkey);

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -9,7 +9,7 @@ const {
 
 // functions for new way of getting variables
 const getValueFromDashboardParams = ctx => async variableString => {
-  const variableName = variableString.substring(variableString.indexOf(':') + 1);
+  const variableName = variableString.slice(variableString.indexOf(':') + 1);
   ctx.state.secretsUsed.add(variableName);
   if (
     ctx.sls.processedInput.commands[0] === 'login' ||
@@ -53,10 +53,10 @@ const getValueFromDashboardOutputs = ctx => async variableString => {
   let region = ctx.provider.getRegion();
   if (variableParts.length === 1) {
     service = variableParts[0].split('.', 1)[0];
-    key = variableParts[0].substr(service.length);
+    key = variableParts[0].slice(service.length);
   } else if (variableParts.length === 4) {
     service = variableParts[3].split('.', 1)[0];
-    key = variableParts[3].substr(service.length);
+    key = variableParts[3].slice(service.length);
     if (variableParts[0]) {
       app = variableParts[0];
     }
@@ -72,7 +72,7 @@ const getValueFromDashboardOutputs = ctx => async variableString => {
     );
   }
   const outputName = key.split('.')[1];
-  const subkey = key.substr(outputName.length + 2);
+  const subkey = key.slice(outputName.length + 2);
   const { value } = await getStateVariable({
     accessKey,
     outputName,

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -8,7 +8,7 @@ const {
 } = require('@serverless/platform-sdk');
 
 // functions for new way of getting variables
-const getValueFromDashboardSecrets = ctx => async variableString => {
+const getValueFromDashboardParams = ctx => async variableString => {
   const variableName = variableString.substring(variableString.indexOf(':') + 1);
   ctx.state.secretsUsed.add(variableName);
   if (
@@ -36,7 +36,7 @@ const getValueFromDashboardSecrets = ctx => async variableString => {
   return secrets[variableName];
 };
 
-const getValueFromDashboardState = ctx => async variableString => {
+const getValueFromDashboardOutputs = ctx => async variableString => {
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.tenant);
   if (
     ctx.sls.processedInput.commands[0] === 'login' ||
@@ -89,6 +89,6 @@ const getValueFromDashboardState = ctx => async variableString => {
 };
 
 module.exports = {
-  getValueFromDashboardSecrets,
-  getValueFromDashboardState,
+  getValueFromDashboardParams,
+  getValueFromDashboardOutputs,
 };

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -31,7 +31,7 @@ const getValueFromDashboardParams = ctx => async variableString => {
     ])
   );
   if (!secrets[variableName]) {
-    throw new Error(`$\{${variableString}} not defined`);
+    throw new ctx.sls.classes.Error(`$\{${variableString}} not defined`);
   }
   return secrets[variableName];
 };
@@ -67,7 +67,7 @@ const getValueFromDashboardOutputs = ctx => async variableString => {
       region = variableParts[2];
     }
   } else {
-    throw new Error(
+    throw new ctx.sls.classes.Error(
       '`${${variableString}}` does not conform to syntax ${outputs:service.key} or ${outputs:app:stage:region:service.key}'
     );
   }

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -138,6 +138,58 @@ describe('variables', () => {
       ]);
     });
 
+    it('gets a state output from dashboard with long options but left blank', async () => {
+      const value = await getValueFromDashboardState(ctx)('state::::service.name');
+      expect(value).to.deep.equal('simple seeeeeccrreeeetttt');
+      expect(getStateVariable.args[0]).to.deep.equal([
+        {
+          accessKey: 'accessKey',
+          stage: 'stage',
+          tenant: 'tenant',
+          app: 'app',
+          service: 'service',
+          outputName: 'name',
+          region: 'region',
+        },
+      ]);
+    });
+
+    it('gets a state output from dashboard with long options but left only stage blank', async () => {
+      const value = await getValueFromDashboardState(ctx)(
+        'state:diff-app::diff-region:service.name'
+      );
+      expect(value).to.deep.equal('simple seeeeeccrreeeetttt');
+      expect(getStateVariable.args[0]).to.deep.equal([
+        {
+          accessKey: 'accessKey',
+          stage: 'stage',
+          tenant: 'tenant',
+          app: 'diff-app',
+          service: 'service',
+          outputName: 'name',
+          region: 'diff-region',
+        },
+      ]);
+    });
+
+    it('gets a state output from dashboard with app/stage/region options', async () => {
+      const value = await getValueFromDashboardState(ctx)(
+        'state:diff-app:diff-stage:diff-region:service.name'
+      );
+      expect(value).to.deep.equal('simple seeeeeccrreeeetttt');
+      expect(getStateVariable.args[0]).to.deep.equal([
+        {
+          accessKey: 'accessKey',
+          stage: 'diff-stage',
+          tenant: 'tenant',
+          app: 'diff-app',
+          service: 'service',
+          outputName: 'name',
+          region: 'diff-region',
+        },
+      ]);
+    });
+
     it('doesnt break during login command', async () => {
       const value = await getValueFromDashboardState({
         ...ctx,

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -6,8 +6,8 @@ const sinon = require('sinon');
 describe('variables', () => {
   let getStateVariable;
   let getDeployProfile;
-  let getValueFromDashboardSecrets;
-  let getValueFromDashboardState;
+  let getValueFromDashboardParams;
+  let getValueFromDashboardOutputs;
 
   before(() => {
     getStateVariable = sinon.stub().callsFake(({ outputName }) => {
@@ -24,7 +24,7 @@ describe('variables', () => {
         },
       ],
     });
-    ({ getValueFromDashboardSecrets, getValueFromDashboardState } = proxyquire('./variables', {
+    ({ getValueFromDashboardParams, getValueFromDashboardOutputs } = proxyquire('./variables', {
       '@serverless/platform-sdk': {
         getAccessKeyForTenant: async () => 'accessKey',
         getStateVariable,
@@ -33,7 +33,7 @@ describe('variables', () => {
     }));
   });
 
-  describe('variables - getValueFromDashboardSecrets', () => {
+  describe('variables - getValueFromDashboardParams', () => {
     afterEach(() => {
       getDeployProfile.resetHistory();
     });
@@ -57,7 +57,7 @@ describe('variables', () => {
     };
 
     it('gets a param from dashboard', async () => {
-      const value = await getValueFromDashboardSecrets(ctx)('param:name');
+      const value = await getValueFromDashboardParams(ctx)('param:name');
       expect(value).to.deep.equal('secretValue');
       expect(ctx.state.secretsUsed).to.deep.equal(new Set(['name']));
       expect(getDeployProfile.args[0]).to.deep.equal([
@@ -72,7 +72,7 @@ describe('variables', () => {
     });
 
     it('gets a secret from dashboard', async () => {
-      const value = await getValueFromDashboardSecrets(ctx)('secrets:name');
+      const value = await getValueFromDashboardParams(ctx)('secrets:name');
       expect(value).to.deep.equal('secretValue');
       expect(ctx.state.secretsUsed).to.deep.equal(new Set(['name']));
       expect(getDeployProfile.args[0]).to.deep.equal([
@@ -87,7 +87,7 @@ describe('variables', () => {
     });
 
     it('doesnt break during login command', async () => {
-      const value = await getValueFromDashboardSecrets({
+      const value = await getValueFromDashboardParams({
         ...ctx,
         sls: {
           ...ctx.sls,
@@ -100,7 +100,7 @@ describe('variables', () => {
     });
   });
 
-  describe('variables - getValueFromDashboardState', () => {
+  describe('variables - getValueFromDashboardOutputs', () => {
     afterEach(() => {
       getStateVariable.resetHistory();
     });
@@ -123,7 +123,7 @@ describe('variables', () => {
     };
 
     it('gets a state output from dashboard', async () => {
-      const value = await getValueFromDashboardState(ctx)('state:service.name');
+      const value = await getValueFromDashboardOutputs(ctx)('state:service.name');
       expect(value).to.deep.equal('simple seeeeeccrreeeetttt');
       expect(getStateVariable.args[0]).to.deep.equal([
         {
@@ -139,7 +139,7 @@ describe('variables', () => {
     });
 
     it('gets a state output from dashboard with long options but left blank', async () => {
-      const value = await getValueFromDashboardState(ctx)('state::::service.name');
+      const value = await getValueFromDashboardOutputs(ctx)('state::::service.name');
       expect(value).to.deep.equal('simple seeeeeccrreeeetttt');
       expect(getStateVariable.args[0]).to.deep.equal([
         {
@@ -155,7 +155,7 @@ describe('variables', () => {
     });
 
     it('gets a state output from dashboard with long options but left only stage blank', async () => {
-      const value = await getValueFromDashboardState(ctx)(
+      const value = await getValueFromDashboardOutputs(ctx)(
         'state:diff-app::diff-region:service.name'
       );
       expect(value).to.deep.equal('simple seeeeeccrreeeetttt');
@@ -173,7 +173,7 @@ describe('variables', () => {
     });
 
     it('gets a state output from dashboard with app/stage/region options', async () => {
-      const value = await getValueFromDashboardState(ctx)(
+      const value = await getValueFromDashboardOutputs(ctx)(
         'state:diff-app:diff-stage:diff-region:service.name'
       );
       expect(value).to.deep.equal('simple seeeeeccrreeeetttt');
@@ -191,7 +191,7 @@ describe('variables', () => {
     });
 
     it('doesnt break during login command', async () => {
-      const value = await getValueFromDashboardState({
+      const value = await getValueFromDashboardOutputs({
         ...ctx,
         sls: {
           ...ctx.sls,


### PR DESCRIPTION
* renamed from `${state:...}` to `${output:...}` (with backwards compatibility
* added syntax to specify app/stage/region: `${output:app:stage:region:...}`. They can be left
  and current value will be used (like with shortform). eg `${output:foo.bar}` is the same
  as `${output::::foo.bar}`