### PR TITLE
Support passing in HTTP method and status code to setEndpoint

### DIFF
--- a/integration-testing/wrapper-service/handler.js
+++ b/integration-testing/wrapper-service/handler.js
@@ -96,6 +96,20 @@ module.exports.spans = async (event, context) => {
   });
 };
 
+module.exports.setEndpoint = async (event, context) => {
+  context.serverlessSdk.setEndpoint('/test/:param1');
+  return 'asyncReturn';
+};
+
+module.exports.setEndpointWithHttpMetadata = async (event, context) => {
+  context.serverlessSdk.setEndpoint({
+    endpoint: '/test/:param2',
+    httpMethod: 'POST',
+    httpStatusCode: 201,
+  });
+  return 'asyncReturn';
+};
+
 module.exports.noWaitForEmptyLoop = (event, context, callback) => {
   context.callbackWaitsForEmptyEventLoop = false;
   https.get({ host: 'httpbin.org', path: '/delay/10' });

--- a/integration-testing/wrapper-service/handler.py
+++ b/integration-testing/wrapper-service/handler.py
@@ -23,5 +23,9 @@ def event_tags(event, context):
     context.serverless_sdk.tag_event('event-tagged', 'true', { 'customerId': 5, 'userName': 'aaron.stuyvenberg'})
     return 'success'
 
+def set_endpoint(event, context):
+    context.serverless_sdk.set_endpoint('/test/:param', 'PATCH', '202')
+    return 'success'
+
 def timeout(event, context):
     time.sleep(10)

--- a/integration-testing/wrapper-service/serverless.yml
+++ b/integration-testing/wrapper-service/serverless.yml
@@ -42,6 +42,10 @@ functions:
     runtime: nodejs10.x
   eventTags:
     handler: handler.eventTags
+  setEndpoint:
+    handler: handler.setEndpoint
+  setEndpointWithHttpMetadata:
+    handler: handler.setEndpointWithHttpMetadata
   timeout:
     handler: handler.timeout
   waitForEmptyLoop:
@@ -62,6 +66,9 @@ functions:
     runtime: python3.7
   pythonEventTags:
     handler: handler.event_tags
+    runtime: python3.7
+  pythonSetEndpoint:
+    handler: handler.set_endpoint
     runtime: python3.7
   pythonTimeout:
     handler: handler.timeout

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -536,6 +536,43 @@ describe('integration: wrapper', function() {
     });
   });
 
