### PR TITLE
Fixes Flask SFPro instrumentation

### DIFF
--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -577,6 +577,7 @@ class SDK(object):
                       set_endpoint(rule, meta={"mechanism": "flask-middleware"})
                   except:
                       pass
+            wrap_view_func.__name__ = view_func.__name__
             return wrapped(rule, endpoint, wrap_view_func, *args, **kwargs)
         try:
             wrapt.wrap_function_wrapper(module, "Flask.add_url_rule", wrap_add_url_rule)


### PR DESCRIPTION
In #376, we added automatic instrumentation of Flask applications to infer
and set API endpoint from application route. However, since the same
function wrapper was reused across routes, Flask's unique check on view
names would fail when trying to instrument a second app route.

The fix here follows standard Python convention and inherits the wrapped
view function's name.