### PR TITLE
Fix and improve tests/CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
   # Minimize git history, but ensure to not break things:
   # - Merging multiple PR's around same time may introduce a case where it's not
   #   the last merge commit that is to be tested
-  depth: 10
+  depth: 30
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,17 @@ env:
 
 # Ensure to install dependencies at their latest versions
 install:
-  # Note: with `npm update` there seems no way to update all project dependency groups in one run
-  - npm update --no-save # Updates just dependencies
-  # Note: npm documents --dev option for dev dependencies update, but it's only --save-dev that works
-  - npm update --save-dev --no-save # Updates just devDependencies
+  # Note: `npm update` has issues which we need to workaround:
+  # - There seems no way to update all project dependency groups in one run
+  #   Hence different calls for prod and dev dependencies
+  # - The bigger depth, the longer update takes (-9999 as proposed in npm docs hangs the process).
+  #   Therefore we keep at 3 which should ensure most of dependencies are at latest versions
+  # - Depth setting makes optional dependencies not optional (install error crashes process)
+  #   Hence we skip install of optional dependencies completely, with --no-optional
+  #   Note: this patch works only for npm@5+
+  # - npm documents --dev option for dev dependencies update, but it's only --save-dev that works
+  - npm update --depth 3 --no-optional --no-save # Updates just dependencies
+  - npm update --depth 3 --save-dev --no-save # Updates just devDependencies
   - cd sdk-js
   - npm install # On publish it's bundled with deps, therefore we rely on `package-lock.json`
   - cd ..
@@ -122,6 +129,10 @@ jobs:
 
     - name: 'Unit Tests - Node.js v6'
       node_js: 6
+      before_install:
+        # npm@3 doesn't seem handle `--no-optional` option of `npm update` command.
+        # Upgrade npm to version which is distributed with Node.js v8
+        - npm i -g npm@6.4.1
       script:
         - npm test -- --require "@babel/register"
         - cd sdk-js

--- a/examples/safeguards-example-service/serverless.yml
+++ b/examples/safeguards-example-service/serverless.yml
@@ -6,7 +6,7 @@ frameworkVersion: '>=1.45.1'
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
 
 functions:
   hello:

--- a/integration-testing/README.md
+++ b/integration-testing/README.md
@@ -4,6 +4,6 @@ Currently covers safegaurds implementation.
 
 ## Setup.
 
-- Must have an `integration` tenant & app.
+- Must have an `integration` org & app.
 - The default safeguards should be setup
 - Change Stage & region safeguard enforcement level to error

--- a/integration-testing/service/serverless.yml
+++ b/integration-testing/service/serverless.yml
@@ -38,7 +38,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
 
   # you can overwrite defaults here
   #  stage: dev

--- a/integration-testing/service/serverless.yml
+++ b/integration-testing/service/serverless.yml
@@ -11,9 +11,9 @@
 #
 # Happy Coding!
 
-tenant: integration
+org: integration
 app: integration
-service: CHANGEME
+service: SERVICE_PLACEHOLDER
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
@@ -38,7 +38,7 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs8.10
 
   # you can overwrite defaults here
   #  stage: dev

--- a/integration-testing/service/serverless.yml
+++ b/integration-testing/service/serverless.yml
@@ -11,8 +11,8 @@
 #
 # Happy Coding!
 
-org: integration
-app: integration
+org: ORG_PLACEHOLDER
+app: APP_PLACEHOLDER
 service: SERVICE_PLACEHOLDER
 
 # You can pin your service to only deploy with a specific Serverless version

--- a/integration-testing/service2/serverless.yml
+++ b/integration-testing/service2/serverless.yml
@@ -11,7 +11,7 @@
 #
 # Happy Coding!
 
-tenant: integration
+org: integration
 app: integration
 service: SERVICE_PLACEHOLDER
 

--- a/integration-testing/service2/serverless.yml
+++ b/integration-testing/service2/serverless.yml
@@ -13,7 +13,7 @@
 
 tenant: integration
 app: integration
-service: CHANGEME
+service: SERVICE_PLACEHOLDER
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details

--- a/integration-testing/service2/serverless.yml
+++ b/integration-testing/service2/serverless.yml
@@ -20,7 +20,7 @@ service: CHANGEME
 frameworkVersion: '>=1.37.1'
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
 functions:
   hello:
     handler: handler.hello

