### PR TITLE
Export the correct method onto the serverlessSdk, right now it is und…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "engines": {
     "node": ">=6.0"
   },

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -311,7 +311,7 @@ class ServerlessSDK {
           }
         };
         // eslint-disable-next-line no-underscore-dangle
-        ServerlessSDK._tagEvent = contextProxy.tagEvent;
+        ServerlessSDK._tagEvent = contextProxy.serverlessSdk.tagEvent;
 
         /*
          * Try Running Code


### PR DESCRIPTION
I made a mistake as we moved from `context.tagEvent` to `context.serverlessSdk.tagEvent` in #326.

This caused older imports, ` const { tagEvent } = require('./serverlessSdk')` to fail, because the method wasn't aliased on the `serverlessSdk` correctly. It resulted in this:
![image](https://user-images.githubusercontent.com/1598537/70971562-48ca0000-20c7-11ea-8fe9-daa372b34503.png)

This change fixes the mistake.