### PR TITLE
Create new handler for dev mode, create start/stop SDK calls

### DIFF
--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -28,7 +28,7 @@ const isDevMode = Boolean(process.env.SLS_DEV_MODE);
  * Wrap Node.js Functions
  */
 const wrapNodeJs = (fn, ctx, accessKey) => {
-  const newHandlerCode = `var serverlessSDK = require('./serverless_sdk/index.js')
+  let newHandlerCode = `var serverlessSDK = require('./serverless_sdk/index.js')
 serverlessSDK = new serverlessSDK({
 orgId: '${ctx.sls.service.org}',
 applicationName: '${ctx.sls.service.app}',
@@ -67,6 +67,72 @@ try {
   module.exports.handler = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)
 }
 `;
+
+  /**
+   * If you're in "dev mode" export a slightly different wrapped handler. Basically, we need to:
+   *
+   * 1. Establish a connection to the websocket so we can collect logs and metrics
+   * 2. Call the user handler
+   */
+  if (isDevMode) {
+    newHandlerCode = `
+      module.exports.handler = async (...args) => {
+        var serverlessSDK = require('./serverless_sdk/index.js')
+      
+        serverlessSDK = new serverlessSDK({
+          orgId: '${ctx.sls.service.org}',
+          applicationName: '${ctx.sls.service.app}',
+          appUid: '${ctx.sls.service.appUid}',
+          orgUid: '${ctx.sls.service.orgUid}',
+          deploymentUid: '${ctx.deploymentUid}',
+          serviceName: '${ctx.sls.service.service}',
+          shouldLogMeta: ${!ctx.sls.service.custom ||
+            !ctx.sls.service.custom.enterprise ||
+            ctx.sls.service.custom.enterprise.collectLambdaLogs !== false},
+          disableAwsSpans: ${Boolean(
+            ctx.sls.service.custom &&
+              ctx.sls.service.custom.enterprise &&
+              ctx.sls.service.custom.enterprise.disableAwsSpans
+          )},
+          disableHttpSpans: ${Boolean(
+            ctx.sls.service.custom &&
+              ctx.sls.service.custom.enterprise &&
+              ctx.sls.service.custom.enterprise.disableHttpSpans
+          )},
+          stageName: '${ctx.provider.getStage()}',
+          serverlessPlatformStage: '${process.env.SERVERLESS_PLATFORM_STAGE || 'prod'}',
+          devModeEnabled: ${isDevMode},
+          accessKey: ${isDevMode ? `'${accessKey}'` : null},
+          pluginVersion: '${version}',
+          disableFrameworksInstrumentation: ${Boolean(
+            ctx.sls.service.custom &&
+              ctx.sls.service.custom.enterprise &&
+              ctx.sls.service.custom.enterprise.disableFrameworksInstrumentation
+          )}
+        })
+
+        const handlerWrapperArgs = { functionName: '${fn.name}', timeout: ${fn.timeout} };
+
+        let result = null;
+  
+        try {
+          await serverlessSDK.startDevMode();
+          
+          const userHandler = require('./${fn.entryOrig}.js');
+          result = serverlessSDK.handler(userHandler.${
+            fn.handlerOrig
+          }, handlerWrapperArgs)(...args);
+         
+        } catch (error) {
+          result = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)(...args);
+        } finally {
+          serverlessSDK.stopDevMode();
+        }
+        
+        return result;
+      };
+    `;
+  }
 
   // Create new handlers
   fs.writeFileSync(path.join(ctx.sls.config.servicePath, `${fn.entryNew}.js`), newHandlerCode);

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -29,13 +29,12 @@ const isDevMode = Boolean(process.env.SLS_DEV_MODE);
  */
 const wrapNodeJs = (fn, ctx, accessKey) => {
   const standardHandlerExec = `
-  try {
-    const userHandler = require('./${fn.entryOrig}.js');
-    module.exports.handler = serverlessSDK.handler(userHandler.${fn.handlerOrig}, handlerWrapperArgs);
-  } catch (error) {
-    module.exports.handler = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs);
-  }
-  `;
+try {
+  const userHandler = require('./${fn.entryOrig}.js');
+  module.exports.handler = serverlessSDK.handler(userHandler.${fn.handlerOrig}, handlerWrapperArgs);
+} catch (error) {
+  module.exports.handler = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs);
+}`;
 
   /**
    * If you're in "dev mode" export a slightly different wrapped handler. Basically, we need to:
@@ -44,63 +43,59 @@ const wrapNodeJs = (fn, ctx, accessKey) => {
    * 2. Call the user handler
    */
   const devModeHandlerExec = `
-  module.exports.handler = (...args) => {
-    return serverlessSDK.startDevMode().then(() => {
-      let result = null;
+module.exports.handler = (...args) => {
+  return serverlessSDK.startDevMode().then(() => {
+    let result = null;
 
-      try {
-        const userHandler = require('./${fn.entryOrig}.js');
-        result = serverlessSDK.handler(userHandler.${fn.handlerOrig}, handlerWrapperArgs)(...args);
-      } catch (error) {
-        result = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)(...args);
-      } finally {
-        serverlessSDK.stopDevMode();
-      }
+    try {
+      const userHandler = require('./${fn.entryOrig}.js');
+      result = serverlessSDK.handler(userHandler.${fn.handlerOrig}, handlerWrapperArgs)(...args);
+    } catch (error) {
+      result = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)(...args);
+    } finally {
+      serverlessSDK.stopDevMode();
+    }
 
-      return result;
-    });
-  };
-  `;
+    return result;
+  });
+};`;
 
   const newHandlerCode = `
