### PR TITLE
Studio - Add Typescript support

### DIFF
--- a/lib/studio.js
+++ b/lib/studio.js
@@ -252,7 +252,7 @@ module.exports = async function(ctx) {
       possibleServerlessConfigFileVariants.includes(resolvedFilepath) &&
       !studio.appState.isDeploying
     ) {
-      sls.cli.log('serverless configuration changed. Checking for function changes...');
+      sls.cli.log('Serverless configuration changed. Checking for function changes...');
 
       /**
        * Compare the function (names) in the serverless.yml file
@@ -267,7 +267,7 @@ module.exports = async function(ctx) {
 
       if (!isEqual(functions, studio.appState.functions)) {
         sls.cli.log('Detected function configuration changes...');
-        sls.cli.log(`Stage "${deployToStage}" will be redeployed to reflect these changes...`);
+        sls.cli.log(`Stage "${deployToStage}" will be re-deployed to reflect these changes...`);
         await studio.deploy({ isRedeploying: true });
         rewatchFiles();
       } else {
@@ -294,7 +294,7 @@ module.exports = async function(ctx) {
      * Mark all functions as deploying, and communicate that state
      */
     functionsNeedingDeploy.forEach(functionName => {
-      sls.cli.log(`${functionName}: changed. Redeploying...`);
+      sls.cli.log(`${functionName}: changed. Re-deploying...`);
       isFunctionDeploying[functionName] = true;
     });
 

--- a/lib/studio/ServerlessExec.js
+++ b/lib/studio/ServerlessExec.js
@@ -1,5 +1,6 @@
 'use strict';
 const path = require('path');
+const fs = require('fs');
 
 const slsCommand = 'serverless';
 
@@ -64,7 +65,23 @@ class ServerlessExec {
      */
     Object.keys(functions).forEach(functionName => {
       const { dir, name } = path.parse(functions[functionName].handler);
-      const handlerEntry = `${path.join(dir, name)}.js`;
+
+      let extension = '.js';
+      let typescriptEnabled = false;
+
+      /**
+       * Assume Typescript if there's a tsconfig.json file
+       */
+      if (fs.existsSync('tsconfig.json')) {
+        extension = '.ts';
+        typescriptEnabled = true;
+      }
+
+      /**
+       * Remember, the serverless.yml handler does not include an extension,
+       * so we need to add it here.
+       */
+      const handlerEntry = `${path.join(dir, name)}${extension}`;
 
       /**
        * Determine modules required by the entry point of the handler
@@ -72,6 +89,7 @@ class ServerlessExec {
       const list = dependencyTree.toList({
         filename: handlerEntry,
         directory: process.cwd(),
+        tsConfig: typescriptEnabled ? './tsconfig.json' : undefined,
 
         /**
          * Don't try to watch files in node_modules

--- a/lib/studio/ServerlessExec.js
+++ b/lib/studio/ServerlessExec.js
@@ -60,22 +60,20 @@ class ServerlessExec {
 
     const { functions } = output;
 
+    let extension = '.js';
+
+    /**
+     * Assume Typescript if there's a tsconfig.json file
+     */
+    if (fs.existsSync('tsconfig.json')) {
+      extension = '.ts';
+    }
+
     /**
      * Use the handler path to reconstruct the path to the entry module
      */
     Object.keys(functions).forEach(functionName => {
       const { dir, name } = path.parse(functions[functionName].handler);
-
-      let extension = '.js';
-      let typescriptEnabled = false;
-
-      /**
-       * Assume Typescript if there's a tsconfig.json file
-       */
-      if (fs.existsSync('tsconfig.json')) {
-        extension = '.ts';
-        typescriptEnabled = true;
-      }
 
       /**
        * Remember, the serverless.yml handler does not include an extension,
@@ -89,7 +87,6 @@ class ServerlessExec {
       const list = dependencyTree.toList({
         filename: handlerEntry,
         directory: process.cwd(),
-        tsConfig: typescriptEnabled ? './tsconfig.json' : undefined,
 
         /**
          * Don't try to watch files in node_modules


### PR DESCRIPTION
### Changes
* Checks to see if the current directory has a `tsconfig.json` file. If so, assume the handlers are `.ts` and use those to feed into `dependency-tree`.

I tested with https://github.com/serverless/examples/tree/master/aws-node-typescript-sqs-standard which uses webpack to transpile. It seems to work well, however, I think if you change files which cause multiple files to re-deploy there is a race-condition and/or files/folders get trampled and webpack bundles function code. I think investigating the `sls deploy function` behavior, and also how the webpack plugin works can be handled separately.