--- a/integration-testing/service2/serverless.yml
+++ b/integration-testing/service2/serverless.yml
@@ -11,8 +11,8 @@
 #
 # Happy Coding!
 
-org: integration
-app: integration
+org: ORG_PLACEHOLDER
+app: APP_PLACEHOLDER
 service: SERVICE_PLACEHOLDER
 
 # You can pin your service to only deploy with a specific Serverless version

--- a/integration-testing/setup.js
+++ b/integration-testing/setup.js
@@ -32,7 +32,13 @@ module.exports = async function(templateName) {
     copy(path.join(__dirname, templateName), serviceTmpDir).then(async () => {
       const slsYamlPath = path.join(serviceTmpDir, 'serverless.yml');
       const slsYamlString = await readFile(slsYamlPath, 'utf8');
-      return writeFile(slsYamlPath, slsYamlString.replace('SERVICE_PLACEHOLDER', serviceName));
+      return writeFile(
+        slsYamlPath,
+        slsYamlString
+          .replace('SERVICE_PLACEHOLDER', serviceName)
+          .replace('ORG_PLACEHOLDER', process.env.SERVERLESS_PLATFORM_TEST_ORG || 'integration')
+          .replace('APP_PLACEHOLDER', process.env.SERVERLESS_PLATFORM_TEST_APP || 'integration')
+      );
     }),
     setupServerless({ mode: 'compiled' }).then(data => data.binary),
   ]);

--- a/integration-testing/setup.js
+++ b/integration-testing/setup.js
@@ -32,7 +32,7 @@ module.exports = async function(templateName) {
     copy(path.join(__dirname, templateName), serviceTmpDir).then(async () => {
       const slsYamlPath = path.join(serviceTmpDir, 'serverless.yml');
       const slsYamlString = await readFile(slsYamlPath, 'utf8');
-      return writeFile(slsYamlPath, slsYamlString.replace('CHANGEME', serviceName));
+      return writeFile(slsYamlPath, slsYamlString.replace('SERVICE_PLACEHOLDER', serviceName));
     }),
     setupServerless({ mode: 'compiled' }).then(data => data.binary),
   ]);

--- a/integration-testing/setup.js
+++ b/integration-testing/setup.js
@@ -6,14 +6,7 @@ const crypto = require('crypto');
 const { copy, readFile, remove, writeFile } = require('fs-extra');
 const setupServerless = require('../test/setupServerless');
 
-const spawn = (childProcessSpawn => (...args) => {
-  const result = childProcessSpawn(...args);
-  result.catch(error => {
-    if (error.stdoutBuffer) process.stdout.write(error.stdoutBuffer);
-    if (error.stderrBuffer) process.stdout.write(error.stderrBuffer);
-  });
-  return result;
-})(require('child-process-ext/spawn'));
+const spawn = require('child-process-ext/spawn');
 
 const tmpDir = os.tmpdir();
 
