### PR TITLE
Revert "Allow users to skip AWS_SDK span collections with env var"

### DIFF
--- a/sdk-js/src/lib/spanHooks/hookAwsSdk.js
+++ b/sdk-js/src/lib/spanHooks/hookAwsSdk.js
@@ -8,11 +8,7 @@ module.exports = emitter => {
     for (const Service of Object.values(awsSdk)) {
       if (Service.serviceIdentifier) {
         Service.prototype.customizeRequests(req => {
-          req.on('complete', res => {
-            if (!process.env.SERVERLESS_ENTERPRISE_SPANS_IGNORE_AWS_SDK) {
-              emitter.emit('span', captureAwsRequestSpan(res));
-            }
-          });
+          req.on('complete', res => emitter.emit('span', captureAwsRequestSpan(res)));
           return req;
         });
       }


### PR DESCRIPTION
Reverts serverless/enterprise-plugin#367

As agreement is to support this setting via `serverless.yml` config