### PR TITLE
SFPRO-466 Rename command "dev" to "studio"

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -51,7 +51,7 @@ module.exports = async function(ctx) {
    * If specified, automatically pick a random stage, and remove it on exit
    */
   if (autoStage) {
-    deployToStage = `${process.env.USER || 'dev'}-${Math.floor(Math.random() * 100000)}`;
+    deployToStage = `${process.env.USER || 'studio'}-${Math.floor(Math.random() * 100000)}`;
   }
 
   const serverlessExec = new ServerlessExec(deployToStage, deployToRegion);
@@ -63,7 +63,7 @@ module.exports = async function(ctx) {
     const endpoints = await serverlessExec.fetchEndpoints();
 
     /**
-     * Communicate relevant configuration settings to the parent process (sls dev):
+     * Communicate relevant configuration settings to the parent process (sls studio):
      *
      *  - General app/org information
      *  - Send new infra/functions to websocket
@@ -87,20 +87,20 @@ module.exports = async function(ctx) {
     return;
   }
 
-  sls.cli.log('Starting Serverless dev mode...');
+  sls.cli.log('Starting Serverless Studio...');
 
   /**
    * As a pseudo-failsafe, don't support the prod stage to limit WebSocket traffic
    */
   if (deployToStage === 'prod') {
-    sls.cli.log("Stage 'prod' cannot be used with 'serverless dev'");
+    sls.cli.log("Stage 'prod' cannot be used with 'serverless studio'");
     return;
   }
 
   /**
-   * Check to see if 'serverless dev' is already running
+   * Check to see if 'serverless studio' is already running
    */
-  const processes = await findProcess('name', /(serverless|sls) dev/g);
+  const processes = await findProcess('name', /(serverless|sls) studio/g);
 
   if (processes.length === 0) {
     sls.cli.log('Failed to detect running serverless process. Exiting.');
@@ -111,7 +111,7 @@ module.exports = async function(ctx) {
    * Only one process can be running
    */
   if (processes.length > 1) {
-    sls.cli.log("Only one instance of 'serverless dev' can be running");
+    sls.cli.log("Only one instance of 'serverless studio' can be running");
     return;
   }
 
@@ -133,7 +133,7 @@ module.exports = async function(ctx) {
 
   if (autoStage) {
     sls.cli.log(`Auto stage generation enabled. Will deploy to stage: "${deployToStage}"...`);
-    sls.cli.log(`Note: exiting dev mode will remove stage "${deployToStage}"...`);
+    sls.cli.log(`Note: exiting Studio will remove stage "${deployToStage}"...`);
   }
 
   const disconnect = async () => {

--- a/lib/dev.test.js
+++ b/lib/dev.test.js
@@ -18,7 +18,7 @@ const modulesCacheStub = {
 
 const userNodeVersion = Number(process.version.split('.')[0].slice(1));
 
-describe('dev mode', function() {
+describe('studio', function() {
   this.timeout(1000 * 60 * 3);
   let serverlessPath;
 
@@ -34,7 +34,7 @@ describe('dev mode', function() {
     try {
       await runServerless(serverlessPath, {
         cwd: awsMonitoredServicePath,
-        cliArgs: ['dev'],
+        cliArgs: ['studio'],
         modulesCacheStub: {
           [platformSdkPath]: {
             ...modulesCacheStub[platformSdkPath],

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -163,9 +163,9 @@ class ServerlessEnterprisePlugin {
           },
         },
       },
-      'dev': {
+      'studio': {
         usage: 'Develop a Serverless application in the cloud.',
-        lifecycleEvents: ['dev'],
+        lifecycleEvents: ['studio'],
         options: {
           stage: {
             usage: 'Stage to use for development.',
@@ -198,7 +198,7 @@ class ServerlessEnterprisePlugin {
       'after:aws:deploy:finalize:cleanup': this.route('after:aws:deploy:finalize:cleanup').bind(
         this
       ),
-      'dev:dev': this.route('dev:dev').bind(this),
+      'studio:studio': this.route('studio:studio').bind(this),
     };
     this.variableResolvers = {
       param: {
@@ -429,12 +429,12 @@ class ServerlessEnterprisePlugin {
         case 'logout:logout':
           await logout(this);
           break;
-        case 'dev:dev':
+        case 'studio:studio':
           if (userNodeVersion >= 8) {
-            const dev = require('./dev');
-            await dev(this);
+            const studio = require('./dev');
+            await studio(this);
           } else {
-            this.sls.cli.log('Node 8 or higher is required to run dev mode.');
+            this.sls.cli.log('Node 8 or higher is required to run Serverless Studio.');
           }
           break;
         case 'generate-event:generate-event':

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -151,7 +151,7 @@ describe('plugin', () => {
         'output:list:list',
         'param:get:get',
         'param:list:list',
-        'dev:dev',
+        'studio:studio',
       ])
     );
     expect(new Set(Object.keys(instance.variableResolvers))).to.deep.equal(

--- a/lib/studio/ServerlessExec.js
+++ b/lib/studio/ServerlessExec.js
@@ -32,7 +32,7 @@ class ServerlessExec {
      * of the serverless.yml to determine HTTP endpoints
      */
     const { stdoutBuffer } = await spawn(slsCommand, [
-      'dev',
+      'studio',
       '--info',
       `--stage=${this.deployToStage}`,
       `--region=${this.deployToRegion}`,


### PR DESCRIPTION
I think we should also rename the `dev.js` file to `studio.js` to fit the naming convention of the rest of the CLI commands, but I thought it would be too hard to review the changes, so I can do that in the next commit.

I also went back and forth on supporting both commands, and/or providing a message indicating that the command has changed. Based on the usage numbers so far, I don't think it's worth it at this point.