-  var serverlessSDK = require('./serverless_sdk/index.js');
+var serverlessSDK = require('./serverless_sdk/index.js');
+serverlessSDK = new serverlessSDK({
+  orgId: '${ctx.sls.service.org}',
+  applicationName: '${ctx.sls.service.app}',
+  appUid: '${ctx.sls.service.appUid}',
+  orgUid: '${ctx.sls.service.orgUid}',
+  deploymentUid: '${ctx.deploymentUid}',
+  serviceName: '${ctx.sls.service.service}',
+  shouldLogMeta: ${!ctx.sls.service.custom ||
+    !ctx.sls.service.custom.enterprise ||
+    ctx.sls.service.custom.enterprise.collectLambdaLogs !== false},
+  disableAwsSpans: ${Boolean(
+    ctx.sls.service.custom &&
+      ctx.sls.service.custom.enterprise &&
+      ctx.sls.service.custom.enterprise.disableAwsSpans
+  )},
+  disableHttpSpans: ${Boolean(
+    ctx.sls.service.custom &&
+      ctx.sls.service.custom.enterprise &&
+      ctx.sls.service.custom.enterprise.disableHttpSpans
+  )},
+  stageName: '${ctx.provider.getStage()}',
+  serverlessPlatformStage: '${process.env.SERVERLESS_PLATFORM_STAGE || 'prod'}',
+  devModeEnabled: ${isDevMode},
+  accessKey: ${isDevMode ? `'${accessKey}'` : null},
+  pluginVersion: '${version}',
+  disableFrameworksInstrumentation: ${Boolean(
+    ctx.sls.service.custom &&
+      ctx.sls.service.custom.enterprise &&
+      ctx.sls.service.custom.enterprise.disableFrameworksInstrumentation
+  )}
+});
 
