### PR TITLE
CI: Workaround OOM NYC issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,8 +104,8 @@ jobs:
         - npm test
         - cd ..
 
-    - name: 'Unit Tests, Coverage - Node.js v10'
-      node_js: 10
+    - name: 'Unit Tests, Coverage - Node.js v13'
+      node_js: 13
       before_install:
         - npm install -g npm codecov
       script:
@@ -116,13 +116,16 @@ jobs:
         - codecov
         - codecov -p sdk-js
 
-    - name: 'Isolated Unit Tests - Node.js v8'
-      node_js: 8
+    - name: 'Isolated Unit Tests - Node.js v10'
+      node_js: 10
       script:
         - npm run test-isolated
         - cd sdk-js
         - npm test
         - cd ..
+
+    - name: 'Unit Tests - Node.js v8'
+      node_js: 8
 
     - name: 'Unit Tests - Node.js v6'
       node_js: 6


### PR DESCRIPTION
We started to observe OOM errors when doing coverage check on Node.js v10: https://travis-ci.com/github/serverless/enterprise-plugin/jobs/305196115

Issue is known on NYC side: https://github.com/istanbuljs/nyc/issues/1263  and they have fix coming: https://github.com/istanbuljs/nyc/pull/1293

I was not able to reproduce this when running on Node.js v13 and v12, hence I've updated CI to run coverage on v13 (which we also didn't test yet)