### PR TITLE
Add usage tracking on setEndpoint SDK method

### DIFF
--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -335,8 +335,9 @@ class ServerlessSDK {
         // eslint-disable-next-line no-underscore-dangle
         ServerlessSDK._tagEvent = contextProxy.serverlessSdk.tagEvent;
 
-        contextProxy.serverlessSdk.setEndpoint = endpoint => {
+        contextProxy.serverlessSdk.setEndpoint = (endpoint, metadata) => {
           trans.$.schema.endpoint = endpoint;
+          trans.$.schema.endpointMechanism = metadata ? metadata.mechanism : 'explicit';
         };
         // eslint-disable-next-line no-underscore-dangle
         ServerlessSDK._setEndpoint = contextProxy.serverlessSdk.setEndpoint;
@@ -393,9 +394,9 @@ class ServerlessSDK {
     ServerlessSDK._tagEvent(label, tag, custom);
   }
 
-  static setEndpoint(endpoint) {
+  static setEndpoint(endpoint, metadata) {
     // eslint-disable-next-line no-underscore-dangle
-    ServerlessSDK._setEndpoint(endpoint);
+    ServerlessSDK._setEndpoint(endpoint, metadata);
   }
 }
 

--- a/sdk-js/src/lib/frameworks/wrappers/express.js
+++ b/sdk-js/src/lib/frameworks/wrappers/express.js
@@ -10,7 +10,9 @@ module.exports.init = (sdk, config) => {
       Route.prototype.dispatch = function handle(req, res, next) {
         try {
           // eslint-disable-next-line no-underscore-dangle
-          sdk._setEndpoint(req.route ? req.route.path : req.path);
+          sdk._setEndpoint(req.route ? req.route.path : req.path, {
+            mechanism: 'express-middleware',
+          });
         } catch (err) {
           if (config && config.debug === true) {
             console.debug('error setting endpoint with express route', err);

--- a/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
+++ b/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
@@ -10,7 +10,7 @@ module.exports.init = (sdk, config) => {
         api.use((req, res, next) => {
           try {
             // eslint-disable-next-line no-underscore-dangle
-            sdk._setEndpoint(req.route);
+            sdk._setEndpoint(req.route, { mechanism: 'lambda-api-middleware' });
           } catch (err) {
             if (config && config.debug) {
               console.debug('error setting endpoint with lambda-api route', err);

--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -106,6 +106,7 @@ class Transaction {
     this.$.schema.compute.instanceInvocationCount = transactionCount;
     this.$.schema.totalSpans = 0;
     this.$.schema.endpoint = data.endpoint;
+    this.$.schema.endpointMeta = data.endpointEndpointMeta;
 
     // Track uptime of container
     this.$.schema.compute.containerUptime = process.uptime();

--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -106,7 +106,6 @@ class Transaction {
     this.$.schema.compute.instanceInvocationCount = transactionCount;
     this.$.schema.totalSpans = 0;
     this.$.schema.endpoint = data.endpoint;
-    this.$.schema.endpointMeta = data.endpointEndpointMeta;
 
     // Track uptime of container
     this.$.schema.compute.containerUptime = process.uptime();


### PR DESCRIPTION
Logs out a field: `endpointMechanism` that indicates if the endpoint was
set explicitly via a SDK call (log field value: `explicit`) or if set via
framework instrumentation (e.g. `express-middleware`).