### PR TITLE
Fix authentication handling in case of params and outputs resolution

### DIFF
--- a/lib/isAuthenticated.js
+++ b/lib/isAuthenticated.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { getLoggedInUser } = require('@serverless/platform-sdk');
+
+module.exports = () => Boolean(getLoggedInUser() || process.env.SERVERLESS_ACCESS_KEY);

--- a/lib/outputCommand.js
+++ b/lib/outputCommand.js
@@ -3,7 +3,7 @@
 const { isEmpty, isObject, entries } = require('lodash');
 const chalk = require('chalk');
 const cliTable = require('cli-color/columns');
-const { getLoggedInUser } = require('@serverless/platform-sdk');
+const isAuthenticated = require('./isAuthenticated');
 const throwAuthError = require('./throwAuthError');
 const resolveOutputs = require('./resolveOutputs');
 const resolveOutput = require('./resolveOutput');
@@ -18,7 +18,7 @@ const resolveInput = function(ctx) {
     },
   } = ctx;
 
-  if (!getLoggedInUser()) throwAuthError(ctx.sls);
+  if (!isAuthenticated()) throwAuthError(ctx.sls);
 
   if (!org) throw new ServerlessError('Missing `org` setting', 'DASHBOARD_MISSING_ORG');
   if (!app) throw new ServerlessError('Missing `app` setting', 'DASHBOARD_MISSING_APP');

--- a/lib/paramCommand.js
+++ b/lib/paramCommand.js
@@ -3,7 +3,7 @@
 const { isEmpty, entries } = require('lodash');
 const chalk = require('chalk');
 const cliTable = require('cli-color/columns');
-const { getLoggedInUser } = require('@serverless/platform-sdk');
+const isAuthenticated = require('./isAuthenticated');
 const throwAuthError = require('./throwAuthError');
 const resolveParams = require('./resolveParams');
 
@@ -17,7 +17,7 @@ const resolveInput = function(ctx) {
     },
   } = ctx;
 
-  if (!getLoggedInUser()) throwAuthError(ctx.sls);
+  if (!isAuthenticated()) throwAuthError(ctx.sls);
 
   if (!org) throw new ServerlessError('Missing `org` setting', 'DASHBOARD_MISSING_ORG');
   if (!app) throw new ServerlessError('Missing `app` setting', 'DASHBOARD_MISSING_APP');

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -3,11 +3,7 @@
 const chalk = require('chalk');
 const _ = require('lodash');
 const updateNotifier = require('update-notifier');
-const {
-  configureFetchDefaults,
-  getLoggedInUser,
-  openBrowser,
-} = require('@serverless/platform-sdk');
+const { configureFetchDefaults, openBrowser } = require('@serverless/platform-sdk');
 const sfePkgJson = require('../package');
 const errorHandler = require('./errorHandler');
 const logsCollection = require('./logsCollection');
@@ -31,6 +27,7 @@ const setApiGatewayAccessLogFormat = require('./setApiGatewayAccessLogFormat');
 const interactiveCli = require('./interactiveCli');
 const paramCommand = require('./paramCommand');
 const outputCommand = require('./outputCommand');
+const isAuthenticated = require('./isAuthenticated');
 const throwAuthError = require('./throwAuthError');
 
 /*
@@ -459,11 +456,10 @@ class ServerlessEnterprisePlugin {
     if (!this.sls.service.service) {
       missingConfigSettings.push('service');
     }
-    const user = getLoggedInUser();
     const currentCommand = this.sls.processedInput.commands[0];
     if (
       missingConfigSettings.length === 0 &&
-      (user || process.env.SERVERLESS_ACCESS_KEY) &&
+      isAuthenticated() &&
       !['login', 'logout', 'generate-event'].includes(currentCommand)
     ) {
       this.sls.enterpriseEnabled = true;

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -57,6 +57,7 @@ describe('plugin', () => {
       './generateEvent': { eventDict: {}, generate },
       './deployProfile': { configureDeployProfile },
       './injectLogsIamRole': injectLogsIamRole,
+      './isAuthenticated': () => true,
       './setApiGatewayAccessLogFormat': setApiGatewayAccessLogFormat,
       '@serverless/platform-sdk': {
         configureFetchDefaults: () => {},

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const resolveOutput = require('./resolveOutput');
 const resolveParams = require('./resolveParams');
+const throwAuthError = require('./throwAuthError');
 
 // functions for new way of getting variables
 const getValueFromDashboardParams = ctx => async variableString => {
@@ -16,6 +17,7 @@ const getValueFromDashboardParams = ctx => async variableString => {
     return '';
   }
 
+  if (!ctx.sls.enterpriseEnabled) throwAuthError(ctx.sls);
   const secrets = await resolveParams({
     org: ctx.sls.service.org,
     app: ctx.sls.service.app,
@@ -63,6 +65,7 @@ const getValueFromDashboardOutputs = ctx => async variableString => {
   }
   const outputName = key.split('.')[1];
   const subkey = key.slice(outputName.length + 2);
+  if (!ctx.sls.enterpriseEnabled) throwAuthError(ctx.sls);
   const value = resolveOutput(outputName, {
     service,
     app,

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -59,6 +59,7 @@ describe('variables', () => {
         processedInput: {
           commands: [],
         },
+        enterpriseEnabled: true,
       },
       provider: {
         getStage: () => 'stage',
@@ -123,6 +124,7 @@ describe('variables', () => {
         processedInput: {
           commands: [],
         },
+        enterpriseEnabled: true,
       },
       provider: {
         getStage: () => 'stage',


### PR DESCRIPTION
PR fixes following bugs:

- Resolution of param and output variables crashed with dirty error when user was not logged.
- Due invalid authentication flow `SERVERLESS_ACCESS_KEY` was not supported in `param` and `output` commands