-  serverlessSDK = new serverlessSDK({
-    orgId: '${ctx.sls.service.org}',
-    applicationName: '${ctx.sls.service.app}',
-    appUid: '${ctx.sls.service.appUid}',
-    orgUid: '${ctx.sls.service.orgUid}',
-    deploymentUid: '${ctx.deploymentUid}',
-    serviceName: '${ctx.sls.service.service}',
-    shouldLogMeta: ${!ctx.sls.service.custom ||
-      !ctx.sls.service.custom.enterprise ||
-      ctx.sls.service.custom.enterprise.collectLambdaLogs !== false},
-    disableAwsSpans: ${Boolean(
-      ctx.sls.service.custom &&
-        ctx.sls.service.custom.enterprise &&
-        ctx.sls.service.custom.enterprise.disableAwsSpans
-    )},
-    disableHttpSpans: ${Boolean(
-      ctx.sls.service.custom &&
-        ctx.sls.service.custom.enterprise &&
-        ctx.sls.service.custom.enterprise.disableHttpSpans
-    )},
-    stageName: '${ctx.provider.getStage()}',
-    serverlessPlatformStage: '${process.env.SERVERLESS_PLATFORM_STAGE || 'prod'}',
-    devModeEnabled: ${isDevMode},
-    accessKey: ${isDevMode ? `'${accessKey}'` : null},
-    pluginVersion: '${version}',
-    disableFrameworksInstrumentation: ${Boolean(
-      ctx.sls.service.custom &&
-        ctx.sls.service.custom.enterprise &&
-        ctx.sls.service.custom.enterprise.disableFrameworksInstrumentation
-    )}
-  });
-
-  const handlerWrapperArgs = { functionName: '${fn.name}', timeout: ${fn.timeout} };
-
-  ${isDevMode ? devModeHandlerExec : standardHandlerExec}
-  `;
+const handlerWrapperArgs = { functionName: '${fn.name}', timeout: ${fn.timeout} };
+${isDevMode ? devModeHandlerExec : standardHandlerExec}`;
 
   // Create new handlers
   fs.writeFileSync(path.join(ctx.sls.config.servicePath, `${fn.entryNew}.js`), newHandlerCode);

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -44,7 +44,7 @@ try {
    */
   const devModeHandlerExec = `
 module.exports.handler = (...args) => {
-  return serverlessSDK.startDevMode().then(() => {
+  serverlessSDK.startDevMode().then(() => {
     try {
       const userHandler = require('./${fn.entryOrig}.js');
       serverlessSDK.handler(userHandler.${fn.handlerOrig}, handlerWrapperArgs)(...args);

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -45,18 +45,14 @@ try {
   const devModeHandlerExec = `
 module.exports.handler = (...args) => {
   return serverlessSDK.startDevMode().then(() => {
-    let result = null;
-
     try {
       const userHandler = require('./${fn.entryOrig}.js');
-      result = serverlessSDK.handler(userHandler.${fn.handlerOrig}, handlerWrapperArgs)(...args);
+      serverlessSDK.handler(userHandler.${fn.handlerOrig}, handlerWrapperArgs)(...args);
     } catch (error) {
-      result = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)(...args);
+      serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)(...args);
     } finally {
       serverlessSDK.stopDevMode();
     }
-
-    return result;
   });
 };`;
 

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -28,45 +28,14 @@ const isDevMode = Boolean(process.env.SLS_DEV_MODE);
  * Wrap Node.js Functions
  */
 const wrapNodeJs = (fn, ctx, accessKey) => {
-  let newHandlerCode = `var serverlessSDK = require('./serverless_sdk/index.js')
-serverlessSDK = new serverlessSDK({
-orgId: '${ctx.sls.service.org}',
-applicationName: '${ctx.sls.service.app}',
-appUid: '${ctx.sls.service.appUid}',
-orgUid: '${ctx.sls.service.orgUid}',
-deploymentUid: '${ctx.deploymentUid}',
-serviceName: '${ctx.sls.service.service}',
-shouldLogMeta: ${!ctx.sls.service.custom ||
-    !ctx.sls.service.custom.enterprise ||
-    ctx.sls.service.custom.enterprise.collectLambdaLogs !== false},
-disableAwsSpans: ${Boolean(
-    ctx.sls.service.custom &&
-      ctx.sls.service.custom.enterprise &&
-      ctx.sls.service.custom.enterprise.disableAwsSpans
-  )},
-disableHttpSpans: ${Boolean(
-    ctx.sls.service.custom &&
-      ctx.sls.service.custom.enterprise &&
-      ctx.sls.service.custom.enterprise.disableHttpSpans
-  )},
-stageName: '${ctx.provider.getStage()}',
-serverlessPlatformStage: '${process.env.SERVERLESS_PLATFORM_STAGE || 'prod'}',
-devModeEnabled: ${isDevMode},
-accessKey: ${isDevMode ? `'${accessKey}'` : null},
-pluginVersion: '${version}',
-disableFrameworksInstrumentation: ${Boolean(
-    ctx.sls.service.custom &&
-      ctx.sls.service.custom.enterprise &&
-      ctx.sls.service.custom.enterprise.disableFrameworksInstrumentation
-  )}})
-const handlerWrapperArgs = { functionName: '${fn.name}', timeout: ${fn.timeout}}
-try {
-  const userHandler = require('./${fn.entryOrig}.js')
-  module.exports.handler = serverlessSDK.handler(userHandler.${fn.handlerOrig}, handlerWrapperArgs)
-} catch (error) {
-  module.exports.handler = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)
-}
-`;
+  const standardHandlerExec = `
+  try {
+    const userHandler = require('./${fn.entryOrig}.js');
+    module.exports.handler = serverlessSDK.handler(userHandler.${fn.handlerOrig}, handlerWrapperArgs);
+  } catch (error) {
+    module.exports.handler = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs);
+  }
+  `;
 
   /**
    * If you're in "dev mode" export a slightly different wrapped handler. Basically, we need to:
@@ -74,65 +43,64 @@ try {
    * 1. Establish a connection to the websocket so we can collect logs and metrics
    * 2. Call the user handler
    */
-  if (isDevMode) {
-    newHandlerCode = `
-      module.exports.handler = async (...args) => {
-        var serverlessSDK = require('./serverless_sdk/index.js')
-      
-        serverlessSDK = new serverlessSDK({
-          orgId: '${ctx.sls.service.org}',
-          applicationName: '${ctx.sls.service.app}',
-          appUid: '${ctx.sls.service.appUid}',
-          orgUid: '${ctx.sls.service.orgUid}',
-          deploymentUid: '${ctx.deploymentUid}',
-          serviceName: '${ctx.sls.service.service}',
-          shouldLogMeta: ${!ctx.sls.service.custom ||
-            !ctx.sls.service.custom.enterprise ||
-            ctx.sls.service.custom.enterprise.collectLambdaLogs !== false},
-          disableAwsSpans: ${Boolean(
-            ctx.sls.service.custom &&
-              ctx.sls.service.custom.enterprise &&
-              ctx.sls.service.custom.enterprise.disableAwsSpans
-          )},
-          disableHttpSpans: ${Boolean(
-            ctx.sls.service.custom &&
-              ctx.sls.service.custom.enterprise &&
-              ctx.sls.service.custom.enterprise.disableHttpSpans
-          )},
-          stageName: '${ctx.provider.getStage()}',
-          serverlessPlatformStage: '${process.env.SERVERLESS_PLATFORM_STAGE || 'prod'}',
-          devModeEnabled: ${isDevMode},
-          accessKey: ${isDevMode ? `'${accessKey}'` : null},
-          pluginVersion: '${version}',
-          disableFrameworksInstrumentation: ${Boolean(
-            ctx.sls.service.custom &&
-              ctx.sls.service.custom.enterprise &&
-              ctx.sls.service.custom.enterprise.disableFrameworksInstrumentation
-          )}
-        })
+  const devModeHandlerExec = `
+  module.exports.handler = (...args) => {
+    return serverlessSDK.startDevMode().then(() => {
+      let result = null;
 
-        const handlerWrapperArgs = { functionName: '${fn.name}', timeout: ${fn.timeout} };
+      try {
+        const userHandler = require('./${fn.entryOrig}.js');
+        result = serverlessSDK.handler(userHandler.${fn.handlerOrig}, handlerWrapperArgs)(...args);
+      } catch (error) {
+        result = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)(...args);
+      } finally {
+        serverlessSDK.stopDevMode();
+      }
 
-        let result = null;
-  
-        try {
-          await serverlessSDK.startDevMode();
-          
-          const userHandler = require('./${fn.entryOrig}.js');
-          result = serverlessSDK.handler(userHandler.${
-            fn.handlerOrig
-          }, handlerWrapperArgs)(...args);
-         
-        } catch (error) {
-          result = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)(...args);
-        } finally {
-          serverlessSDK.stopDevMode();
-        }
-        
-        return result;
-      };
-    `;
-  }
+      return result;
+    });
+  };
+  `;
+
+  const newHandlerCode = `
+  var serverlessSDK = require('./serverless_sdk/index.js');
+
+  serverlessSDK = new serverlessSDK({
+    orgId: '${ctx.sls.service.org}',
+    applicationName: '${ctx.sls.service.app}',
+    appUid: '${ctx.sls.service.appUid}',
+    orgUid: '${ctx.sls.service.orgUid}',
+    deploymentUid: '${ctx.deploymentUid}',
+    serviceName: '${ctx.sls.service.service}',
+    shouldLogMeta: ${!ctx.sls.service.custom ||
+      !ctx.sls.service.custom.enterprise ||
+      ctx.sls.service.custom.enterprise.collectLambdaLogs !== false},
+    disableAwsSpans: ${Boolean(
+      ctx.sls.service.custom &&
+        ctx.sls.service.custom.enterprise &&
+        ctx.sls.service.custom.enterprise.disableAwsSpans
+    )},
+    disableHttpSpans: ${Boolean(
+      ctx.sls.service.custom &&
+        ctx.sls.service.custom.enterprise &&
+        ctx.sls.service.custom.enterprise.disableHttpSpans
+    )},
+    stageName: '${ctx.provider.getStage()}',
+    serverlessPlatformStage: '${process.env.SERVERLESS_PLATFORM_STAGE || 'prod'}',
+    devModeEnabled: ${isDevMode},
+    accessKey: ${isDevMode ? `'${accessKey}'` : null},
+    pluginVersion: '${version}',
+    disableFrameworksInstrumentation: ${Boolean(
+      ctx.sls.service.custom &&
+        ctx.sls.service.custom.enterprise &&
+        ctx.sls.service.custom.enterprise.disableFrameworksInstrumentation
+    )}
+  });
+
+  const handlerWrapperArgs = { functionName: '${fn.name}', timeout: ${fn.timeout} };
+
+  ${isDevMode ? devModeHandlerExec : standardHandlerExec}
+  `;
 
   // Create new handlers
   fs.writeFileSync(path.join(ctx.sls.config.servicePath, `${fn.entryNew}.js`), newHandlerCode);

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -147,31 +147,34 @@ describe('wrap - wrap', () => {
     expect(
       fs.writeFileSync.calledWith(
         'path/s_func.js',
-        `var serverlessSDK = require('./serverless_sdk/index.js')
+        `
+var serverlessSDK = require('./serverless_sdk/index.js');
 serverlessSDK = new serverlessSDK({
-orgId: 'org',
-applicationName: 'app',
-appUid: 'appUid',
-orgUid: 'orgUid',
-deploymentUid: 'deploymentUid',
-serviceName: 'service',
-shouldLogMeta: true,
-disableAwsSpans: false,
-disableHttpSpans: false,
-stageName: 'dev',
-serverlessPlatformStage: 'prod',
-devModeEnabled: false,
-accessKey: null,
-pluginVersion: '${version}',
-disableFrameworksInstrumentation: false})
-const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
+  orgId: 'org',
+  applicationName: 'app',
+  appUid: 'appUid',
+  orgUid: 'orgUid',
+  deploymentUid: 'deploymentUid',
+  serviceName: 'service',
+  shouldLogMeta: true,
+  disableAwsSpans: false,
+  disableHttpSpans: false,
+  stageName: 'dev',
+  serverlessPlatformStage: 'prod',
+  devModeEnabled: false,
+  accessKey: null,
+  pluginVersion: '${version}',
+  disableFrameworksInstrumentation: false
+});
+
+const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6 };
+
 try {
-  const userHandler = require('./handlerFile.js')
-  module.exports.handler = serverlessSDK.handler(userHandler.handlerFunc, handlerWrapperArgs)
+  const userHandler = require('./handlerFile.js');
+  module.exports.handler = serverlessSDK.handler(userHandler.handlerFunc, handlerWrapperArgs);
 } catch (error) {
-  module.exports.handler = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)
-}
-`
+  module.exports.handler = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs);
+}`
       )
     ).to.be.true;
     expect(fs.writeFileSync.calledWith('path/s_dunc.py')).to.be.true;
@@ -232,31 +235,34 @@ try {
     expect(
       fs.writeFileSync.calledWith(
         'path/s_func.js',
-        `var serverlessSDK = require('./serverless_sdk/index.js')
+        `
+var serverlessSDK = require('./serverless_sdk/index.js');
 serverlessSDK = new serverlessSDK({
-orgId: 'org',
-applicationName: 'app',
-appUid: 'appUid',
-orgUid: 'orgUid',
-deploymentUid: 'deploymentUid',
-serviceName: 'service',
-shouldLogMeta: true,
-disableAwsSpans: false,
-disableHttpSpans: false,
-stageName: 'dev',
-serverlessPlatformStage: 'prod',
-devModeEnabled: false,
-accessKey: null,
-pluginVersion: '${version}',
-disableFrameworksInstrumentation: false})
-const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
+  orgId: 'org',
+  applicationName: 'app',
+  appUid: 'appUid',
+  orgUid: 'orgUid',
+  deploymentUid: 'deploymentUid',
+  serviceName: 'service',
+  shouldLogMeta: true,
+  disableAwsSpans: false,
+  disableHttpSpans: false,
+  stageName: 'dev',
+  serverlessPlatformStage: 'prod',
+  devModeEnabled: false,
+  accessKey: null,
+  pluginVersion: '${version}',
+  disableFrameworksInstrumentation: false
+});
+
+const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6 };
+
 try {
-  const userHandler = require('./handlerFile.js')
-  module.exports.handler = serverlessSDK.handler(userHandler.handlerFunc, handlerWrapperArgs)
+  const userHandler = require('./handlerFile.js');
+  module.exports.handler = serverlessSDK.handler(userHandler.handlerFunc, handlerWrapperArgs);
 } catch (error) {
-  module.exports.handler = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)
-}
-`
+  module.exports.handler = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs);
+}`
       )
     ).to.be.true;
     expect(fs.readFile.calledWith('bundle.zip')).to.be.true;
@@ -344,31 +350,34 @@ try {
     expect(
       fs.writeFileSync.calledWith(
         'path/s_func.js',
-        `var serverlessSDK = require('./serverless_sdk/index.js')
+        `
+var serverlessSDK = require('./serverless_sdk/index.js');
 serverlessSDK = new serverlessSDK({
-orgId: 'org',
-applicationName: 'app',
-appUid: 'appUid',
-orgUid: 'orgUid',
-deploymentUid: 'deploymentUid',
-serviceName: 'service',
-shouldLogMeta: true,
-disableAwsSpans: false,
-disableHttpSpans: false,
-stageName: 'dev',
-serverlessPlatformStage: 'prod',
-devModeEnabled: false,
-accessKey: null,
-pluginVersion: '${version}',
-disableFrameworksInstrumentation: false})
-const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6}
+  orgId: 'org',
+  applicationName: 'app',
+  appUid: 'appUid',
+  orgUid: 'orgUid',
+  deploymentUid: 'deploymentUid',
+  serviceName: 'service',
+  shouldLogMeta: true,
+  disableAwsSpans: false,
+  disableHttpSpans: false,
+  stageName: 'dev',
+  serverlessPlatformStage: 'prod',
+  devModeEnabled: false,
+  accessKey: null,
+  pluginVersion: '${version}',
+  disableFrameworksInstrumentation: false
+});
+
+const handlerWrapperArgs = { functionName: 'service-dev-func', timeout: 6 };
+
 try {
-  const userHandler = require('./handlerFile.js')
-  module.exports.handler = serverlessSDK.handler(userHandler.handlerFunc, handlerWrapperArgs)
+  const userHandler = require('./handlerFile.js');
+  module.exports.handler = serverlessSDK.handler(userHandler.handlerFunc, handlerWrapperArgs);
 } catch (error) {
-  module.exports.handler = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs)
-}
-`
+  module.exports.handler = serverlessSDK.handler(() => { throw error }, handlerWrapperArgs);
+}`
       )
     ).to.be.true;
     expect(

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@serverless/event-mocks": "^1.1.1",
-    "@serverless/platform-client": "^0.23.0",
+    "@serverless/platform-client": "^0.24.0",
     "@serverless/platform-sdk": "^2.3.0",
     "chalk": "^2.4.2",
     "child-process-ext": "^2.1.0",

--- a/sdk-js/package-lock.json
+++ b/sdk-js/package-lock.json
@@ -244,14 +244,17 @@
       "dev": true
     },
     "@serverless/platform-client": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-0.23.0.tgz",
-      "integrity": "sha512-fp0ya8x/aDBSJOpyXQsQGXBYKyhMSUhEojo2RHItMSimU9oclYBfVr9XdJ4YAWzgddyRjDdrPp2HxPaNzn2N2w==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-0.24.0.tgz",
+      "integrity": "sha512-ppxR5wONzzxNSmt/9agfSzC0F4yrkHZWAR5IPLm4yj+dMxb+768XrbqBU6vnOfCcmjb89OX5Bk0GvyQh+T5gLw==",
       "requires": {
         "adm-zip": "^0.4.13",
         "axios": "^0.19.2",
+        "https-proxy-agent": "^5.0.0",
         "isomorphic-ws": "^4.0.1",
         "js-yaml": "^3.13.1",
+        "jwt-decode": "^2.2.0",
+        "querystring": "^0.2.0",
         "traverse": "^0.6.6",
         "ws": "^7.2.1"
       }
@@ -471,6 +474,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/after-all-results/-/after-all-results-2.0.0.tgz",
       "integrity": "sha1-asL8ICtQD4jaj09VMM+hAPTGotA="
+    },
+    "agent-base": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "aggregate-error": {
       "version": "3.0.1",
@@ -3592,6 +3603,15 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4291,6 +4311,11 @@
           "dev": true
         }
       }
+    },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -5675,8 +5700,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -7528,9 +7552,9 @@
       }
     },
     "ws": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
-      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/sdk-js/package.json
+++ b/sdk-js/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@serverless/platform-client": "^0.23.0",
+    "@serverless/platform-client": "^0.24.0",
     "after-all-results": "^2.0.0",
     "flat": "^5.0.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
### What is this?

Previously we were injecting conditional calls to the new platform SDK around the called user-handler function in the wrapper. I had (mistakingly) changed the handler to be `async`, which broke the integration tests. Instead, I decided to be more explicit and split out the 'dev' mode experience by creating a new top level handler if you have this mode enabled. I think is is better for several reasons:
1. It's a safer code change, since new code won't be introduced into the standard SLS Pro code path. It also keeps the function handler code smaller.
2. This actually fixes a pretty big bug with the previous approach - now logs from _required_ modules (before your actual handler) will be captured. The key was to start log collecting before: `const userHandler = require('./${fn.entryOrig}.js');`
3. This fixes the tests. I believe the previous code was fine, but this keeps the handler async-i-ness the same.