### PR TITLE
[Dev mode] Add auto-stage flag, make it opt-in, not automatic

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -58,15 +58,10 @@ module.exports = async function(ctx) {
    * Stage used for development. By default, pick a generated stage,
    * unless specified by the user.
    */
-  let deployToStage = `${process.env.USER || 'dev'}-${Math.floor(Math.random() * 100000)}`;
+  let deployToStage = ctx.provider.getStage();
   let deployToRegion = 'us-east-1';
 
-  /**
-   * If specified, do not remove the stage on exit
-   */
-  let persistStage = false;
-
-  const { stage, region, info, persist } = sls.processedInput.options;
+  const { stage, region, info, autoStage } = sls.processedInput.options;
 
   if (stage) {
     deployToStage = stage;
@@ -76,8 +71,11 @@ module.exports = async function(ctx) {
     deployToRegion = region;
   }
 
-  if (persist) {
-    persistStage = true;
+  /**
+   * If specified, automatically pick a random stage, and remove it on exit
+   */
+  if (autoStage) {
+    deployToStage = `${process.env.USER || 'dev'}-${Math.floor(Math.random() * 100000)}`;
   }
 
   /**
@@ -236,6 +234,11 @@ module.exports = async function(ctx) {
 
   await sdk.publishSync({ event: 'studio.connect', data: { clientType: 'cli' } });
 
+  if (autoStage) {
+    sls.cli.log(`Auto stage generation enabled. Will deploy to stage: "${deployToStage}"...`);
+    sls.cli.log(`Note: exiting dev mode will remove stage "${deployToStage}"...`);
+  }
+
   const disconnect = async () => {
     if (sdk.isConnected()) {
       await sdk.publishSync({ event: 'studio.disconnect', data: { clientType: 'cli' } });
@@ -250,9 +253,9 @@ module.exports = async function(ctx) {
     await disconnect();
 
     /**
-     * Tear down the stage, unless specified otherwise
+     * Tear down the stage if in "auto-stage" mode
      */
-    if (!persistStage) {
+    if (autoStage) {
       process.stdout.write('\n');
       sls.cli.log(`Cleaning up stage "${deployToStage}"...`);
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -168,16 +168,16 @@ class ServerlessEnterprisePlugin {
         lifecycleEvents: ['dev'],
         options: {
           stage: {
-            usage: 'Stage to use for development',
+            usage: 'Stage to use for development.',
             shortcut: 's',
           },
           region: {
-            usage: 'Region to use for development',
+            usage: 'Region to use for development.',
             shortcut: 'r',
           },
-          persist: {
-            usage: 'If specified, do not remove the stage when this process is stopped',
-            shortcut: 'p',
+          autoStage: {
+            usage: 'If specified, generate a random stage. This stage will be removed on exit.',
+            shortcut: 'a',
           },
         },
         enterprise: true,


### PR DESCRIPTION
### Description
* Adds to `auto-stage` flag to the dev mode, which will perform the same default we had previous (generate a stage name, and tear down on exit)
* Removes the secret `--persist` flag which didn't remove a stage on CLI exit. That doesn't seem necessary anymore.