### PR TITLE
Fix error reporting in log group name resolution

### DIFF
--- a/lib/logsCollection.js
+++ b/lib/logsCollection.js
@@ -79,15 +79,15 @@ module.exports = async ctx => {
     let logGroupName = logGroups[logGroupIndex].resource.Properties.LogGroupName;
 
     if (typeof logGroupName !== 'string') {
+      if (!logGroupName || !logGroupName['Fn::Join']) {
+        throw new Error(
+          `Unable to resolve '${logGroupIndex}' log group name out of: ${inspect(
+            logGroups[logGroupIndex].resource.Properties
+          )}`
+        );
+      }
       if (logGroupName['Fn::Join']) {
         logGroupName = logGroupName['Fn::Join'][1].join(logGroupName['Fn::Join'][0]);
-        if (!logGroupName) {
-          throw new Error(
-            `Unable to resolve log group name out of: ${inspect(
-              logGroups[logGroupIndex].resource.Properties.LogGroupName
-            )}`
-          );
-        }
       } else {
         continue;
       }

--- a/lib/logsCollection.test.js
+++ b/lib/logsCollection.test.js
@@ -111,4 +111,55 @@ describe('logsCollection', () => {
       },
     });
   });
+
+  it('handles invalid logGroup definition', async () => {
+    const log = sinon.spy();
+    const request = async () => ({ Account: 'ACCOUNT_ID' });
+    const getStage = sinon.stub().returns('dev');
+    const getRegion = sinon.stub().returns('us-east-1');
+    const getServiceName = sinon.stub().returns('serviceName');
+    const ctx = {
+      sls: {
+        cli: { log },
+        service: {
+          org: 'org',
+          app: 'app',
+          appUid: 'app123',
+          orgUid: 'org123',
+          custom: { enterprise: { collectLambdaLogs: true } },
+          getServiceName,
+          provider: {
+            compiledCloudFormationTemplate: {
+              Resources: {
+                lambdaLogs: {
+                  Type: 'AWS::Logs::LogGroup',
+                  Properties: {
+                    LogGroupName: '/aws/lambda/service-name-dev-func',
+                  },
+                },
+                apiGatewayLogs: {
+                  Type: 'AWS::Logs::LogGroup',
+                  Properties: {
+                    LogGroupName: null,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      provider: {
+        request,
+        getStage,
+        getRegion,
+      },
+    };
+    const that = { serverless: { classes: { Error } } };
+    try {
+      await logsCollection.call(that, ctx);
+      throw new Error('Unexpected');
+    } catch (error) {
+      expect(error.message.startsWith('Unable to resolve ')).to.be.true;
+    }
+  });
 });


### PR DESCRIPTION
Follow up to #358 which didn't provide a correct patch. This time it should be right