### PR TITLE
Downgrade `semver` to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "node-dir": "^0.1.17",
     "node-fetch": "^2.6.0",
     "regenerator-runtime": "^0.13.3",
-    "semver": "^7.1.1",
+    "semver": "^6.3.0",
     "simple-git": "^1.129.0",
     "source-map-support": "^0.5.16",
     "update-notifier": "^2.5.0",


### PR DESCRIPTION
Fixes #352 

While v7 seems safe for Node.js v6+, in package.json is advertised as Node.js v10+ only. Hence to be on a safe side, downgrading to v6