### PR TITLE
Limit Python wrapper to 50 spans

### DIFF
--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -339,7 +339,7 @@ class SDK(object):
                         "traceId": context.aws_request_id,
                         "xTraceId": os.environ.get("_X_AMZN_TRACE_ID"),
                     },
-                    "spans": self.spans,
+                    "spans": self.spans[:50], # Limit spans to only the first 50
                     "eventTags": self.event_tags,
                     "startTime": start_isoformat,
                     "tags": tags,


### PR DESCRIPTION
If the CloudWatch log message is too long, it gets truncated and we drop it. To avoid this, we [limit the number of spans to 50 in the JS SDK](https://github.com/serverless/enterprise-plugin/blob/master/sdk-js/src/index.js#L264-L266). This does the same for the Python SDK.

Question for @dschep if interested -- I couldn't figure out how to get at the `spans` array in the async context manager, so I just stored all the spans and then truncated at the very end. Any opposition to that?