### PR TITLE
2.2.1 sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@serverless/event-mocks": "^1.1.1",
-    "@serverless/platform-sdk": "^2.0.3",
+    "@serverless/platform-sdk": "^2.2.1",
     "chalk": "^2.4.2",
     "flat": "^4.1.0",
     "fs-extra": "^7.0.1",


### PR DESCRIPTION
Seems like we may have some compatibility issues with the latest plugin version and 2.0.3, causing integration test failures and possible failures to communicate with the platform sdk.
![image](https://user-images.githubusercontent.com/1598537/68691656-b53a6800-0539-11ea-9c73-e4d4acb20938.png)
