### PR TITLE
Unfix babel versions (after bug was fixed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
-    "@babel/cli": "7.6.2",
-    "@babel/core": "7.6.2",
+    "@babel/cli": "^7.6.4",
+    "@babel/core": "^7.6.4",
     "@babel/preset-env": "^7.1.0",
     "@babel/register": "^7.6.0",
     "@serverless/eslint-config": "^1.0.1",


### PR DESCRIPTION
Issue we were applying workaround for with https://github.com/serverless/enterprise-plugin
/pull/295 got fixed with https://github.com/babel/babel/pull/10536 (published as v7.6.4)