@@ -47,24 +40,16 @@ module.exports = async function(templateName) {
 
   const sls = (args, options = {}) => {
     console.info(`Invoke sls ${args.join(' ')}`);
-    const childDeferred = spawn('node', [serverlessBinPath, ...args], {
+    return spawn('node', [serverlessBinPath, ...args], {
       ...options,
       cwd: serviceTmpDir,
       env: {
         ...process.env,
         SERVERLESS_PLATFORM_STAGE,
-        FORCE_COLOR: '1',
         SLS_DEBUG: '*',
         ...options.env,
       },
     });
-    if (childDeferred.stdout) {
-      childDeferred.stdout.on('data', data => process.stdout.write(data));
-    }
-    if (childDeferred.stderr) {
-      childDeferred.stderr.on('data', data => process.stderr.write(data));
-    }
-    return childDeferred;
   };
   return {
     sls,

--- a/integration-testing/wrapper-service/serverless.yml
+++ b/integration-testing/wrapper-service/serverless.yml
@@ -4,7 +4,7 @@ service: SERVICE_PLACEHOLDER
 
 provider:
   name: aws
-  runtime: nodejs10.x
+  runtime: nodejs12.x
 
 functions:
   # NodeJS handlers
@@ -36,9 +36,9 @@ functions:
     handler: handler.promiseAndCallbackRace
   spans:
     handler: handler.spans
-  spans8:
+  spans10:
     handler: handler.spans
-    runtime: nodejs12.x
+    runtime: nodejs10.x
   eventTags:
     handler: handler.eventTags
   timeout:

--- a/integration-testing/wrapper-service/serverless.yml
+++ b/integration-testing/wrapper-service/serverless.yml
@@ -1,5 +1,5 @@
-org: integration
-app: integration
+org: ORG_PLACEHOLDER
+app: APP_PLACEHOLDER
 service: SERVICE_PLACEHOLDER
 
 provider:

--- a/integration-testing/wrapper-service/serverless.yml
+++ b/integration-testing/wrapper-service/serverless.yml
@@ -1,4 +1,4 @@
-tenant: integration
+org: integration
 app: integration
 service: SERVICE_PLACEHOLDER
 

--- a/integration-testing/wrapper-service/serverless.yml
+++ b/integration-testing/wrapper-service/serverless.yml
@@ -38,7 +38,7 @@ functions:
     handler: handler.spans
   spans8:
     handler: handler.spans
-    runtime: nodejs8.10
+    runtime: nodejs12.x
   eventTags:
     handler: handler.eventTags
   timeout:

--- a/integration-testing/wrapper-service/serverless.yml
+++ b/integration-testing/wrapper-service/serverless.yml
@@ -1,6 +1,6 @@
 tenant: integration
 app: integration
-service: CHANGEME
+service: SERVICE_PLACEHOLDER
 
 provider:
   name: aws

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -306,10 +306,10 @@ describe('integration: wrapper', function() {
     });
   });
 
-  it('gets spans in node 8', async () => {
+  it('gets spans in node 10', async () => {
     const { LogResult } = await awsRequest(lambdaService, 'invoke', {
       LogType: 'Tail',
-      FunctionName: `${serviceName}-dev-spans8`,
+      FunctionName: `${serviceName}-dev-spans10`,
     });
     const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('transaction');

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -1,7 +1,6 @@
 'use strict';
 process.env.SERVERLESS_PLATFORM_STAGE = 'dev';
 
-const stripAnsi = require('strip-ansi');
 const setup = require('./setup');
 const { getAccessKeyForTenant, getDeployProfile } = require('@serverless/platform-sdk');
 const AWS = require('aws-sdk');
@@ -27,11 +26,8 @@ describe('integration: wrapper', function() {
     });
 
     lambda = new AWS.Lambda({ region: 'us-east-1', credentials });
-    ({ sls, teardown } = await setup('wrapper-service'));
+    ({ sls, teardown, serviceName } = await setup('wrapper-service'));
     await sls(['deploy']);
-    serviceName = stripAnsi(
-      String((await sls(['print', '--path', 'service'], { env: { SLS_DEBUG: '' } })).stdoutBuffer)
-    ).trim();
   });
 
   afterAll(() => {

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -4,29 +4,35 @@ process.env.SERVERLESS_PLATFORM_STAGE = 'dev';
 
 const setup = require('./setup');
 const { getAccessKeyForTenant, getDeployProfile } = require('@serverless/platform-sdk');
-const AWS = require('aws-sdk');
+const awsRequest = require('@serverless/test/aws-request');
 
-let lambda;
 let sls;
 let teardown;
 let serviceName;
+const org = process.env.SERVERLESS_PLATFORM_TEST_ORG || 'integration';
+const app = process.env.SERVERLESS_PLATFORM_TEST_APP || 'integration';
 
 describe('integration: wrapper', function() {
   this.timeout(1000 * 60 * 5);
+  let lambdaService;
 
   beforeAll(async () => {
-    const accessKey = await getAccessKeyForTenant('integration');
-    const {
-      providerCredentials: { secretValue: credentials },
-    } = await getDeployProfile({
-      org: 'integration',
-      app: 'integration',
-      stage: 'dev',
-      service: serviceName,
-      accessKey,
-    });
+    const accessKey = await getAccessKeyForTenant(org);
+    lambdaService = {
+      name: 'Lambda',
+      params: {
+        credentials: (
+          await getDeployProfile({
+            tenant: org,
+            app,
+            stage: 'dev',
+            service: serviceName,
+            accessKey,
+          })
+        ).providerCredentials.secretValue,
+      },
+    };
 
-    lambda = new AWS.Lambda({ region: 'us-east-1', credentials });
     ({ sls, teardown, serviceName } = await setup('wrapper-service'));
     await sls(['deploy']);
   });
@@ -37,189 +43,210 @@ describe('integration: wrapper', function() {
   });
 
   it('gets right return value from  wrapped sync handler', async () => {
-    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-sync` }).promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-sync`,
+    });
     expect(JSON.parse(Payload)).to.equal(null); // why did i think this was possible?
   });
 
   it('gets right return value from  wrapped syncError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-syncError` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-syncError`,
+    });
     expect(JSON.parse(Payload).errorMessage).to.equal('syncError');
   });
 
   it('gets right return value from  wrapped async handler', async () => {
-    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-async` }).promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-async`,
+    });
     expect(JSON.parse(Payload)).to.equal('asyncReturn');
   });
 
   it('gets right return value from  wrapped asyncError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-asyncError` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-asyncError`,
+    });
     expect(JSON.parse(Payload).errorMessage).to.equal('asyncError');
   });
 
   it('gets right return value from  wrapped asyncDanglingCallback handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-asyncDanglingCallback` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-asyncDanglingCallback`,
+    });
     expect(JSON.parse(Payload)).to.equal('asyncDanglyReturn');
   });
 
   it('gets right return value from  wrapped done handler', async () => {
-    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-done` }).promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-done`,
+    });
     expect(JSON.parse(Payload)).to.equal('doneReturn');
   });
 
   it('gets right return value from  wrapped doneError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-doneError` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-doneError`,
+    });
     expect(JSON.parse(Payload).errorMessage).to.equal('doneError');
   });
 
   it('gets right return value from  wrapped callback handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-callback` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-callback`,
+    });
     expect(JSON.parse(Payload)).to.equal('callbackReturn');
   });
 
   it('gets right return value from  wrapped callback handler with dangling events but callbackWaitsForEmptyEventLoop=false', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-noWaitForEmptyLoop` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-noWaitForEmptyLoop`,
+    });
     expect(JSON.parse(Payload)).to.equal('noWaitForEmptyLoop');
   });
 
   it('gets right return value from  wrapped callbackError handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-callbackError` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-callbackError`,
+    });
     expect(JSON.parse(Payload).errorMessage).to.equal('callbackError');
   });
 
   it('gets right return value from  wrapped fail handler', async () => {
-    const { Payload } = await lambda.invoke({ FunctionName: `${serviceName}-dev-fail` }).promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-fail`,
+    });
     expect(JSON.parse(Payload).errorMessage).to.equal('failError');
   });
 
   it('gets right return value from  wrapped succeed handler', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-succeed` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-succeed`,
+    });
     expect(JSON.parse(Payload)).to.equal('succeedReturn');
   });
 
   xit('gets SFE log msg from wrapped sync handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-sync` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-sync`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/"errorId":null/);
   });
 
   it('gets SFE log msg from wrapped syncError handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-syncError` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-syncError`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/"errorId":"Error!\$syncError"/);
   });
 
   it('gets SFE log msg from wrapped async handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-async` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-async`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/"errorId":null/);
   });
 
   it('gets SFE log msg from wrapped asyncError handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncError` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-asyncError`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/"errorId":"Error!\$asyncError"/);
   });
 
   it('gets SFE log msg from wrapped asyncDanglingCallback handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-asyncDanglingCallback` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-asyncDanglingCallback`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/"errorId":null/);
   });
 
   it('gets SFE log msg from wrapped done handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-done` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-done`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/"errorId":null/);
   });
 
   it('gets SFE log msg from wrapped doneError handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-doneError` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-doneError`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/"errorId":"NotAnErrorType!\$doneError"/);
   });
 
   it('gets SFE log msg from wrapped callback handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callback` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-callback`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/"errorId":null/);
   });
 
   it('gets SFE log msg from wrapped callbackError handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callbackError` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-callbackError`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/"errorId":"NotAnErrorType!\$callbackError"/);
   });
 
   it('gets SFE log msg from wrapped fail handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-fail` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-fail`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/"errorId":"NotAnErrorType!\$failError"/);
   });
 
   it('gets SFE log msg from wrapped succeed handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-succeed` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-succeed`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/"errorId":null/);
   });
 
   it('gets right duration value from  wrapped callback handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-callback` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-callback`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     const duration = parseFloat(logResult.match(/"duration":(\d+\.\d+)/)[1]);
     expect(duration).to.be.above(5);
   });
 
   it('gets the callback return value when a promise func calls callback', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-promise-and-callback-race` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-promise-and-callback-race`,
+    });
     expect(JSON.parse(Payload)).to.equal('callbackEarlyReturn');
   });
 
   it('gets spans', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-spans` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-spans`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
     const payload = JSON.parse(
@@ -279,9 +306,10 @@ describe('integration: wrapper', function() {
   });
 
   it('gets spans in node 8', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-spans8` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-spans8`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
     const payload = JSON.parse(
@@ -341,9 +369,10 @@ describe('integration: wrapper', function() {
   });
 
   it('gets SFE log msg from wrapped node timeout handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-timeout` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-timeout`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
     const payload = JSON.parse(
@@ -356,9 +385,10 @@ describe('integration: wrapper', function() {
   });
 
   it('gets SFE log msg from wrapped node timeout handler with callbackWaitsForEmptyEventLoop true', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-waitForEmptyLoop` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-waitForEmptyLoop`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
     const payload = JSON.parse(
@@ -371,16 +401,17 @@ describe('integration: wrapper', function() {
   });
 
   it('gets the return value when calling python', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-pythonSuccess` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-pythonSuccess`,
+    });
     expect(JSON.parse(Payload)).to.equal('success');
   });
 
   it('gets SFE log msg from wrapped python handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-pythonSuccess` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-pythonSuccess`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
     const payload = JSON.parse(
@@ -418,9 +449,10 @@ describe('integration: wrapper', function() {
   });
 
   it('gets http connection errors from python', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-pythonHttpError` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-pythonHttpError`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
     const payload = JSON.parse(
@@ -441,16 +473,17 @@ describe('integration: wrapper', function() {
   });
 
   it('gets the return value when calling python2', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-pythonSuccess2` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-pythonSuccess2`,
+    });
     expect(JSON.parse(Payload)).to.equal('success');
   });
 
   it('gets SFE log msg from wrapped python2 handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-pythonSuccess2` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-pythonSuccess2`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
     const payload = JSON.parse(
@@ -488,9 +521,9 @@ describe('integration: wrapper', function() {
   });
 
   it('gets the error value when calling python error', async () => {
-    const { Payload } = await lambda
-      .invoke({ FunctionName: `${serviceName}-dev-pythonError` })
-      .promise();
+    const { Payload } = await awsRequest(lambdaService, 'invoke', {
+      FunctionName: `${serviceName}-dev-pythonError`,
+    });
     const payload = JSON.parse(Payload);
     expect(payload.stackTrace[0]).to.match(
       / *File "\/var\/task\/serverless_sdk\/__init__.py", line \d+, in wrapped_handler\n *return user_handler\(event, context\)\n/
@@ -506,9 +539,10 @@ describe('integration: wrapper', function() {
   });
 
   it('gets SFE log msg from wrapped python error handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-pythonError` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-pythonError`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
     const payload = JSON.parse(
@@ -521,9 +555,10 @@ describe('integration: wrapper', function() {
   });
 
   it('gets node eventTags', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-eventTags` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-eventTags`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
     const payload = JSON.parse(
@@ -542,9 +577,10 @@ describe('integration: wrapper', function() {
   });
 
   it('gets python eventTags', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-pythonEventTags` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-pythonEventTags`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
     const payload = JSON.parse(
@@ -563,9 +599,10 @@ describe('integration: wrapper', function() {
   });
 
   it('gets SFE log msg from wrapped python timeout handler', async () => {
-    const { LogResult } = await lambda
-      .invoke({ LogType: 'Tail', FunctionName: `${serviceName}-dev-pythonTimeout` })
-      .promise();
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-pythonTimeout`,
+    });
     const logResult = new Buffer(LogResult, 'base64').toString();
     expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
     const payload = JSON.parse(

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -12,6 +12,14 @@ let serviceName;
 const org = process.env.SERVERLESS_PLATFORM_TEST_ORG || 'integration';
 const app = process.env.SERVERLESS_PLATFORM_TEST_APP || 'integration';
 
+const resolveLog = encodedLogMsg => {
+  const logMsg = new Buffer(encodedLogMsg, 'base64').toString();
+  expect(logMsg).to.match(/SERVERLESS_ENTERPRISE/);
+  const logLine = logMsg.split('\n').find(line => line.includes('SERVERLESS_ENTERPRISE'));
+  const payloadString = logLine.split('SERVERLESS_ENTERPRISE')[1].split('END RequestId')[0];
+  return JSON.parse(payloadString);
+};
+
 describe('integration: wrapper', function() {
   this.timeout(1000 * 60 * 5);
   let lambdaService;
@@ -247,14 +255,7 @@ describe('integration: wrapper', function() {
       LogType: 'Tail',
       FunctionName: `${serviceName}-dev-spans`,
     });
-    const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
-    const payload = JSON.parse(
-      logResult
-        .split('\n')
-        .filter(line => line.includes('SERVERLESS_ENTERPRISE'))[0]
-        .split('SERVERLESS_ENTERPRISE')[1]
-    );
+    const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('transaction');
     expect(payload.payload.spans.length).to.equal(5);
     // first custom span (create sts client)
@@ -310,14 +311,7 @@ describe('integration: wrapper', function() {
       LogType: 'Tail',
       FunctionName: `${serviceName}-dev-spans8`,
     });
-    const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
-    const payload = JSON.parse(
-      logResult
-        .split('\n')
-        .filter(line => line.includes('SERVERLESS_ENTERPRISE'))[0]
-        .split('SERVERLESS_ENTERPRISE')[1]
-    );
+    const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('transaction');
     expect(payload.payload.spans.length).to.equal(5);
     // first custom span (create sts client)
@@ -373,14 +367,7 @@ describe('integration: wrapper', function() {
       LogType: 'Tail',
       FunctionName: `${serviceName}-dev-timeout`,
     });
-    const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
-    const payload = JSON.parse(
-      logResult
-        .split('\n')
-        .filter(line => line.includes('SERVERLESS_ENTERPRISE'))[0]
-        .split('SERVERLESS_ENTERPRISE')[1]
-    );
+    const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('report');
   });
 
@@ -389,14 +376,7 @@ describe('integration: wrapper', function() {
       LogType: 'Tail',
       FunctionName: `${serviceName}-dev-waitForEmptyLoop`,
     });
-    const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
-    const payload = JSON.parse(
-      logResult
-        .split('\n')
-        .filter(line => line.includes('SERVERLESS_ENTERPRISE'))[0]
-        .split('SERVERLESS_ENTERPRISE')[1]
-    );
+    const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('report');
   });
 
