### PR TITLE
Downgrade uuid  to v3

### DIFF
--- a/lib/interactiveCli/register.test.js
+++ b/lib/interactiveCli/register.test.js
@@ -4,6 +4,7 @@ const { join } = require('path');
 const sinon = require('sinon');
 const { readFile, writeFile } = require('fs-extra');
 const yaml = require('yamljs');
+const resolveSync = require('ncjsm/resolve/sync');
 const runServerless = require('@serverless/test/run-serverless');
 const configureInquirerStub = require('@serverless/test/configure-inquirer-stub');
 const { getLoggedInUser, writeConfigFile } = require('@serverless/platform-sdk');
@@ -65,7 +66,7 @@ describe('interactiveCli: register', function () {
     backupIsTTY = process.stdin.isTTY;
     process.stdin.isTTY = true;
     serverlessPath = (await setupServerless()).root;
-    const inquirerPath = join(serverlessPath, 'lib/plugins/interactiveCli/inquirer');
+    const inquirerPath = resolveSync(serverlessPath, '@serverless/inquirer').realPath;
     inquirer = require(inquirerPath);
     modulesCacheStub = {
       [require.resolve(inquirerPath)]: inquirer,

--- a/lib/interactiveCli/set-app.test.js
+++ b/lib/interactiveCli/set-app.test.js
@@ -4,6 +4,7 @@ const { join } = require('path');
 const sinon = require('sinon');
 const { readFile, writeFile } = require('fs-extra');
 const yaml = require('yamljs');
+const resolveSync = require('ncjsm/resolve/sync');
 const runServerless = require('@serverless/test/run-serverless');
 const configureInquirerStub = require('@serverless/test/configure-inquirer-stub');
 const { getLoggedInUser } = require('@serverless/platform-sdk');
@@ -46,7 +47,7 @@ describe('interactiveCli: set-app', function () {
     const { root, version } = await setupServerless();
     serverlessPath = root;
     serverlessVersion = version;
-    const inquirerPath = join(serverlessPath, 'lib/plugins/interactiveCli/inquirer');
+    const inquirerPath = resolveSync(serverlessPath, '@serverless/inquirer').realPath;
     inquirer = require(inquirerPath);
     createAppStub = sinon.spy(async ({ app }) => ({ appName: app }));
     setDefaultDeploymentProfileStub = sinon.stub().resolves();

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "simple-git": "^1.132.0",
     "source-map-support": "^0.5.19",
     "update-notifier": "^2.5.0",
-    "uuid": "^8.0.0",
+    "uuid": "^3.4.0",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
While v8 sort of works with Node.js v6, this version of Node.js is not advertised as supported by uuid v8, and we received reports that this upgrade is problematic.

Related issue: https://github.com/serverless/serverless/pull/7778