### PR TITLE
Studio - don't kill process if sls deploy fails

### DIFF
--- a/lib/studio/ServerlessExec.js
+++ b/lib/studio/ServerlessExec.js
@@ -27,20 +27,20 @@ class ServerlessExec {
     const filenameToFunctions = {};
     const trackedFiles = [];
 
-    /**
-     * Issue the --info variant of this command to get a parsed JSON output
-     * of the serverless.yml to determine HTTP endpoints
-     */
-    const { stdoutBuffer } = await spawn(slsCommand, [
-      'studio',
-      '--info',
-      `--stage=${this.deployToStage}`,
-      `--region=${this.deployToRegion}`,
-    ]);
-
     let output = {};
 
     try {
+      /**
+       * Issue the --info variant of this command to get a parsed JSON output
+       * of the serverless.yml to determine HTTP endpoints
+       */
+      const { stdoutBuffer } = await spawn(slsCommand, [
+        'studio',
+        '--info',
+        `--stage=${this.deployToStage}`,
+        `--region=${this.deployToRegion}`,
+      ]);
+
       output = JSON.parse(stdoutBuffer.toString());
     } catch (e) {
       /**

--- a/lib/studio/Studio.js
+++ b/lib/studio/Studio.js
@@ -104,11 +104,9 @@ class Studio {
     this.updateAppState({ isDeploying: !functionName });
     await this.publishAppState();
 
+    let hasDeployFailed = false;
     try {
       await this.serverlessExec.deploy(functionName);
-      if (!functionName) {
-        this.sls.cli.log(`Successfully deployed stage "${this.serverlessExec.deployToStage}"`);
-      }
     } catch (e) {
       /**
        * If 'sls deploy' fails, the error will be reported to the CLI
@@ -116,9 +114,14 @@ class Studio {
        * the .yml. We should catch here to prevent the rest of the watch
        * mode from exiting.
        */
-    } finally {
-      this.updateAppState({ isDeploying: false });
+      hasDeployFailed = true;
     }
+
+    if (!hasDeployFailed && !functionName) {
+      this.sls.cli.log(`Successfully deployed stage "${this.serverlessExec.deployToStage}"`);
+    }
+
+    this.updateAppState({ isDeploying: false });
 
     await this.refreshAppState();
     await this.publishAppState();

--- a/lib/studio/Studio.js
+++ b/lib/studio/Studio.js
@@ -104,11 +104,20 @@ class Studio {
     this.updateAppState({ isDeploying: !functionName });
     await this.publishAppState();
 
-    await this.serverlessExec.deploy(functionName);
-    this.updateAppState({ isDeploying: false });
-
-    if (!functionName) {
-      this.sls.cli.log(`Successfully deployed stage "${this.serverlessExec.deployToStage}"`);
+    try {
+      await this.serverlessExec.deploy(functionName);
+      if (!functionName) {
+        this.sls.cli.log(`Successfully deployed stage "${this.serverlessExec.deployToStage}"`);
+      }
+    } catch (e) {
+      /**
+       * If 'sls deploy' fails, the error will be reported to the CLI
+       * already. This could happen for many reasons, such as a typo in
+       * the .yml. We should catch here to prevent the rest of the watch
+       * mode from exiting.
+       */
+    } finally {
+      this.updateAppState({ isDeploying: false });
     }
 
     await this.refreshAppState();


### PR DESCRIPTION
### Description
Basically just wrap the `sls deploy` call in a try/catch so that deployment errors don't kick you out of the long-running watch mode of Studio.

![2020-04-27 16 49 45 2](https://user-images.githubusercontent.com/11420/80419774-bb35c280-88a7-11ea-9b69-aeefc4b089ff.gif)
