### PR TITLE
[dev mode] Fix serverless.yml watch detection, add more output

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -20,7 +20,7 @@ const execOptions = {
   stdio: 'inherit',
 };
 
-const slsCommand = 'serverless';
+const slsCommand = './node_modules/.bin/serverless';
 
 module.exports = async function(ctx) {
   const { sls } = ctx;
@@ -379,6 +379,8 @@ module.exports = async function(ctx) {
 
     appState.isDeploying = false;
 
+    sls.cli.log(`Succesfully deployed stage "${deployToStage}"`);
+
     await updateAppState();
     await publishAppState();
   };
@@ -417,7 +419,9 @@ module.exports = async function(ctx) {
     /**
      * Re-watch new files
      */
-    watcher.add(['serverless.yml', ...trackedFiles]);
+    const serverlessYml = path.resolve('serverless.yml');
+
+    watcher.add([serverlessYml, ...trackedFiles]);
   };
 
   /**
@@ -453,7 +457,9 @@ module.exports = async function(ctx) {
   watcher.on('change', async filepath => {
     const { isFunctionDeploying } = appState;
 
-    if (filepath.endsWith('serverless.yml')) {
+    if (filepath.endsWith('serverless.yml') && !appState.isDeploying) {
+      sls.cli.log('serverless.yml changed. Checking for function changes...');
+
       /**
        * Compare the function (names) in the serverless.yml file
        * with what's already in the app state. We need to redeploy
@@ -466,13 +472,16 @@ module.exports = async function(ctx) {
       const { functions } = await getServerlessInfo();
 
       if (!isEqual(functions, appState.functions)) {
-        sls.cli.log('serverless.yml functions changed');
+        sls.cli.log('Detected function configuration changes...');
+        sls.cli.log(`Stage "${deployToStage}" will be redeployed to reflect these changes...`);
         await deploy(true);
 
         await updateAppState();
         await publishAppState();
 
         rewatchFiles();
+      } else {
+        sls.cli.log('No function changes detected. Continuing...');
       }
 
       return;


### PR DESCRIPTION
### Changes
* The `serverless.yml` wasn't being watched correctly after I forced all watched files to be absolute paths, from the previous commit to properly watch for handler modules in the same directory.
* I added some more output to give a better indication of what is happening
* Fixes an issue where multiple "sls deploy" calls could be made at the same time

```
Serverless: serverless.yml changed. Checking for function changes...
Serverless: Detected function configuration changes...
Serverless: Stage "test" will be redeployed to reflect these changes...
Serverless: Redeploying to stage "test". This may take a few minutes...
Serverless: Packaging service...
Serverless: Installing dependencies for custom CloudFormation resources...
Serverless: Safeguards Processing...
Serverless: Safeguards Results:

   Summary --------------------------------------------------

   passed - no-secret-env-vars
   passed - allowed-runtimes
   passed - allowed-regions
   passed - framework-version
   passed - no-unsafe-wildcard-iam-permissions

Serverless: Safeguards Summary: 5 passed, 0 warnings, 0 errors
Serverless: Uploading CloudFormation file to S3...
Serverless: Uploading artifacts...
Serverless: Uploading service shapefile-to-geojson.zip file to S3 (307.88 KB)...
Serverless: Uploading custom CloudFormation resources...
Serverless: Validating template...
Serverless: Updating Stack...
```