### PR TITLE
PLAT-2296 Cache params resolution

### DIFF
--- a/lib/resolveParams.js
+++ b/lib/resolveParams.js
@@ -1,20 +1,24 @@
 'use strict';
 
+const memoizee = require('memoizee');
 const { getAccessKeyForTenant, getDeployProfile } = require('@serverless/platform-sdk');
 
-module.exports = async ({ org, app, stage }) => {
-  const deploymentProfile = await getDeployProfile({
-    accessKey: await getAccessKeyForTenant(org),
-    stage,
-    app,
-    tenant: org,
-  });
-  const params = Object.create(null);
-  for (const {
-    secretName: name,
-    secretProperties: { value },
-  } of deploymentProfile.secretValues) {
-    params[name] = value;
-  }
-  return params;
-};
+module.exports = memoizee(
+  async ({ org, app, stage }) => {
+    const deploymentProfile = await getDeployProfile({
+      accessKey: await getAccessKeyForTenant(org),
+      stage,
+      app,
+      tenant: org,
+    });
+    const params = Object.create(null);
+    for (const {
+      secretName: name,
+      secretProperties: { value },
+    } of deploymentProfile.secretValues) {
+      params[name] = value;
+    }
+    return params;
+  },
+  { promise: true, normalizer: ([{ org, app, stage }]) => JSON.stringify({ org, app, stage }) }
+);

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -8,6 +8,7 @@ describe('variables', () => {
   let getDeployProfile;
   let getValueFromDashboardParams;
   let getValueFromDashboardOutputs;
+  let resolveParams;
 
   before(() => {
     getStateVariable = sinon.stub().callsFake(({ outputName }) => {
@@ -24,7 +25,7 @@ describe('variables', () => {
         },
       ],
     });
-    ({ getValueFromDashboardParams, getValueFromDashboardOutputs } = requireUncached(
+    ({ getValueFromDashboardParams, getValueFromDashboardOutputs, resolveParams } = requireUncached(
       [
         require.resolve('./variables'),
         require.resolve('./resolveParams'),
@@ -37,7 +38,7 @@ describe('variables', () => {
           getStateVariable,
           getDeployProfile,
         });
-        return require('./variables');
+        return { ...require('./variables'), resolveParams: require('./resolveParams') };
       }
     ));
   });
@@ -45,6 +46,7 @@ describe('variables', () => {
   describe('variables - getValueFromDashboardParams', () => {
     afterEach(() => {
       getDeployProfile.resetHistory();
+      resolveParams.clear();
     });
 
     const ctx = {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "jsonata": "^1.7.0",
     "jszip": "^3.2.2",
     "lodash": "^4.17.15",
+    "memoizee": "^0.4.14",
     "moment": "^2.24.0",
     "node-dir": "^0.1.17",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
As params are immutable across single command run, it's fine to resolve them once.

So far variable resolver, was requesting deployment profile (with whole set of params) for every approached param variable in sls config. This patch improves that.