### PR TITLE
Ensure to not enforce logs settings in not applicable scenarios

### DIFF
--- a/lib/setApiGatewayAccessLogFormat.js
+++ b/lib/setApiGatewayAccessLogFormat.js
@@ -2,6 +2,26 @@
 
 const { API_GATEWAY_LOG_FORMAT, API_GATEWAY_V2_LOG_FORMAT } = require('./utils.js');
 
+const setupHttpLogs = serviceConfig => {
+  if (!serviceConfig.provider.logs) serviceConfig.provider.logs = {};
+
+  const logsConfig = serviceConfig.provider.logs;
+  if (!logsConfig.restApi || typeof logsConfig.restApi !== 'object') {
+    logsConfig.restApi = {};
+  }
+  logsConfig.restApi.format = JSON.stringify(API_GATEWAY_LOG_FORMAT);
+};
+
+const setupHttpApiLogs = serviceConfig => {
+  if (!serviceConfig.provider.logs) serviceConfig.provider.logs = {};
+
+  const logsConfig = serviceConfig.provider.logs;
+  if (!logsConfig.httpApi || typeof logsConfig.httpApi !== 'object') {
+    logsConfig.httpApi = {};
+  }
+  logsConfig.httpApi.format = JSON.stringify(API_GATEWAY_V2_LOG_FORMAT);
+};
+
 module.exports = ctx => {
   const serviceConfig = ctx.sls.service;
   if (
@@ -12,16 +32,6 @@ module.exports = ctx => {
     return;
   }
 
-  if (!serviceConfig.provider.logs) serviceConfig.provider.logs = {};
-
-  const logsConfig = serviceConfig.provider.logs;
-  if (!logsConfig.restApi || typeof logsConfig.restApi !== 'object') {
-    logsConfig.restApi = {};
-  }
-  logsConfig.restApi.format = JSON.stringify(API_GATEWAY_LOG_FORMAT);
-
-  if (!logsConfig.httpApi || typeof logsConfig.httpApi !== 'object') {
-    logsConfig.httpApi = {};
-  }
-  logsConfig.httpApi.format = JSON.stringify(API_GATEWAY_V2_LOG_FORMAT);
+  setupHttpLogs(serviceConfig);
+  setupHttpApiLogs(serviceConfig);
 };

--- a/lib/setApiGatewayAccessLogFormat.js
+++ b/lib/setApiGatewayAccessLogFormat.js
@@ -12,9 +12,7 @@ module.exports = ctx => {
     return;
   }
 
-  if (!serviceConfig.provider.logs) {
-    serviceConfig.provider.logs = {};
-  }
+  if (!serviceConfig.provider.logs) serviceConfig.provider.logs = {};
 
   const logsConfig = serviceConfig.provider.logs;
   if (!logsConfig.restApi || typeof logsConfig.restApi !== 'object') {

--- a/lib/setApiGatewayAccessLogFormat.js
+++ b/lib/setApiGatewayAccessLogFormat.js
@@ -3,30 +3,31 @@
 const { API_GATEWAY_LOG_FORMAT, API_GATEWAY_V2_LOG_FORMAT } = require('./utils.js');
 
 module.exports = ctx => {
+  const serviceConfig = ctx.sls.service;
   if (
-    ctx.sls.service.custom &&
-    ctx.sls.service.custom.enterprise &&
-    ctx.sls.service.custom.enterprise.collectApiGatewayLogs === false
+    serviceConfig.custom &&
+    serviceConfig.custom.enterprise &&
+    serviceConfig.custom.enterprise.collectApiGatewayLogs === false
   ) {
     return;
   }
 
-  if (!ctx.sls.service.provider.logs) {
-    ctx.sls.service.provider.logs = {};
+  if (!serviceConfig.provider.logs) {
+    serviceConfig.provider.logs = {};
   }
   if (
-    !ctx.sls.service.provider.logs.restApi ||
-    typeof ctx.sls.service.provider.logs.restApi !== 'object'
+    !serviceConfig.provider.logs.restApi ||
+    typeof serviceConfig.provider.logs.restApi !== 'object'
   ) {
-    ctx.sls.service.provider.logs.restApi = {};
+    serviceConfig.provider.logs.restApi = {};
   }
-  ctx.sls.service.provider.logs.restApi.format = JSON.stringify(API_GATEWAY_LOG_FORMAT);
+  serviceConfig.provider.logs.restApi.format = JSON.stringify(API_GATEWAY_LOG_FORMAT);
 
   if (
-    !ctx.sls.service.provider.logs.httpApi ||
-    typeof ctx.sls.service.provider.logs.httpApi !== 'object'
+    !serviceConfig.provider.logs.httpApi ||
+    typeof serviceConfig.provider.logs.httpApi !== 'object'
   ) {
-    ctx.sls.service.provider.logs.httpApi = {};
+    serviceConfig.provider.logs.httpApi = {};
   }
-  ctx.sls.service.provider.logs.httpApi.format = JSON.stringify(API_GATEWAY_V2_LOG_FORMAT);
+  serviceConfig.provider.logs.httpApi.format = JSON.stringify(API_GATEWAY_V2_LOG_FORMAT);
 };

--- a/lib/setApiGatewayAccessLogFormat.js
+++ b/lib/setApiGatewayAccessLogFormat.js
@@ -15,19 +15,15 @@ module.exports = ctx => {
   if (!serviceConfig.provider.logs) {
     serviceConfig.provider.logs = {};
   }
-  if (
-    !serviceConfig.provider.logs.restApi ||
-    typeof serviceConfig.provider.logs.restApi !== 'object'
-  ) {
-    serviceConfig.provider.logs.restApi = {};
-  }
-  serviceConfig.provider.logs.restApi.format = JSON.stringify(API_GATEWAY_LOG_FORMAT);
 
-  if (
-    !serviceConfig.provider.logs.httpApi ||
-    typeof serviceConfig.provider.logs.httpApi !== 'object'
-  ) {
-    serviceConfig.provider.logs.httpApi = {};
+  const logsConfig = serviceConfig.provider.logs;
+  if (!logsConfig.restApi || typeof logsConfig.restApi !== 'object') {
+    logsConfig.restApi = {};
   }
-  serviceConfig.provider.logs.httpApi.format = JSON.stringify(API_GATEWAY_V2_LOG_FORMAT);
+  logsConfig.restApi.format = JSON.stringify(API_GATEWAY_LOG_FORMAT);
+
+  if (!logsConfig.httpApi || typeof logsConfig.httpApi !== 'object') {
+    logsConfig.httpApi = {};
+  }
+  logsConfig.httpApi.format = JSON.stringify(API_GATEWAY_V2_LOG_FORMAT);
 };

--- a/lib/setApiGatewayAccessLogFormat.js
+++ b/lib/setApiGatewayAccessLogFormat.js
@@ -5,6 +5,11 @@ const _ = require('lodash');
 const { API_GATEWAY_LOG_FORMAT, API_GATEWAY_V2_LOG_FORMAT } = require('./utils.js');
 
 const setupHttpLogs = serviceConfig => {
+  if (serviceConfig.provider.apiGateway && serviceConfig.provider.apiGateway.restApiId) {
+    // Do not proceed if events reference Rest API configured externally
+    return;
+  }
+
   let logsConfig = serviceConfig.provider.logs;
   if (logsConfig && logsConfig.restApi != null) {
     // Ensure to not override eventual specified logs configuration
@@ -27,6 +32,11 @@ const setupHttpLogs = serviceConfig => {
 };
 
 const setupHttpApiLogs = serviceConfig => {
+  if (serviceConfig.provider.httpApi && serviceConfig.provider.httpApi.id) {
+    // Do not proceed if events reference HTTP API configured externally
+    return;
+  }
+
   let logsConfig = serviceConfig.provider.logs;
   if (logsConfig && logsConfig.httpApi != null) {
     // Ensure to not override eventual specified logs configuration

--- a/lib/setApiGatewayAccessLogFormat.js
+++ b/lib/setApiGatewayAccessLogFormat.js
@@ -1,24 +1,32 @@
 'use strict';
 
+const _ = require('lodash');
+
 const { API_GATEWAY_LOG_FORMAT, API_GATEWAY_V2_LOG_FORMAT } = require('./utils.js');
 
 const setupHttpLogs = serviceConfig => {
-  if (!serviceConfig.provider.logs) serviceConfig.provider.logs = {};
-
-  const logsConfig = serviceConfig.provider.logs;
-  if (!logsConfig.restApi || typeof logsConfig.restApi !== 'object') {
-    logsConfig.restApi = {};
+  let logsConfig = serviceConfig.provider.logs;
+  if (logsConfig && logsConfig.restApi != null) {
+    // Ensure to not override eventual specified logs configuration
+    if (!logsConfig.restApi) return;
+    if (logsConfig.restApi.format) return;
   }
+
+  if (!logsConfig) logsConfig = serviceConfig.provider.logs = {};
+  if (!_.isObject(logsConfig.restApi)) logsConfig.restApi = {};
   logsConfig.restApi.format = JSON.stringify(API_GATEWAY_LOG_FORMAT);
 };
 
 const setupHttpApiLogs = serviceConfig => {
-  if (!serviceConfig.provider.logs) serviceConfig.provider.logs = {};
-
-  const logsConfig = serviceConfig.provider.logs;
-  if (!logsConfig.httpApi || typeof logsConfig.httpApi !== 'object') {
-    logsConfig.httpApi = {};
+  let logsConfig = serviceConfig.provider.logs;
+  if (logsConfig && logsConfig.httpApi != null) {
+    // Ensure to not override eventual specified logs configuration
+    if (!logsConfig.httpApi) return;
+    if (logsConfig.httpApi.format) return;
   }
+
+  if (!logsConfig) logsConfig = serviceConfig.provider.logs = {};
+  if (!_.isObject(logsConfig.httpApi)) logsConfig.httpApi = {};
   logsConfig.httpApi.format = JSON.stringify(API_GATEWAY_V2_LOG_FORMAT);
 };
 

--- a/lib/setApiGatewayAccessLogFormat.js
+++ b/lib/setApiGatewayAccessLogFormat.js
@@ -12,6 +12,15 @@ const setupHttpLogs = serviceConfig => {
     if (logsConfig.restApi.format) return;
   }
 
+  if (
+    !_.values(serviceConfig.functions).some(functionData =>
+      functionData.events.some(event => event.http)
+    )
+  ) {
+    // Do not proceed if there are no `http` events
+    return;
+  }
+
   if (!logsConfig) logsConfig = serviceConfig.provider.logs = {};
   if (!_.isObject(logsConfig.restApi)) logsConfig.restApi = {};
   logsConfig.restApi.format = JSON.stringify(API_GATEWAY_LOG_FORMAT);
@@ -23,6 +32,15 @@ const setupHttpApiLogs = serviceConfig => {
     // Ensure to not override eventual specified logs configuration
     if (!logsConfig.httpApi) return;
     if (logsConfig.httpApi.format) return;
+  }
+
+  if (
+    !_.values(serviceConfig.functions).some(functionData =>
+      functionData.events.some(event => event.httpApi)
+    )
+  ) {
+    // Do not proceed if there are no `httpApi` events
+    return;
   }
 
   if (!logsConfig) logsConfig = serviceConfig.provider.logs = {};

--- a/lib/setApiGatewayAccessLogFormat.test.js
+++ b/lib/setApiGatewayAccessLogFormat.test.js
@@ -13,6 +13,10 @@ describe('setApiGatewayAccessLogFormat', () => {
       sls: {
         service: {
           provider: {},
+          functions: {
+            http: { events: [{ http: {} }] },
+            httpApi: { events: [{ httpApi: {} }] },
+          },
         },
       },
     };
@@ -50,5 +54,19 @@ describe('setApiGatewayAccessLogFormat', () => {
     setApiGatewayAccessLogFormat(ctx);
     expect(ctx.sls.service.provider.logs.httpApi).to.deep.equal(expectedHttpApiLogsConfig);
     expect(ctx.sls.service.provider.logs.restApi).to.deep.equal({ format: 'myformat' });
+  });
+
+  it('Do not set the Rest API log format if there are no Rest API events configured', async () => {
+    delete ctx.sls.service.functions.http;
+    setApiGatewayAccessLogFormat(ctx);
+    expect(ctx.sls.service.provider.logs.httpApi).to.deep.equal(expectedHttpApiLogsConfig);
+    expect(ctx.sls.service.provider.logs.restApi).to.equal(undefined);
+  });
+
+  it('Do not set the HTTP API log format if there are no HTTP API events configured', async () => {
+    delete ctx.sls.service.functions.httpApi;
+    setApiGatewayAccessLogFormat(ctx);
+    expect(ctx.sls.service.provider.logs.httpApi).to.equal(undefined);
+    expect(ctx.sls.service.provider.logs.restApi).to.deep.equal(expectedRestApiLogsConfig);
   });
 });

--- a/lib/setApiGatewayAccessLogFormat.test.js
+++ b/lib/setApiGatewayAccessLogFormat.test.js
@@ -5,22 +5,9 @@ const { API_GATEWAY_LOG_FORMAT, API_GATEWAY_V2_LOG_FORMAT } = require('./utils')
 
 describe('setApiGatewayAccessLogFormat', () => {
   let ctx;
-  const expectedCtx = {
-    sls: {
-      service: {
-        provider: {
-          logs: {
-            restApi: {
-              format: JSON.stringify(API_GATEWAY_LOG_FORMAT),
-            },
-            httpApi: {
-              format: JSON.stringify(API_GATEWAY_V2_LOG_FORMAT),
-            },
-          },
-        },
-      },
-    },
-  };
+  const expectedRestApiLogsConfig = { format: JSON.stringify(API_GATEWAY_LOG_FORMAT) };
+  const expectedHttpApiLogsConfig = { format: JSON.stringify(API_GATEWAY_V2_LOG_FORMAT) };
+
   beforeEach(() => {
     ctx = {
       sls: {
@@ -39,24 +26,30 @@ describe('setApiGatewayAccessLogFormat', () => {
 
   it('sets the log format if no logs are configured', async () => {
     setApiGatewayAccessLogFormat(ctx);
-    expect(expectedCtx).to.deep.equal(ctx);
+    expect(ctx.sls.service.provider.logs.restApi).to.deep.equal(expectedRestApiLogsConfig);
+    expect(ctx.sls.service.provider.logs.httpApi).to.deep.equal(expectedHttpApiLogsConfig);
   });
 
   it('sets the log format if no restApi logs are configured', async () => {
     ctx.sls.service.provider = { logs: {} };
     setApiGatewayAccessLogFormat(ctx);
-    expect(expectedCtx).to.deep.equal(ctx);
+    expect(ctx.sls.service.provider.logs.restApi).to.deep.equal(expectedRestApiLogsConfig);
+    expect(ctx.sls.service.provider.logs.httpApi).to.deep.equal(expectedHttpApiLogsConfig);
   });
 
   it('sets the log format if rest/http-api logs are set to default format', async () => {
     ctx.sls.service.provider = { logs: { restApi: true, httpApi: true } };
     setApiGatewayAccessLogFormat(ctx);
-    expect(expectedCtx).to.deep.equal(ctx);
+    setApiGatewayAccessLogFormat(ctx);
+    expect(ctx.sls.service.provider.logs.restApi).to.deep.equal(expectedRestApiLogsConfig);
+    expect(ctx.sls.service.provider.logs.httpApi).to.deep.equal(expectedHttpApiLogsConfig);
   });
 
   it('sets the log format if rest/http-api logs are set with a different format', async () => {
     ctx.sls.service.provider = { logs: { restApi: { format: 'myformat' } } };
     setApiGatewayAccessLogFormat(ctx);
-    expect(expectedCtx).to.deep.equal(ctx);
+    setApiGatewayAccessLogFormat(ctx);
+    expect(ctx.sls.service.provider.logs.restApi).to.deep.equal(expectedRestApiLogsConfig);
+    expect(ctx.sls.service.provider.logs.httpApi).to.deep.equal(expectedHttpApiLogsConfig);
   });
 });

--- a/lib/setApiGatewayAccessLogFormat.test.js
+++ b/lib/setApiGatewayAccessLogFormat.test.js
@@ -45,11 +45,10 @@ describe('setApiGatewayAccessLogFormat', () => {
     expect(ctx.sls.service.provider.logs.httpApi).to.deep.equal(expectedHttpApiLogsConfig);
   });
 
-  it('sets the log format if rest/http-api logs are set with a different format', async () => {
+  it('Do not set the log format if rest/http-api logs are set with a different format', async () => {
     ctx.sls.service.provider = { logs: { restApi: { format: 'myformat' } } };
     setApiGatewayAccessLogFormat(ctx);
-    setApiGatewayAccessLogFormat(ctx);
-    expect(ctx.sls.service.provider.logs.restApi).to.deep.equal(expectedRestApiLogsConfig);
     expect(ctx.sls.service.provider.logs.httpApi).to.deep.equal(expectedHttpApiLogsConfig);
+    expect(ctx.sls.service.provider.logs.restApi).to.deep.equal({ format: 'myformat' });
   });
 });

--- a/lib/setApiGatewayAccessLogFormat.test.js
+++ b/lib/setApiGatewayAccessLogFormat.test.js
@@ -69,4 +69,18 @@ describe('setApiGatewayAccessLogFormat', () => {
     expect(ctx.sls.service.provider.logs.httpApi).to.equal(undefined);
     expect(ctx.sls.service.provider.logs.restApi).to.deep.equal(expectedRestApiLogsConfig);
   });
+
+  it('Do not set the Rest API log format if external Rest API is referenced', async () => {
+    ctx.sls.service.provider.apiGateway = { restApiId: 'foo' };
+    setApiGatewayAccessLogFormat(ctx);
+    expect(ctx.sls.service.provider.logs.httpApi).to.deep.equal(expectedHttpApiLogsConfig);
+    expect(ctx.sls.service.provider.logs.restApi).to.equal(undefined);
+  });
+
+  it('Do not set the HTTP API log format if external HTTP API is referenced', async () => {
+    ctx.sls.service.provider.httpApi = { id: 'foo' };
+    setApiGatewayAccessLogFormat(ctx);
+    expect(ctx.sls.service.provider.logs.httpApi).to.equal(undefined);
+    expect(ctx.sls.service.provider.logs.restApi).to.deep.equal(expectedRestApiLogsConfig);
+  });
 });


### PR DESCRIPTION
Fixes #425 

Currently Rest API and HTTP API logs setting are enforced no matter what, e.g.
- When no `http` or `httpApi` events are registered
- When logging is turned off explicitly
- When endpoints are attached to external Rest API or HTTP API
- When custom logging format is set (dashboard format is enforced silently).

This raised a numerous issues so far, e.g. https://github.com/serverless/enterprise-plugin/issues/425, https://github.com/serverless/serverless/issues/7650, https://github.com/serverless/serverless/issues/7186

This update ensures that logging is not turned on if:
- There are no `http`/`httpApi` events registered
- Configured endpoints are attached to external Rest/HTTP API

Also dashboard logs format is not set if in configuration other format is explicitly set