@@ -412,14 +392,7 @@ describe('integration: wrapper', function() {
       LogType: 'Tail',
       FunctionName: `${serviceName}-dev-pythonSuccess`,
     });
-    const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
-    const payload = JSON.parse(
-      logResult
-        .split('\n')
-        .filter(line => line.startsWith('SERVERLESS_ENTERPRISE'))[0]
-        .slice(22)
-    );
+    const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('transaction');
     expect(payload.payload.spans.length).to.equal(3);
     expect(new Set(Object.keys(payload.payload.spans[0]))).to.deep.equal(
@@ -453,14 +426,7 @@ describe('integration: wrapper', function() {
       LogType: 'Tail',
       FunctionName: `${serviceName}-dev-pythonHttpError`,
     });
-    const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
-    const payload = JSON.parse(
-      logResult
-        .split('\n')
-        .filter(line => line.startsWith('SERVERLESS_ENTERPRISE'))[0]
-        .slice(22)
-    );
+    const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('transaction');
     expect(payload.payload.spans.length).to.equal(1);
     expect(payload.payload.spans[0].tags).to.deep.equal({
@@ -484,14 +450,7 @@ describe('integration: wrapper', function() {
       LogType: 'Tail',
       FunctionName: `${serviceName}-dev-pythonSuccess2`,
     });
-    const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
-    const payload = JSON.parse(
-      logResult
-        .split('\n')
-        .filter(line => line.startsWith('SERVERLESS_ENTERPRISE'))[0]
-        .slice(22)
-    );
+    const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('transaction');
     expect(payload.payload.spans.length).to.equal(3);
     expect(new Set(Object.keys(payload.payload.spans[0]))).to.deep.equal(
@@ -543,14 +502,7 @@ describe('integration: wrapper', function() {
       LogType: 'Tail',
       FunctionName: `${serviceName}-dev-pythonError`,
     });
-    const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
-    const payload = JSON.parse(
-      logResult
-        .split('\n')
-        .filter(line => line.startsWith('SERVERLESS_ENTERPRISE'))[0]
-        .slice(22)
-    );
+    const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('error');
   });
 
@@ -559,14 +511,7 @@ describe('integration: wrapper', function() {
       LogType: 'Tail',
       FunctionName: `${serviceName}-dev-eventTags`,
     });
-    const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
-    const payload = JSON.parse(
-      logResult
-        .split('\n')
-        .filter(line => line.includes('SERVERLESS_ENTERPRISE'))[0]
-        .split('SERVERLESS_ENTERPRISE')[1]
-    );
+    const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('transaction');
     expect(payload.payload.eventTags.length).to.equal(1);
     expect(payload.payload.eventTags[0]).to.deep.equal({
@@ -581,14 +526,7 @@ describe('integration: wrapper', function() {
       LogType: 'Tail',
       FunctionName: `${serviceName}-dev-pythonEventTags`,
     });
-    const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
-    const payload = JSON.parse(
-      logResult
-        .split('\n')
-        .filter(line => line.includes('SERVERLESS_ENTERPRISE'))[0]
-        .split('SERVERLESS_ENTERPRISE')[1]
-    );
+    const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('transaction');
     expect(payload.payload.eventTags.length).to.equal(1);
     expect(payload.payload.eventTags[0]).to.deep.equal({
@@ -603,14 +541,7 @@ describe('integration: wrapper', function() {
       LogType: 'Tail',
       FunctionName: `${serviceName}-dev-pythonTimeout`,
     });
-    const logResult = new Buffer(LogResult, 'base64').toString();
-    expect(logResult).to.match(/SERVERLESS_ENTERPRISE/);
-    const payload = JSON.parse(
-      logResult
-        .split('\n')
-        .filter(line => line.includes('SERVERLESS_ENTERPRISE'))[0]
-        .split('SERVERLESS_ENTERPRISE')[1]
-    );
+    const payload = resolveLog(LogResult);
     expect(payload.type).to.equal('report');
   });
 });

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -19,7 +19,7 @@ describe('integration: wrapper', function() {
     const {
       providerCredentials: { secretValue: credentials },
     } = await getDeployProfile({
-      tenant: 'integration',
+      org: 'integration',
       app: 'integration',
       stage: 'dev',
       service: serviceName,

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -1,4 +1,5 @@
 'use strict';
+
 process.env.SERVERLESS_PLATFORM_STAGE = 'dev';
 
 const setup = require('./setup');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "./scripts/build.sh",
     "cover": "nyc npm test",
-    "integration-test": "mocha-isolated --pass-through-aws-creds --skip-fs-cleanup-check \"integration-testing/**/*.test.js\"",
+    "integration-test": "mocha-isolated --pass-through-aws-creds --skip-fs-cleanup-check --max-workers=20 \"integration-testing/**/*.test.js\"",
     "lint": "eslint --cache .",
     "lint:staged": "lint-staged",
     "lint:updated": "pipe-git-updated --ext=js -- eslint --cache",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
   "mocha": {
     "reporter": "@serverless/test/setup/mocha-reporter",
     "require": [
+      "@serverless/test/setup/log",
       "@serverless/test/setup/async-leaks-detector",
       "@serverless/test/setup/mock-homedir",
       "@serverless/test/setup/restore-cwd",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@babel/preset-env": "^7.7.7",
     "@babel/register": "^7.7.7",
     "@serverless/eslint-config": "^1.2.1",
-    "@serverless/test": "^3.3.0",
+    "@serverless/test": "^3.4.0",
     "aws-sdk": "^2.596.0",
     "chai": "^4.2.0",
     "child-process-ext": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
       "@serverless/test/setup/async-leaks-detector",
       "@serverless/test/setup/mock-homedir",
       "@serverless/test/setup/restore-cwd",
+      "@serverless/test/setup/restore-env",
       "./test/map-mocha-globals"
     ],
     "timeout": 5000


### PR DESCRIPTION
- Increase git depth to avoid fails on multiple merges
- Ensure latest versions of deep dependencies are installed
- Ensure concurrent run of integration tests
- Run integration against against `nodejs12.x` (and ensure they're not run against `nodejs8.10` as that crashes now)
- Make `app` and `org` in integration tests configurable via env vars
- Ensure smart debug logging (all logs configured via [log](https://github.com/medikoo/log#log) will be flushed on test fail), having that cleanup places where verbose logging was forced
- Ensure not affected `process.env` for each test run
- Rely on debuggable `awsRequest` in wrapper tests
- Fix span log testing in wrapper tests