### PR TITLE
Ensure no meta log when collectLambdaLogs is false

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -33,6 +33,9 @@ appUid: '${ctx.sls.service.appUid}',
 orgUid: '${ctx.sls.service.orgUid}',
 deploymentUid: '${ctx.deploymentUid}',
 serviceName: '${ctx.sls.service.service}',
+shouldLogMeta: ${!ctx.sls.service.custom ||
+    !ctx.sls.service.custom.enterprise ||
+    ctx.sls.service.custom.enterprise.collectLambdaLogs !== false},
 stageName: '${ctx.provider.getStage()}',
 pluginVersion: '${version}'})
 const handlerWrapperArgs = { functionName: '${fn.name}', timeout: ${fn.timeout}}
@@ -60,6 +63,13 @@ sdk = serverless_sdk.SDK(
     org_uid='${ctx.sls.service.orgUid}',
     deployment_uid='${ctx.deploymentUid}',
     service_name='${ctx.sls.service.service}',
+    should_log_meta=${
+      !ctx.sls.service.custom ||
+      !ctx.sls.service.custom.enterprise ||
+      ctx.sls.service.custom.enterprise.collectLambdaLogs !== false
+        ? 'True'
+        : 'False'
+    },
     stage_name='${ctx.provider.getStage()}',
     plugin_version='${version}'
 )

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -155,6 +155,7 @@ appUid: 'appUid',
 orgUid: 'orgUid',
 deploymentUid: 'deploymentUid',
 serviceName: 'service',
+shouldLogMeta: true,
 stageName: 'dev',
 pluginVersion: '${version}'})
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
@@ -233,6 +234,7 @@ appUid: 'appUid',
 orgUid: 'orgUid',
 deploymentUid: 'deploymentUid',
 serviceName: 'service',
+shouldLogMeta: true,
 stageName: 'dev',
 pluginVersion: '${version}'})
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
@@ -338,6 +340,7 @@ appUid: 'appUid',
 orgUid: 'orgUid',
 deploymentUid: 'deploymentUid',
 serviceName: 'service',
+shouldLogMeta: true,
 stageName: 'dev',
 pluginVersion: '${version}'})
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
@@ -361,6 +364,7 @@ sdk = serverless_sdk.SDK(
     org_uid='orgUid',
     deployment_uid='deploymentUid',
     service_name='service',
+    should_log_meta=True,
     stage_name='dev',
     plugin_version='${version}'
 )

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -42,6 +42,7 @@ class ServerlessSDK {
     this.$.serviceName = obj.serviceName || null;
     this.$.stageName = obj.stageName || null;
     this.$.pluginVersion = obj.pluginVersion || null;
+    this.shouldLogMeta = obj.shouldLogMeta;
   }
 
   /*
@@ -142,6 +143,7 @@ class ServerlessSDK {
           functionName: meta.functionName,
           timeout: meta.timeout,
           computeType: meta.computeType,
+          shouldLogMeta: this.shouldLogMeta,
           eventType,
         });
 

--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -73,6 +73,7 @@ class Transaction {
     }
 
     this.processed = false;
+    this.shouldLogMeta = data.shouldLogMeta;
     transactionCount += 1;
     this.$ = {
       schema: null,
@@ -243,6 +244,7 @@ class Transaction {
   }
 
   buildOutput(type) {
+    if (!this.shouldLogMeta) return;
     if (!this.processed) {
       // End transaction timer
       const duration = nanosecondnow() - this.$.duration;

--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -90,6 +90,7 @@ class SDK(object):
         org_uid,
         deployment_uid,
         service_name,
+        should_log_meta,
         stage_name,
         plugin_version,
     ):
@@ -99,6 +100,7 @@ class SDK(object):
         self.org_uid = org_uid
         self.deployment_uid = deployment_uid
         self.service_name = service_name
+        self.should_log_meta = should_log_meta
         self.stage_name = stage_name
         self.plugin_version = plugin_version
         self.invokation_count = 0
@@ -372,8 +374,9 @@ class SDK(object):
                 "schemaVersion": "0.0",
                 "timestamp": end_isoformat,
             }
-            print("SERVERLESS_ENTERPRISE {}".format(
-                json.dumps(transaction_data)))
+            if self.should_log_meta:
+                print("SERVERLESS_ENTERPRISE {}".format(
+                    json.dumps(transaction_data)))
             if exception and error_data["errorFatal"]:
                 raise exception
 


### PR DESCRIPTION
We should not log meta (`SERVERLESS_ENTERPRISE`) log, when we do not consume lambda logs.

This patch fixes that.

I've confirmed by running integration tests, that logging works as expected (when `collectLambdaLogs` is not false). 