### PR TITLE
Upgrade platform-client to 0.25.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@serverless/event-mocks": "^1.1.1",
-    "@serverless/platform-client": "^0.25.7",
+    "@serverless/platform-client": "^0.25.14",
     "@serverless/platform-sdk": "^2.3.0",
     "chalk": "^2.4.2",
     "child-process-ext": "^2.1.1",

--- a/sdk-js/package-lock.json
+++ b/sdk-js/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "serverless-sdk-js",
-  "version": "0.0.1",
+  "name": "@serverless/sdk-js",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -314,9 +314,9 @@
       "dev": true
     },
     "@serverless/platform-client": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-0.25.7.tgz",
-      "integrity": "sha512-ZOKgT49qQPGjv0tDN46INO0gkc5syL2y5t0pau5ljQPtQpJzHrUL87xRlDj3BD+4Y9QFZV1UXXNsOQZsyCBsPw==",
+      "version": "0.25.14",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-0.25.14.tgz",
+      "integrity": "sha512-ww5GBt5QEHYppLH8X+gEFiuMoFu9xdXK0bEROYbuxUliiB0IfXTXLzWR5whhi/S94R7pTnJ4O+WUiFj0PcV/tQ==",
       "requires": {
         "adm-zip": "^0.4.13",
         "axios": "^0.19.2",

--- a/sdk-js/package.json
+++ b/sdk-js/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@serverless/platform-client": "^0.25.7",
+    "@serverless/platform-client": "^0.25.14",
     "after-all-results": "^2.0.0",
     "flat": "^5.0.0",
     "lodash": "^4.17.15",


### PR DESCRIPTION
Use the latest `platform-client` to take advantage of the timeout changes @eahefnawy made to help WebSocket disconnects.