### PR TITLE
Allow users to skip AWS_SDK span collections with env var

### DIFF
--- a/sdk-js/src/lib/spanHooks/hookAwsSdk.js
+++ b/sdk-js/src/lib/spanHooks/hookAwsSdk.js
@@ -8,7 +8,11 @@ module.exports = emitter => {
     for (const Service of Object.values(awsSdk)) {
       if (Service.serviceIdentifier) {
         Service.prototype.customizeRequests(req => {
-          req.on('complete', res => emitter.emit('span', captureAwsRequestSpan(res)));
+          req.on('complete', res => {
+            if (!process.env.SERVERLESS_ENTERPRISE_SPANS_IGNORE_AWS_SDK) {
+              emitter.emit('span', captureAwsRequestSpan(res));
+            }
+          });
           return req;
         });
       }


### PR DESCRIPTION
This PR adds functionality to the sdk-js that allows the user to skip the collection of span information on the AWS SDK if the `SERVERLESS_ENTERPRISE_SPANS_IGNORE_AWS_SDK` env var is set in their lambda.

Here is the invocation explorer in Pro WITHOUT the env var set:
![Pro_with_AWS_span](https://user-images.githubusercontent.com/895892/74462728-f2bad400-4e4d-11ea-87ae-06c8ba97fe7a.png)
Here is the same function WITH the env var set:
![Pro_without_AWS_span](https://user-images.githubusercontent.com/895892/74462768-ff3f2c80-4e4d-11ea-86ea-fe79bb043a7d.png)

Test plan: 
- [x] Create a simple lambda function with an S3 put or get, run function, verifiy span in explorer
- [x] Add `SERVERLESS_ENTERPRISE_SPANS_IGNORE_AWS_SDK` env var to lambda, verify absence of span in explorer