### PR TITLE
Add appropriate link to the cfnRole guard info on serverless document…

### DIFF
--- a/lib/safeguards/policies/require-cfn-role.js
+++ b/lib/safeguards/policies/require-cfn-role.js
@@ -8,4 +8,4 @@ module.exports = function requireCfnRolePolicy(policy, service) {
   }
 };
 
-module.exports.docs = 'http://slss.io/sg-require-cfn-role';
+module.exports.docs = 'https://serverless.com/framework/docs/dashboard/safeguards/available/#require-cloudformation-deployment-role';


### PR DESCRIPTION
Wrong link at :
```
Warned - no cfnRole set
      details: http://slss.io/sg-require-cfn-role
      Require the cfnRole option, which specifies a particular role for CloudFormation to assume while deploying.
```