### PR TITLE
[dev mode] Don't watch node_modules, add more output, cleaner exit disconnect

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -208,11 +208,13 @@ module.exports = async function(ctx) {
   await sdk.publishSync({ event: 'studio.connect', data: { clientType: 'cli' } });
 
   const disconnect = async () => {
-    await sdk.publishSync({ event: 'studio.disconnect', data: { clientType: 'cli' } });
-    await sdk.disconnect();
+    if (sdk.isConnected()) {
+      await sdk.publishSync({ event: 'studio.disconnect', data: { clientType: 'cli' } });
+      await sdk.disconnect();
 
-    process.stdout.write('\n');
-    sls.cli.log('Disconnected from the Serverless Platform');
+      process.stdout.write('\n');
+      sls.cli.log('Disconnected from the Serverless Platform');
+    }
   };
 
   const cleanup = async () => {
@@ -261,7 +263,24 @@ module.exports = async function(ctx) {
       }
     );
 
-    const output = JSON.parse(stdoutBuffer.toString());
+    let output = {};
+
+    try {
+      output = JSON.parse(stdoutBuffer.toString());
+    } catch (e) {
+      /**
+       * If you ctrl+c during "serverless dev --info" to extract parsed
+       * yml information and HTTP endpoints, this will blow up. For now,
+       * just return some empty state objects so we can exit cleanly
+       * without an error.
+       */
+      return {
+        filenameToFunctions,
+        trackedFiles,
+        output,
+        functions: [],
+      };
+    }
 
     const { functions } = output;
 
@@ -278,6 +297,11 @@ module.exports = async function(ctx) {
       const list = dependencyTree.toList({
         filename: handlerEntry,
         directory: process.cwd(),
+
+        /**
+         * Don't try to watch files in node_modules
+         */
+        filter: filename => filename.indexOf('node_modules') === -1,
       });
 
       /**
@@ -354,6 +378,7 @@ module.exports = async function(ctx) {
     );
 
     appState.isDeploying = false;
+
     await updateAppState();
     await publishAppState();
   };
@@ -361,6 +386,8 @@ module.exports = async function(ctx) {
   /**
    * Communicate initial state of the serverless.yml
    */
+  sls.cli.log('Sending initial app state...');
+
   await updateAppState();
   await publishAppState({
     isDeploying: true,
@@ -406,9 +433,19 @@ module.exports = async function(ctx) {
     cwd: '/',
   });
 
-  rewatchFiles();
+  sls.cli.log('Building function dependency watch list...');
 
-  sls.cli.log('Watching for changes...');
+  await rewatchFiles();
+
+  sls.cli.log(
+    `Tracking ${
+      Object.keys(functionToFilenames).length
+    } function handler(s), and their dependencies...`
+  );
+
+  watcher.on('ready', () => {
+    sls.cli.log('Watching for changes...');
+  });
 
   /**
    * Watch for file changes


### PR DESCRIPTION
### Changes
- I believe this will fix the issue that @ac360 ran into. I wasn't able to repro it locally, but we currently use [dependency-tree](https://github.com/dependents/node-dependency-tree) to traverse your handler dependency graph and build a watch list of files, which wasn't scoped to non `node_modules` 💥 (see https://github.com/dependents/node-dependency-tree/issues/38). A `require('aws-sdk')` resulted in watching 800+ files alone. For context, I'm using this approach instead of simply watching anything under the current directory, because I would like to map modules -> functions (rebuilding a shared module, should redeploy the appropriate functions). There's a lot of optimization/exploration/refactoring/research that could be done here.
- I added more output to better indicate that something is happening. I still would like to add a `--debug` mode for troubleshooting.
- Fixed an unpleasant parsing error when ctrl+c'ing during a deployment

Sigh, one day I will write tests for this thing 😭The file watching aspset badly needs to be isolated from the WebSocket communication bits.


