### PR TITLE
Automatically set API endpoint with route inferred from framework

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -47,7 +47,12 @@ disableHttpSpans: ${Boolean(
       ctx.sls.service.custom.enterprise.disableHttpSpans
   )},
 stageName: '${ctx.provider.getStage()}',
-pluginVersion: '${version}'})
+pluginVersion: '${version}',
+disableFrameworkInstrumentation=${Boolean(
+    ctx.sls.service.custom &&
+      ctx.sls.service.custom.enterprise &&
+      ctx.sls.service.custom.enterprise.disableFrameworkInstrumentation
+  )}})
 const handlerWrapperArgs = { functionName: '${fn.name}', timeout: ${fn.timeout}}
 try {
   const userHandler = require('./${fn.entryOrig}.js')
@@ -99,7 +104,7 @@ sdk = serverless_sdk.SDK(
     disable_framework_instrumentation=${
       ctx.sls.service.custom &&
       ctx.sls.service.custom.enterprise &&
-      ctx.sls.service.custom.enterprise.disableFrameworks
+      ctx.sls.service.custom.enterprise.disableFrameworkInstrumentation
         ? 'True'
         : 'False'
     }

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -48,10 +48,10 @@ disableHttpSpans: ${Boolean(
   )},
 stageName: '${ctx.provider.getStage()}',
 pluginVersion: '${version}',
-disableFrameworkInstrumentation: ${Boolean(
+disableFrameworksInstrumentation: ${Boolean(
     ctx.sls.service.custom &&
       ctx.sls.service.custom.enterprise &&
-      ctx.sls.service.custom.enterprise.disableFrameworkInstrumentation
+      ctx.sls.service.custom.enterprise.disableFrameworksInstrumentation
   )}})
 const handlerWrapperArgs = { functionName: '${fn.name}', timeout: ${fn.timeout}}
 try {
@@ -101,10 +101,10 @@ sdk = serverless_sdk.SDK(
     },
     stage_name='${ctx.provider.getStage()}',
     plugin_version='${version}',
-    disable_framework_instrumentation=${
+    disable_frameworks_instrumentation=${
       ctx.sls.service.custom &&
       ctx.sls.service.custom.enterprise &&
-      ctx.sls.service.custom.enterprise.disableFrameworkInstrumentation
+      ctx.sls.service.custom.enterprise.disableFrameworksInstrumentation
         ? 'True'
         : 'False'
     }

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -48,7 +48,7 @@ disableHttpSpans: ${Boolean(
   )},
 stageName: '${ctx.provider.getStage()}',
 pluginVersion: '${version}',
-disableFrameworkInstrumentation=${Boolean(
+disableFrameworkInstrumentation: ${Boolean(
     ctx.sls.service.custom &&
       ctx.sls.service.custom.enterprise &&
       ctx.sls.service.custom.enterprise.disableFrameworkInstrumentation

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -95,7 +95,14 @@ sdk = serverless_sdk.SDK(
         : 'False'
     },
     stage_name='${ctx.provider.getStage()}',
-    plugin_version='${version}'
+    plugin_version='${version}',
+    disable_framework_instrumentation=${
+      ctx.sls.service.custom &&
+      ctx.sls.service.custom.enterprise &&
+      ctx.sls.service.custom.enterprise.disableFrameworks
+        ? 'True'
+        : 'False'
+    }
 )
 handler_wrapper_kwargs = {'function_name': '${fn.name}', 'timeout': ${fn.timeout}}
 try:

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -159,8 +159,8 @@ shouldLogMeta: true,
 disableAwsSpans: false,
 disableHttpSpans: false,
 stageName: 'dev',
-pluginVersion: '${version}'},
-disableFrameworkInstrumentation: false)
+pluginVersion: '${version}',
+disableFrameworkInstrumentation: false})
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
 try {
   const userHandler = require('./handlerFile.js')
@@ -241,8 +241,8 @@ shouldLogMeta: true,
 disableAwsSpans: false,
 disableHttpSpans: false,
 stageName: 'dev',
-pluginVersion: '${version}'},
-disableFrameworkInstrumentation: false)
+pluginVersion: '${version}',
+disableFrameworkInstrumentation: false})
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
 try {
   const userHandler = require('./handlerFile.js')
@@ -350,8 +350,8 @@ shouldLogMeta: true,
 disableAwsSpans: false,
 disableHttpSpans: false,
 stageName: 'dev',
-pluginVersion: '${version}'},
-disableFrameworkInstrumentation: false)
+pluginVersion: '${version}',
+disableFrameworkInstrumentation: false})
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
 try {
   const userHandler = require('./handlerFile.js')

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -160,7 +160,7 @@ disableAwsSpans: false,
 disableHttpSpans: false,
 stageName: 'dev',
 pluginVersion: '${version}',
-disableFrameworkInstrumentation: false})
+disableFrameworksInstrumentation: false})
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
 try {
   const userHandler = require('./handlerFile.js')
@@ -242,7 +242,7 @@ disableAwsSpans: false,
 disableHttpSpans: false,
 stageName: 'dev',
 pluginVersion: '${version}',
-disableFrameworkInstrumentation: false})
+disableFrameworksInstrumentation: false})
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
 try {
   const userHandler = require('./handlerFile.js')
@@ -351,7 +351,7 @@ disableAwsSpans: false,
 disableHttpSpans: false,
 stageName: 'dev',
 pluginVersion: '${version}',
-disableFrameworkInstrumentation: false})
+disableFrameworksInstrumentation: false})
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
 try {
   const userHandler = require('./handlerFile.js')
@@ -378,7 +378,7 @@ sdk = serverless_sdk.SDK(
     disable_http_spans=False,
     stage_name='dev',
     plugin_version='${version}',
-    disable_framework_instrumentation=False
+    disable_frameworks_instrumentation=False
 )
 handler_wrapper_kwargs = {'function_name': 'service-dev-dunc', 'timeout': 6}
 try:

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -374,7 +374,8 @@ sdk = serverless_sdk.SDK(
     disable_aws_spans=False,
     disable_http_spans=False,
     stage_name='dev',
-    plugin_version='${version}'
+    plugin_version='${version}',
+    disable_framework_instrumentation=False
 )
 handler_wrapper_kwargs = {'function_name': 'service-dev-dunc', 'timeout': 6}
 try:

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -159,7 +159,8 @@ shouldLogMeta: true,
 disableAwsSpans: false,
 disableHttpSpans: false,
 stageName: 'dev',
-pluginVersion: '${version}'})
+pluginVersion: '${version}'},
+disableFrameworkInstrumentation: false)
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
 try {
   const userHandler = require('./handlerFile.js')
@@ -240,7 +241,8 @@ shouldLogMeta: true,
 disableAwsSpans: false,
 disableHttpSpans: false,
 stageName: 'dev',
-pluginVersion: '${version}'})
+pluginVersion: '${version}'},
+disableFrameworkInstrumentation: false)
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
 try {
   const userHandler = require('./handlerFile.js')
@@ -348,7 +350,8 @@ shouldLogMeta: true,
 disableAwsSpans: false,
 disableHttpSpans: false,
 stageName: 'dev',
-pluginVersion: '${version}'})
+pluginVersion: '${version}'},
+disableFrameworkInstrumentation: false)
 const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
 try {
   const userHandler = require('./handlerFile.js')

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -53,7 +53,7 @@ class ServerlessSDK {
     }
     if (!obj.disableAwsSpans) require('./lib/spanHooks/hookAwsSdk')(spanEmitter);
     if (!obj.disableHttpSpans) require('./lib/spanHooks/hookHttp')(spanEmitter);
-    if (!obj.disableFrameworkInstrumentation) {
+    if (!obj.disableFrameworksInstrumentation) {
       require('./lib/frameworks')(ServerlessSDK, this.config);
     }
   }

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -53,7 +53,9 @@ class ServerlessSDK {
     }
     if (!obj.disableAwsSpans) require('./lib/spanHooks/hookAwsSdk')(spanEmitter);
     if (!obj.disableHttpSpans) require('./lib/spanHooks/hookHttp')(spanEmitter);
-    if (!obj.disableFrameworks) require('./lib/frameworks')(ServerlessSDK, this.config);
+    if (!obj.disableFrameworkInstrumentation) {
+      require('./lib/frameworks')(ServerlessSDK, this.config);
+    }
   }
 
   /*

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -53,6 +53,7 @@ class ServerlessSDK {
     }
     if (!obj.disableAwsSpans) require('./lib/spanHooks/hookAwsSdk')(spanEmitter);
     if (!obj.disableHttpSpans) require('./lib/spanHooks/hookHttp')(spanEmitter);
+    if (!obj.disableFrameworks) require('./lib/frameworks')(ServerlessSDK, this.config);
   }
 
   /*

--- a/sdk-js/src/lib/frameworks/index.js
+++ b/sdk-js/src/lib/frameworks/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const express = require('./wrappers/express');
 const lambdaApi = require('./wrappers/lambda-api');
 

--- a/sdk-js/src/lib/frameworks/index.js
+++ b/sdk-js/src/lib/frameworks/index.js
@@ -1,0 +1,16 @@
+const express = require('./wrappers/express');
+const lambdaApi = require('./wrappers/lambda-api');
+
+function wrap(wrapper, sdk, config) {
+  try {
+    wrapper.init(sdk, config);
+  } catch (err) {
+    if (config && config.debug === true) {
+      console.debug('error initializing wrapper', err);
+    }
+  }
+}
+
+module.exports = (sdk, config) => {
+  [express, lambdaApi].forEach(wrapper => wrap(wrapper, sdk, config));
+};

--- a/sdk-js/src/lib/frameworks/wrappers/express.js
+++ b/sdk-js/src/lib/frameworks/wrappers/express.js
@@ -9,6 +9,7 @@ module.exports.init = (sdk, config) => {
       const defaultImplementation = Route.prototype.dispatch;
       Route.prototype.dispatch = function handle(req, res, next) {
         try {
+          // eslint-disable-next-line no-underscore-dangle
           sdk._setEndpoint(req.route ? req.route.path : req.path);
         } catch (err) {
           if (config && config.debug === true) {

--- a/sdk-js/src/lib/frameworks/wrappers/express.js
+++ b/sdk-js/src/lib/frameworks/wrappers/express.js
@@ -1,0 +1,26 @@
+const requireHook = require('require-in-the-middle');
+
+module.exports.init = (sdk, config) => {
+  requireHook(['express'], express => {
+    try {
+      const Route = express.Route;
+      const defaultImplementation = Route.prototype.dispatch;
+      Route.prototype.dispatch = function handle(req, res, next) {
+        try {
+          sdk._setEndpoint(req.route ? req.route.path : req.path);
+        } catch (err) {
+          if (config && config.debug === true) {
+            console.debug('error setting endpoint with express route', err);
+          }
+        } finally {
+          defaultImplementation.call(this, req, res, next);
+        }
+      };
+    } catch (err) {
+      if (config && config.debug === true) {
+        console.debug('error setting up express hook', err);
+      }
+    }
+    return express;
+  });
+};

--- a/sdk-js/src/lib/frameworks/wrappers/express.js
+++ b/sdk-js/src/lib/frameworks/wrappers/express.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const requireHook = require('require-in-the-middle');
 
 module.exports.init = (sdk, config) => {

--- a/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
+++ b/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const requireHook = require('require-in-the-middle');
 
 module.exports.init = (sdk, config) => {

--- a/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
+++ b/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
@@ -9,6 +9,7 @@ module.exports.init = (sdk, config) => {
       try {
         api.use((req, res, next) => {
           try {
+            // eslint-disable-next-line no-underscore-dangle
             sdk._setEndpoint(req.route);
           } catch (err) {
             if (config && config.debug) {

--- a/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
+++ b/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
@@ -1,0 +1,27 @@
+const requireHook = require('require-in-the-middle');
+
+module.exports.init = (sdk, config) => {
+  requireHook(['lambda-api'], lambdaApi => {
+    return function(args) {
+      const api = lambdaApi(args);
+      try {
+        api.use((req, res, next) => {
+          try {
+            sdk._setEndpoint(req.route);
+          } catch (err) {
+            if (config && config.debug) {
+              console.debug('error setting endpoint with lambda-api route', err);
+            }
+          } finally {
+            next();
+          }
+        });
+      } catch (err) {
+        if (config && config.debug) {
+          console.debug('error instrumenting lambda-api middleware', err);
+        }
+      }
+      return api;
+    };
+  });
+};

--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -95,7 +95,7 @@ class SDK(object):
         disable_http_spans,
         stage_name,
         plugin_version,
-        disable_framework_instrumentation,
+        disable_frameworks_instrumentation,
     ):
         self.org_id = org_id
         self.application_name = application_name
@@ -118,7 +118,7 @@ class SDK(object):
         self.instrument_stdlib_urllib("urllib.request")
         self.instrument_stdlib_urllib("urllib2")
 
-        if not disable_framework_instrumentation:
+        if not disable_frameworks_instrumentation:
             self.instrument_flask("flask")
 
     def handler(self, user_handler, function_name, timeout):

--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -95,6 +95,7 @@ class SDK(object):
         disable_http_spans,
         stage_name,
         plugin_version,
+        disable_framework_instrumentation,
     ):
         self.org_id = org_id
         self.application_name = application_name
@@ -116,6 +117,9 @@ class SDK(object):
         self.instrument_urllib3()
         self.instrument_stdlib_urllib("urllib.request")
         self.instrument_stdlib_urllib("urllib2")
+
+        if not disable_framework_instrumentation:
+            self.instrument_flask("flask")
 
     def handler(self, user_handler, function_name, timeout):
         def wrapped_handler(event, context):
@@ -547,5 +551,31 @@ class SDK(object):
         try:
             wrapt.wrap_function_wrapper(
                 module, "AbstractHTTPHandler.do_open", wrapper)
+        except ImportError:
+            pass
+
+    def instrument_flask(self, module):
+        def wrap_add_url_rule(wrapped, app, args, kwargs):
+            args = list(args)
+            rule = args.pop(0)
+            try:
+                endpoint = kwargs.pop('endpoint')
+            except KeyError:
+                endpoint = args.pop(0)
+            try:
+                view_func = kwargs.pop('view_func')
+            except KeyError:
+                view_func = args.pop(0)
+            def wrap_view_func(**req_args):
+              try:
+                  return view_func(**req_args)
+              finally:
+                  try:
+                      set_endpoint(rule)
+                  except:
+                      pass
+            return wrapped(rule, endpoint, wrap_view_func, *args, **kwargs)
+        try:
+            wrapt.wrap_function_wrapper(module, "Flask.add_url_rule", wrap_add_url_rule)
         except ImportError:
             pass


### PR DESCRIPTION
Supported frameworks:
1. express v4.x
2. lambda-api v0.10.x
3. flask v1.x