### PR TITLE
Use $context.error.messageString for a quoted message string in API gateway logs

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,7 +34,10 @@ const API_GATEWAY_LOG_FORMAT = {
   integrationStatus: '$context.integrationStatus',
   responseLatency: '$context.responseLatency',
   responseLength: '$context.responseLength',
-  errorMessage: '$context.error.messageString',
+  // we have to escape the error message based on
+  // https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#util-template-reference
+  // eslint-disable-next-line quotes
+  errorMessage: `$util.escapeJavaScript($context.error.message).replaceAll("\\'","'")`,
   format: 'SLS_ACCESS_LOG',
   version: '1.0.0',
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,7 +34,7 @@ const API_GATEWAY_LOG_FORMAT = {
   integrationStatus: '$context.integrationStatus',
   responseLatency: '$context.responseLatency',
   responseLength: '$context.responseLength',
-  errorMessage: '$context.error.message',
+  errorMessage: '$context.error.messageString',
   format: 'SLS_ACCESS_LOG',
   version: '1.0.0',
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,8 +36,7 @@ const API_GATEWAY_LOG_FORMAT = {
   responseLength: '$context.responseLength',
   // we have to escape the error message based on
   // https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#util-template-reference
-  // eslint-disable-next-line quotes
-  errorMessage: `$util.escapeJavaScript($context.error.message).replaceAll("\\'","'")`,
+  errorMessage: '$util.escapeJavaScript($context.error.message).replaceAll("\\\'","\'")',
   format: 'SLS_ACCESS_LOG',
   version: '1.0.0',
 };


### PR DESCRIPTION
This PR addresses the issue reported in PLAT-2342 where there are unquoted strings in the error response.  

This PR still needs to be tested/validated - I have not figured out a way to test it locally, trying to find a way to test it in dev