### PR TITLE
Stringify python tags

### DIFF
--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -175,7 +175,7 @@ class SDK(object):
                 )
 
         def tag_event(tag, value = '', custom = ''):
-            self.event_tags.append({'tagName': tag, 'tagValue': value, 'custom': json.dumps(custom)})
+            self.event_tags.append({'tagName': str(tag), 'tagValue': str(value), 'custom': json.dumps(custom)})
             if len(self.event_tags) > 10:
                 self.event_tags.pop(0)
 


### PR DESCRIPTION
This is a bug where I totally forgot to stringify tag names and values for the python implementation of tagEvent.