### PR TITLE
Add buildId to removal deployment records

### DIFF
--- a/lib/deployment/parse.js
+++ b/lib/deployment/parse.js
@@ -252,6 +252,7 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
     }
   } else {
     deployment.set({
+      buildId: process.env.SLS_BUILD_ID,
       versionFramework: ctx.sls.version,
       versionEnterprisePlugin: packageJsonVersion,
       tenantUid: service.tenantUid,

--- a/lib/deployment/parse.js
+++ b/lib/deployment/parse.js
@@ -145,18 +145,12 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
         if (!gitShowError.message.includes('fatal:')) throw gitShowError;
       }
       if (vcs.commit) {
-        vcs.commitMessage = (await git.raw([
-          'show',
-          '-s',
-          '--format=%B',
-          branch.current || '',
-        ])).trim();
-        vcs.committerEmail = (await git.raw([
-          'show',
-          '-s',
-          '--format=%ae',
-          branch.current || '',
-        ])).trim();
+        vcs.commitMessage = (
+          await git.raw(['show', '-s', '--format=%B', branch.current || ''])
+        ).trim();
+        vcs.committerEmail = (
+          await git.raw(['show', '-s', '--format=%ae', branch.current || ''])
+        ).trim();
       }
       vcs.relativePath = (await git.raw(['rev-parse', '--show-prefix'])).trim();
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "engines": {
     "node": ">=6.0"
   },


### PR DESCRIPTION
This adds a `buildId` property to the deployment record on `sls remove` requests. The value is the SLS_BUILD_ID environment variable, if present.

It matches the existing behavior on `sls deploy` requests. It is necessary for tying deployment engine requests together with plugin deployment records.