### PR TITLE
Use setTimeout.unref instead of sleep for watchdog process

### DIFF
--- a/integration-testing/wrapper-service/handler.js
+++ b/integration-testing/wrapper-service/handler.js
@@ -102,8 +102,8 @@ module.exports.noWaitForEmptyLoop = (event, context, callback) => {
   callback(null, 'noWaitForEmptyLoop');
 };
 
+//  By default in lambda, context.callbackWaitsForEmptyEventLoop = true
 module.exports.waitForEmptyLoop = (event, context, callback) => {
-  context.callbackWaitsForEmptyEventLoop = true;
   https.get({ host: 'httpbin.org', path: '/delay/10' });
   setTimeout(() => {
     return callback(null, 'noWaitForEmptyLoop');

--- a/integration-testing/wrapper-service/handler.js
+++ b/integration-testing/wrapper-service/handler.js
@@ -102,4 +102,12 @@ module.exports.noWaitForEmptyLoop = (event, context, callback) => {
   callback(null, 'noWaitForEmptyLoop');
 };
 
+module.exports.waitForEmptyLoop = (event, context, callback) => {
+  context.callbackWaitsForEmptyEventLoop = true;
+  https.get({ host: 'httpbin.org', path: '/delay/10' });
+  setTimeout(() => {
+    return callback(null, 'noWaitForEmptyLoop');
+  }, 10000);
+};
+
 module.exports.timeout = async () => await new Promise(resolve => setTimeout(resolve, 10000));

--- a/integration-testing/wrapper-service/serverless.yml
+++ b/integration-testing/wrapper-service/serverless.yml
@@ -43,6 +43,8 @@ functions:
     handler: handler.eventTags
   timeout:
     handler: handler.timeout
+  waitForEmptyLoop:
+    handler: handler.waitForEmptyLoop
 
   # Python handlers
   pythonSuccess:

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -358,6 +358,21 @@ describe('integration: wrapper', function() {
     expect(payload.type).to.equal('report');
   });
 
+  it('gets SFE log msg from wrapped node timeout handler with callbackWaitsForEmptyEventLoop true', async () => {
+    const { LogResult } = await lambda
+      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-waitForEmptyLoop` })
+      .promise();
+    const logResult = new Buffer(LogResult, 'base64').toString();
+    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
+    const payload = JSON.parse(
+      logResult
+        .split('\n')
+        .filter(line => line.includes('SERVERLESS_ENTERPRISE'))[0]
+        .split('SERVERLESS_ENTERPRISE')[1]
+    );
+    expect(payload.type).to.equal('report');
+  });
+
   it('gets the return value when calling python', async () => {
     const { Payload } = await lambda
       .invoke({ FunctionName: `${serviceName}-dev-pythonSuccess` })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "engines": {
     "node": ">=6.0"
   },

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -145,7 +145,10 @@ class ServerlessSDK {
           eventType,
         });
 
-        setTimeout(() => trans.report(), (config.timeout * 1000 || 6000) - 50).unref();
+        const timeoutHandler = setTimeout(
+          () => trans.report(),
+          (config.timeout * 1000 || 6000) - 50
+        ).unref();
 
         // Capture Compute Data: aws.lambda
         trans.set('compute.runtime', `aws.lambda.nodejs.${process.versions.node}`);
@@ -204,6 +207,7 @@ class ServerlessSDK {
         let finalized = false;
         const finalize = (error, cb) => {
           if (finalized) return;
+          clearTimeout(timeoutHandler);
           try {
             if (capturedError) {
               trans.error(capturedError, false, cb);

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { spawn } = require('child_process');
-
 /*
  * Spans and Monkey Patching
  */
@@ -147,11 +145,7 @@ class ServerlessSDK {
           eventType,
         });
 
-        // SIGTERM self shortly before timeout & catch and print transaction
-        const timeoutHandler = spawn(`sleep ${(config.timeout || 6) - 0.05} && kill $PPID`, {
-          shell: true,
-        });
-        process.on('SIGTERM', () => trans.report());
+        setTimeout(() => trans.report(), (config.timeout * 1000 || 6000) - 50).unref();
 
         // Capture Compute Data: aws.lambda
         trans.set('compute.runtime', `aws.lambda.nodejs.${process.versions.node}`);
@@ -210,7 +204,6 @@ class ServerlessSDK {
         let finalized = false;
         const finalize = (error, cb) => {
           if (finalized) return;
-          timeoutHandler.kill('SIGKILL'); // kill the timeout handler
           try {
             if (capturedError) {
               trans.error(capturedError, false, cb);


### PR DESCRIPTION
Closes #327 
This replaces a `spawn` command with a `setTimeout()` which we `unref()` to prevent `callbackWaitsForEmptyEventLoop: true` from disallowing the function to exit until the watchdog timer ends.