+  it('sets node endpoint', async () => {
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-setEndpoint`,
+    });
+    const payload = resolveLog(LogResult);
+    expect(payload.type).to.equal('transaction');
+    expect(payload.payload.tags.endpoint).to.equal('/test/:param1');
+    expect(payload.payload.tags.endpointMechanism).to.equal('explicit');
+  });
+
+  it('sets node endpoint along with http metadata', async () => {
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-setEndpointWithHttpMetadata`,
+    });
+    const payload = resolveLog(LogResult);
+    expect(payload.type).to.equal('transaction');
+    expect(payload.payload.tags.endpoint).to.equal('/test/:param2');
+    expect(payload.payload.tags.httpMethod).to.equal('POST');
+    expect(payload.payload.tags.httpStatusCode).to.equal('201');
+    expect(payload.payload.tags.endpointMechanism).to.equal('explicit');
+  });
+
+  it('sets python endpoint', async () => {
+    const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+      LogType: 'Tail',
+      FunctionName: `${serviceName}-dev-pythonSetEndpoint`,
+    });
+    const payload = resolveLog(LogResult);
+    expect(payload.type).to.equal('transaction');
+    expect(payload.payload.tags.endpoint).to.equal('/test/:param');
+    expect(payload.payload.tags.httpMethod).to.equal('PATCH');
+    expect(payload.payload.tags.httpStatusCode).to.equal('202');
+    expect(payload.payload.tags.endpointMechanism).to.equal('explicit');
+  });
+
   it('gets SFE log msg from wrapped python timeout handler', async () => {
     const { LogResult } = await awsRequest(lambdaService, 'invoke', {
       LogType: 'Tail',

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -377,7 +377,7 @@ class ServerlessSDK {
         ) => {
           trans.$.schema.endpoint = endpoint;
           trans.$.schema.httpMethod = httpMethod;
-          trans.$.schema.httpStatusCode = String(httpStatusCode);
+          trans.$.schema.httpStatusCode = httpStatusCode && String(httpStatusCode);
           trans.$.schema.endpointMechanism = metadata ? metadata.mechanism : 'explicit';
         };
         // eslint-disable-next-line no-underscore-dangle

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -369,13 +369,17 @@ class ServerlessSDK {
         // eslint-disable-next-line no-underscore-dangle
         ServerlessSDK._tagEvent = contextProxy.serverlessSdk.tagEvent;
 
-        contextProxy.serverlessSdk.setEndpoint = (
-          endpoint,
-          httpMethod,
-          httpStatusCode,
-          metadata
-        ) => {
-          if (endpoint) trans.$.schema.endpoint = endpoint;
+        contextProxy.serverlessSdk.setEndpoint = endpoint => {
+          let value;
+          let httpMethod;
+          let httpStatusCode;
+          let metadata;
+          if (typeof endpoint === 'string' || endpoint instanceof String) {
+            value = endpoint;
+          } else {
+            ({ value, httpMethod, httpStatusCode, metadata } = endpoint);
+          }
+          if (value) trans.$.schema.endpoint = value;
           if (httpMethod) trans.$.schema.httpMethod = httpMethod;
           if (httpStatusCode) trans.$.schema.httpStatusCode = String(httpStatusCode);
           trans.$.schema.endpointMechanism = metadata ? metadata.mechanism : 'explicit';
@@ -439,9 +443,15 @@ class ServerlessSDK {
     ServerlessSDK._tagEvent(label, tag, custom);
   }
 
-  static setEndpoint(endpoint, httpMethod, httpStatusCode, metadata) {
-    // eslint-disable-next-line no-underscore-dangle
-    ServerlessSDK._setEndpoint(endpoint, httpMethod, httpStatusCode, metadata);
+  static setEndpoint(endpoint) {
+    if (typeof endpoint === 'string' || endpoint instanceof String) {
+      // eslint-disable-next-line no-underscore-dangle
+      ServerlessSDK._setEndpoint(endpoint);
+    } else {
+      const { httpMethod, httpStatusCode, metadata } = endpoint;
+      // eslint-disable-next-line no-underscore-dangle
+      ServerlessSDK._setEndpoint(endpoint, { httpMethod, httpStatusCode, metadata });
+    }
   }
 }
 

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -56,7 +56,7 @@ class ServerlessSDK {
     if (!obj.disableAwsSpans) require('./lib/spanHooks/hookAwsSdk')(spanEmitter);
     if (!obj.disableHttpSpans) require('./lib/spanHooks/hookHttp')(spanEmitter);
     if (!obj.disableFrameworksInstrumentation) {
-      require('./lib/frameworks')(ServerlessSDK, this.config);
+      require('./lib/frameworks')(ServerlessSDK, this.$.config);
     }
   }
 
@@ -375,9 +375,9 @@ class ServerlessSDK {
           httpStatusCode,
           metadata
         ) => {
-          trans.$.schema.endpoint = endpoint;
-          trans.$.schema.httpMethod = httpMethod;
-          trans.$.schema.httpStatusCode = httpStatusCode && String(httpStatusCode);
+          if (endpoint) trans.$.schema.endpoint = endpoint;
+          if (httpMethod) trans.$.schema.httpMethod = httpMethod;
+          if (httpStatusCode) trans.$.schema.httpStatusCode = String(httpStatusCode);
           trans.$.schema.endpointMechanism = metadata ? metadata.mechanism : 'explicit';
         };
         // eslint-disable-next-line no-underscore-dangle

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -371,9 +371,9 @@ class ServerlessSDK {
 
         contextProxy.serverlessSdk.setEndpoint = (
           endpoint,
-          metadata,
           httpMethod,
-          httpStatusCode
+          httpStatusCode,
+          metadata
         ) => {
           trans.$.schema.endpoint = endpoint;
           trans.$.schema.httpMethod = httpMethod;
@@ -439,9 +439,9 @@ class ServerlessSDK {
     ServerlessSDK._tagEvent(label, tag, custom);
   }
 
-  static setEndpoint(endpoint, metadata, httpMethod, httpStatusCode) {
+  static setEndpoint(endpoint, httpMethod, httpStatusCode, metadata) {
     // eslint-disable-next-line no-underscore-dangle
-    ServerlessSDK._setEndpoint(endpoint, metadata, httpMethod, httpStatusCode);
+    ServerlessSDK._setEndpoint(endpoint, httpMethod, httpStatusCode, metadata);
   }
 }
 

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -444,6 +444,7 @@ class ServerlessSDK {
   }
 
   static setEndpoint(endpoint) {
+    // eslint-disable-next-line no-underscore-dangle
     ServerlessSDK._setEndpoint(endpoint);
   }
 }

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -444,14 +444,7 @@ class ServerlessSDK {
   }
 
   static setEndpoint(endpoint) {
-    if (typeof endpoint === 'string' || endpoint instanceof String) {
-      // eslint-disable-next-line no-underscore-dangle
-      ServerlessSDK._setEndpoint(endpoint);
-    } else {
-      const { httpMethod, httpStatusCode, metadata } = endpoint;
-      // eslint-disable-next-line no-underscore-dangle
-      ServerlessSDK._setEndpoint(endpoint, { httpMethod, httpStatusCode, metadata });
-    }
+    ServerlessSDK._setEndpoint(endpoint);
   }
 }
 

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -377,7 +377,7 @@ class ServerlessSDK {
           if (typeof endpoint === 'string' || endpoint instanceof String) {
             value = endpoint;
           } else {
-            ({ value, httpMethod, httpStatusCode, metadata } = endpoint);
+            ({ endpoint: value, httpMethod, httpStatusCode, metadata } = endpoint);
           }
           if (value) trans.$.schema.endpoint = value;
           if (httpMethod) trans.$.schema.httpMethod = httpMethod;

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -369,8 +369,15 @@ class ServerlessSDK {
         // eslint-disable-next-line no-underscore-dangle
         ServerlessSDK._tagEvent = contextProxy.serverlessSdk.tagEvent;
 
-        contextProxy.serverlessSdk.setEndpoint = (endpoint, metadata) => {
+        contextProxy.serverlessSdk.setEndpoint = (
+          endpoint,
+          metadata,
+          httpMethod,
+          httpStatusCode
+        ) => {
           trans.$.schema.endpoint = endpoint;
+          trans.$.schema.httpMethod = httpMethod;
+          trans.$.schema.httpStatusCode = String(httpStatusCode);
           trans.$.schema.endpointMechanism = metadata ? metadata.mechanism : 'explicit';
         };
         // eslint-disable-next-line no-underscore-dangle
@@ -432,9 +439,9 @@ class ServerlessSDK {
     ServerlessSDK._tagEvent(label, tag, custom);
   }
 
-  static setEndpoint(endpoint, metadata) {
+  static setEndpoint(endpoint, metadata, httpMethod, httpStatusCode) {
     // eslint-disable-next-line no-underscore-dangle
-    ServerlessSDK._setEndpoint(endpoint, metadata);
+    ServerlessSDK._setEndpoint(endpoint, metadata, httpMethod, httpStatusCode);
   }
 }
 

--- a/sdk-js/src/lib/frameworks/wrappers/express.js
+++ b/sdk-js/src/lib/frameworks/wrappers/express.js
@@ -10,7 +10,7 @@ module.exports.init = (sdk, config) => {
       Route.prototype.dispatch = function handle(req, res, next) {
         try {
           // eslint-disable-next-line no-underscore-dangle
-          sdk._setEndpoint(req.route ? req.route.path : req.path, {
+          sdk._setEndpoint(req.route ? req.route.path : req.path, req.method, null, {
             mechanism: 'express-middleware',
           });
         } catch (err) {

--- a/sdk-js/src/lib/frameworks/wrappers/express.js
+++ b/sdk-js/src/lib/frameworks/wrappers/express.js
@@ -11,8 +11,10 @@ module.exports.init = (sdk, config) => {
       Route.prototype.dispatch = function handle(req, res, next) {
         try {
           // eslint-disable-next-line no-underscore-dangle
-          sdk._setEndpoint(req.route ? req.route.path : req.path, req.method, null, {
-            mechanism: 'express-middleware',
+          sdk._setEndpoint({
+            endpoint: req.route ? req.route.path : req.path,
+            httpMethod: req.method,
+            metadata: { mechanism: 'express-middleware' },
           });
         } catch (err) {
           if (config && config.debug === true) {
@@ -33,10 +35,14 @@ module.exports.init = (sdk, config) => {
       const app = express();
       try {
         const statusHandler = {
-          set: function(obj, property, value) {
+          set(obj, property, value) {
             try {
               if (property === 'statusCode') {
-                sdk._setEndpoint(null, null, value, { mechanism: 'express-middleware' });
+                // eslint-disable-next-line no-underscore-dangle
+                sdk._setEndpoint({
+                  httpStatusCode: value,
+                  metadata: { mechanism: 'express-middleware' },
+                });
               }
             } catch (err) {
               if (config && config.debug === true) {
@@ -44,8 +50,8 @@ module.exports.init = (sdk, config) => {
               }
             } finally {
               obj[property] = value;
-              return true;
             }
+            return true;
           },
         };
         app.response = new Proxy(app.response, statusHandler);

--- a/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
+++ b/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
@@ -10,7 +10,7 @@ module.exports.init = (sdk, config) => {
         api.use((req, res, next) => {
           try {
             // eslint-disable-next-line no-underscore-dangle
-            sdk._setEndpoint(req.route, { mechanism: 'lambda-api-middleware' });
+            sdk._setEndpoint(req.route, req.method, null, { mechanism: 'lambda-api-middleware' });
           } catch (err) {
             if (config && config.debug) {
               console.debug('error setting endpoint with lambda-api route', err);

--- a/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
+++ b/sdk-js/src/lib/frameworks/wrappers/lambda-api.js
@@ -7,16 +7,21 @@ module.exports.init = (sdk, config) => {
     return function(args) {
       const api = lambdaApi(args);
       try {
-        api.use((req, res, next) => {
+        const strip = path =>
+          api._base
+            ? path.slice(api._base.length + 1 /* leading '/' */) // eslint-disable-line no-underscore-dangle
+            : path;
+
+        api.finally((req, res) => {
           try {
             // eslint-disable-next-line no-underscore-dangle
-            sdk._setEndpoint(req.route, req.method, null, { mechanism: 'lambda-api-middleware' });
+            sdk._setEndpoint(req.route || strip(req.path), req.method, res._statusCode, {
+              mechanism: 'lambda-api-middleware',
+            });
           } catch (err) {
             if (config && config.debug) {
               console.debug('error setting endpoint with lambda-api route', err);
             }
-          } finally {
-            next();
           }
         });
       } catch (err) {

--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -357,7 +357,7 @@ class SDK(object):
                 "endpoint": self.endpoint,
                 "httpMethod": self.http_method,
                 "httpStatusCode": self.http_status_code,
-                "endpointMechanism": self.endpoint_meta["mechanism"] if self.endpoint_meta else None,
+                "endpointMechanism": self.endpoint_meta["mechanism"] if self.endpoint_meta else "explicit",
             }
             tags.update(error_data)
             if error_data["errorExceptionType"] == "TimeoutError":

--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -206,7 +206,7 @@ class SDK(object):
             self.endpoint = endpoint
             self.endpoint_meta = meta
             self.http_method = http_method
-            self.request_status_code = str(request_status_code)
+            self.request_status_code = str(request_status_code) if request_status_code else None
 
         class SDK_METHOD_WRAPPER:
             def __init__(self, capture_exception, tag_event, span, set_endpoint):

--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -77,8 +77,8 @@ def span(span_type):
     return _span(span_type)
 
 
-def set_endpoint(endpoint, meta=None):
-    _set_endpoint(endpoint, meta)
+def set_endpoint(endpoint, meta=None, httpMethod=None, httpStatusCode=None):
+    _set_endpoint(endpoint, meta, httpMethod, httpStatusCode)
 
 
 class SDK(object):
@@ -202,9 +202,11 @@ class SDK(object):
             if len(self.event_tags) > 10:
                 self.event_tags.pop(0)
 
-        def set_endpoint(endpoint, meta=None):
+        def set_endpoint(endpoint, meta=None, http_method=None, request_status_code=None):
             self.endpoint = endpoint
             self.endpoint_meta = meta
+            self.http_method = http_method
+            self.request_status_code = str(request_status_code)
 
         class SDK_METHOD_WRAPPER:
             def __init__(self, capture_exception, tag_event, span, set_endpoint):

--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -581,7 +581,11 @@ class SDK(object):
               finally:
                   try:
                       from flask import request
-                      set_endpoint(rule, request.method, meta={"mechanism": "flask-middleware"})
+                      set_endpoint(
+                        rule,
+                        http_method=request.method,
+                        meta={"mechanism": "flask-middleware"}
+                      )
                   except:
                       pass
             wrap_view_func.__name__ = view_func.__name__
@@ -595,7 +599,12 @@ class SDK(object):
                   from flask import request
                   status = response.status_code or response.default_status
                   path = request.path if status == 404 or status >= 500 else None
-                  set_endpoint(path, request.method, status, meta={"mechanism": "flask-middleware"})
+                  set_endpoint(
+                    path,
+                    http_method=request.method,
+                    http_status_code=status,
+                    meta={"mechanism": "flask-middleware"}
+                  )
               except:
                 pass
               return response

--- a/sdk-py/serverless_sdk/__init__.py
+++ b/sdk-py/serverless_sdk/__init__.py
@@ -77,8 +77,8 @@ def span(span_type):
     return _span(span_type)
 
 
-def set_endpoint(endpoint, meta=None, httpMethod=None, httpStatusCode=None):
-    _set_endpoint(endpoint, meta, httpMethod, httpStatusCode)
+def set_endpoint(endpoint, http_method=None, http_status_code=None, meta=None):
+    _set_endpoint(endpoint, http_method==http_method, http_status_code=http_status_code, meta=meta)
 
 
 class SDK(object):
@@ -112,6 +112,8 @@ class SDK(object):
         self.spans = []
         self.event_tags = []
         self.endpoint = None
+        self.http_method = None
+        self.http_status_code = None
         self.endpoint_meta = None
 
         self.instrument_botocore()
@@ -202,11 +204,11 @@ class SDK(object):
             if len(self.event_tags) > 10:
                 self.event_tags.pop(0)
 
-        def set_endpoint(endpoint, meta=None, http_method=None, request_status_code=None):
+        def set_endpoint(endpoint, http_method=None, http_status_code=None, meta=None):
             self.endpoint = endpoint
-            self.endpoint_meta = meta
             self.http_method = http_method
-            self.request_status_code = str(request_status_code) if request_status_code else None
+            self.http_status_code = str(http_status_code) if http_status_code else None
+            self.endpoint_meta = meta
 
         class SDK_METHOD_WRAPPER:
             def __init__(self, capture_exception, tag_event, span, set_endpoint):
@@ -353,6 +355,8 @@ class SDK(object):
                 "traceId": context.aws_request_id,
                 "transactionId": span_id,
                 "endpoint": self.endpoint,
+                "httpMethod": self.http_method,
+                "httpStatusCode": self.http_status_code,
                 "endpointMechanism": self.endpoint_meta["mechanism"] if self.endpoint_meta else None,
             }
             tags.update(error_data)


### PR DESCRIPTION
This change sets two new attributes - httpMethod and requestStatusCode. This lets users effectively disable APIGW access logs to reduce spend.

There's a comprehensive QA plan outlined here:
https://github.com/serverless/enterprise-dashboard/pull/2916