### PR TITLE
Fix AttributeError when error response None

### DIFF
--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -405,7 +405,7 @@ class SDK(object):
                     response = wrapped(*args, **kwargs)
                     return response
                 except Exception as error:
-                    if hasattr(error, "response"):
+                    if getattr(error, "response", None) is not None:
                         response = error.response
                     else:
                         response = {}


### PR DESCRIPTION
The `error` can have a `response` attribute with the value `None`, but
the existing handling assumes any `error.response` is a `dict` (or at
least, has a `get` method). This causes an `AttributeError` when we try
to use it.

This commit fixes the error by setting `response = {}` when there is no
`error.response` _or_ it is `None`, rather than only in the former case.