### PR TITLE
Don't barf when boto error doesn't have a response

### DIFF
--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -392,7 +392,10 @@ class SDK(object):
                     response = wrapped(*args, **kwargs)
                     return response
                 except Exception as error:
-                    response = error.response
+                    if hasattr(error, "response"):
+                        response = error.response
+                    else:
+                        response = {}
                     raise error
                 finally:
                     span.set_tag(


### PR DESCRIPTION
Hey folks, ran into this little issue today. To replicate the bug cause before this fix, use a boto function with an invalid parameter type. in my  case, I was  passing a tuple `('someid',)` instead of a string`'someid'` in `boto3.client('apigateway').delete_usage_plan_key(...)` as `keyId`.