### PR TITLE
[Dev mode] Make sure to watch all functions. Force absolute paths.

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -386,6 +386,7 @@ module.exports = async function(ctx) {
      * Remove all paths
      */
     watcher.unwatch('*');
+    await watcher.unwatch('*');
 
     /**
      * Re-watch new files
@@ -394,9 +395,17 @@ module.exports = async function(ctx) {
   };
 
   /**
-   * Create a new watcher
+   * Create a new watcher. By default don't watch anything. The serverless.yml file
+   * will be parsed for function handlers. Those handlers will have their dependency
+   * trees mapped, and those files will be added dynamically by `rewatchFiles()`
    */
-  const watcher = chokidar.watch();
+  const watcher = chokidar.watch([], {
+    /**
+     * Tracked files are absolute, and explicit. By default cwd is the currently working directory,
+     * which mean the mapping between function and files is wrong.
+     */
+    cwd: '/',
+  });
 
   rewatchFiles();
 
@@ -433,7 +442,11 @@ module.exports = async function(ctx) {
       return;
     }
 
-    const functionNames = filenameToFunctionsMapping[filepath];
+    /**
+     * Force resolved file path to be absolute.
+     */
+    const resolvedFilepath = path.normalize(`${path.sep}${filepath}`);
+    const functionNames = filenameToFunctionsMapping[resolvedFilepath];
 
     if (!functionNames) {
       return;
@@ -448,7 +461,7 @@ module.exports = async function(ctx) {
           return;
         }
 
-        sls.cli.log(`${functionName}: Function changed. Redeploying...`);
+        sls.cli.log(`${functionName}: changed. Redeploying...`);
 
         isFunctionDeploying[functionName] = true;
 

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -385,7 +385,6 @@ module.exports = async function(ctx) {
     /**
      * Remove all paths
      */
-    watcher.unwatch('*');
     await watcher.unwatch('*');
 
     /**

--- a/lib/dev.js
+++ b/lib/dev.js
@@ -402,7 +402,7 @@ module.exports = async function(ctx) {
   const watcher = chokidar.watch([], {
     /**
      * Tracked files are absolute, and explicit. By default cwd is the currently working directory,
-     * which mean the mapping between function and files is wrong.
+     * which means the mapping between function and files will be wrong.
      */
     cwd: '/',
   });


### PR DESCRIPTION
### Bug fixes for dev mode
* Chokidar's `unwatch` is async and needs to be awaited. I have not seen this cause bugs, but if you add/remove functions to your serverless.yml, this could result in over/under watching files
* Fixes a bug reported by Gareth and Kaz. In the case where you had a very simple handler:
```
  hello:
    handler: handler.hello
```
This would not get watched correctly. Now all paths are forced to be absolute, and watching this function works correctly.

I spent a fair amount of time trying to write a unit test to ensure that the correct files are watched (flat/nested function handler files), unfortunately, I think this command needs to be refactored, as you suggested, so the watch pieces can be more easily tested. I will try to follow up with a refactoring / unit test PR as soon as I can.