### PR TITLE
Include tagEvent on context

### DIFF
--- a/integration-testing/wrapper-service/handler.js
+++ b/integration-testing/wrapper-service/handler.js
@@ -2,7 +2,6 @@
 const https = require('https');
 const AWS = require('aws-sdk');
 // eslint-disable-next-line import/no-unresolved
-const { tagEvent, span } = require('./serverless_sdk');
 
 module.exports.sync = () => {
   return 'syncReturn';
@@ -54,14 +53,17 @@ module.exports.promiseAndCallbackRace = async (event, context, callback) => {
   return 'asyncReturn';
 };
 
-module.exports.eventTags = async () => {
-  tagEvent('event-tagged', 'true', { customerId: 5, userName: 'aaron.stuyvenberg' });
+module.exports.eventTags = async (event, context) => {
+  context.serverlessSdk.tagEvent('event-tagged', 'true', {
+    customerId: 5,
+    userName: 'aaron.stuyvenberg',
+  });
   return 'asyncReturn';
 };
 
 module.exports.spans = async (event, context) => {
   let sts;
-  span('create sts client', () => {
+  context.serverlessSdk.span('create sts client', () => {
     sts = new AWS.STS();
   });
   await sts.getCallerIdentity().promise();

--- a/integration-testing/wrapper-service/handler.py
+++ b/integration-testing/wrapper-service/handler.py
@@ -1,10 +1,9 @@
 import time
 import boto3
 from botocore.vendored import requests
-from serverless_sdk import tag_event, span
 
 def success(event, context):
-    with span('create sts client'):
+    with context.serverless_sdk.span('create sts client'):
         sts = boto3.client('sts')
     sts.get_caller_identity()
     requests.get('https://httpbin.org/get')
@@ -21,7 +20,7 @@ def http_error(event, context):
     return 'http_erroO'
 
 def event_tags(event, context):
-    tag_event('event-tagged', 'true', { 'customerId': 5, 'userName': 'aaron.stuyvenberg'})
+    context.serverless_sdk.tag_event('event-tagged', 'true', { 'customerId': 5, 'userName': 'aaron.stuyvenberg'})
     return 'success'
 
 def timeout(event, context):

--- a/lib/deployment/parse.js
+++ b/lib/deployment/parse.js
@@ -145,18 +145,12 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
         if (!gitShowError.message.includes('fatal:')) throw gitShowError;
       }
       if (vcs.commit) {
-        vcs.commitMessage = (await git.raw([
-          'show',
-          '-s',
-          '--format=%B',
-          branch.current || '',
-        ])).trim();
-        vcs.committerEmail = (await git.raw([
-          'show',
-          '-s',
-          '--format=%ae',
-          branch.current || '',
-        ])).trim();
+        vcs.commitMessage = (
+          await git.raw(['show', '-s', '--format=%B', branch.current || ''])
+        ).trim();
+        vcs.committerEmail = (
+          await git.raw(['show', '-s', '--format=%ae', branch.current || ''])
+        ).trim();
       }
       vcs.relativePath = (await git.raw(['rev-parse', '--show-prefix'])).trim();
     }

--- a/lib/deployment/parse.js
+++ b/lib/deployment/parse.js
@@ -145,12 +145,18 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
         if (!gitShowError.message.includes('fatal:')) throw gitShowError;
       }
       if (vcs.commit) {
-        vcs.commitMessage = (
-          await git.raw(['show', '-s', '--format=%B', branch.current || ''])
-        ).trim();
-        vcs.committerEmail = (
-          await git.raw(['show', '-s', '--format=%ae', branch.current || ''])
-        ).trim();
+        vcs.commitMessage = (await git.raw([
+          'show',
+          '-s',
+          '--format=%B',
+          branch.current || '',
+        ])).trim();
+        vcs.committerEmail = (await git.raw([
+          'show',
+          '-s',
+          '--format=%ae',
+          branch.current || '',
+        ])).trim();
       }
       vcs.relativePath = (await git.raw(['rev-parse', '--show-prefix'])).trim();
     }

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -300,7 +300,7 @@ class ServerlessSDK {
         // eslint-disable-next-line no-underscore-dangle
         ServerlessSDK._span = contextProxy.span;
 
-        const tagEvent = (tagName, tagValue = '', custom = {}) => {
+        contextProxy.tagEvent = (tagName, tagValue = '', custom = {}) => {
           transactionEventTags.push({
             tagName: tagName.toString(),
             tagValue: tagValue.toString(),
@@ -311,7 +311,7 @@ class ServerlessSDK {
           }
         };
         // eslint-disable-next-line no-underscore-dangle
-        ServerlessSDK._tagEvent = tagEvent;
+        ServerlessSDK._tagEvent = contextProxy.tagEvent;
 
         /*
          * Try Running Code

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -251,9 +251,11 @@ class ServerlessSDK {
           },
         });
 
+        contextProxy.serverlessSdk = {};
         contextProxy.captureError = err => {
           capturedError = err;
         };
+        contextProxy.serverlessSdk.captureError = contextProxy.captureError; // TODO deprecate in next major rev
         // eslint-disable-next-line no-underscore-dangle
         ServerlessSDK._captureError = contextProxy.captureError;
 
@@ -297,10 +299,11 @@ class ServerlessSDK {
           end();
           return null;
         };
+        contextProxy.serverlessSdk.span = contextProxy.span; // TODO deprecate in next major rev
         // eslint-disable-next-line no-underscore-dangle
         ServerlessSDK._span = contextProxy.span;
 
-        contextProxy.tagEvent = (tagName, tagValue = '', custom = {}) => {
+        contextProxy.serverlessSdk.tagEvent = (tagName, tagValue = '', custom = {}) => {
           transactionEventTags.push({
             tagName: tagName.toString(),
             tagValue: tagValue.toString(),

--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -185,6 +185,7 @@ class SDK(object):
 
         global _tag_event
         _tag_event = tag_event
+        context.tag_event = tag_event
 
         global _span
         _span = self.user_span

--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -179,17 +179,24 @@ class SDK(object):
             if len(self.event_tags) > 10:
                 self.event_tags.pop(0)
 
+        class SDK_METHOD_WRAPPER:
+            def __init__(self, capture_exception, tag_event, span):
+                self.capture_exception = capture_exception
+                self.tag_event = tag_event
+                self.span = span
+
         global _capture_exception
         _capture_exception = capture_exception
         context.capture_exception = capture_exception
 
         global _tag_event
         _tag_event = tag_event
-        context.tag_event = tag_event
 
         global _span
         _span = self.user_span
         context.span = self.user_span
+
+        context.serverless_sdk = SDK_METHOD_WRAPPER(capture_exception, tag_event, span)
 
         # handle getting a SIGTERM, which represents an imminent timeout
         def sigterm_handler(signal, frame):


### PR DESCRIPTION
This simply adds tagEvent to the `context.serverlessSdk` (node) and `context.serverless_sdk` (py) object to conform to the standard we set in `captureError`.

Initially the plan was to move both `captureError` and `tagEvent` to methods in the plugin itself, but we decided it's easier and cleaner to continue applying them to the `context` object. at this time.

I did not bump `package.json` because we have yet to release 3.2.4

Python QA:
![image](https://user-images.githubusercontent.com/1598537/68977971-32c2da00-07bf-11ea-82ea-d5c4f9479bb0.png)


Node QA:
![image](https://user-images.githubusercontent.com/1598537/68977993-3eae9c00-07bf-11ea-8899-f5422393251b.png)
