### PR TITLE
Do not request dashboard meta when it's not needed

### DIFF
--- a/lib/interactiveCli/index.js
+++ b/lib/interactiveCli/index.js
@@ -14,8 +14,8 @@ module.exports = ctx => {
       if (!ctx.sls.config.servicePath || !ctx.sls.interactiveCli) {
         return;
       }
-      const { supportedRuntimes, supportedRegions } = await getMetadata();
       if (ctx.sls.processedInput.options.org || ctx.sls.processedInput.options.app) {
+        const { supportedRuntimes, supportedRegions } = await getMetadata();
         if (ctx.sls.service.provider.name !== 'aws') {
           throw new ctx.sls.classes.Error(
             `Sorry, the provider ${ctx.sls.service.provider.name} is not yet supported by the dashboard. Check out the docs at http://slss.io/dashboard-requirements" for supported providers.`
@@ -26,11 +26,11 @@ module.exports = ctx => {
             `Sorry, the runtime ${ctx.sls.service.provider.runtime} is not yet supported by the dashboard. Check out the docs at http://slss.io/dashboard-requirements" for supported providers.`
           );
         }
-      }
-      if (!supportedRegions.includes(ctx.provider.getRegion())) {
-        throw new ctx.sls.classes.Error(
-          `Sorry, the region ${ctx.provider.getRegion()} is not yet supported by the dashboard. Check out the docs at http://slss.io/dashboard-requirements" for supported providers.`
-        );
+        if (!supportedRegions.includes(ctx.provider.getRegion())) {
+          throw new ctx.sls.classes.Error(
+            `Sorry, the region ${ctx.provider.getRegion()} is not yet supported by the dashboard. Check out the docs at http://slss.io/dashboard-requirements" for supported providers.`
+          );
+        }
       }
     },
     'before:interactiveCli:setupAws': async () => {


### PR DESCRIPTION
When testing locally, non AWS provider case, I've approached following crash:

![Screenshot 2020-03-31 at 14 00 23](https://user-images.githubusercontent.com/122434/77975933-0071dd80-7358-11ea-9e6b-5f9480b29dd4.png)

When investigating I've found that we request metadata for dashboard uncoditionally. I've fixed the conditionals so it's not the case