### PR TITLE
Return callback result in SDK span

### DIFF
--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -29,7 +29,6 @@ const resolveAndValidateLog = (encodedLogMsg) => {
   if (result.b) {
     const zipped = new Buffer(result.b, 'base64');
     const unzipped = JSON.parse(zlib.gunzipSync(zipped));
-    log.debug('log object %o', unzipped);
     return unzipped;
   }
   return result;
@@ -348,8 +347,8 @@ const setupTests = (mode, env = {}) => {
       );
       expect(payload.payload.spans[3].tags).to.deep.equal({
         type: 'http',
-        requestHostname: 'example.com',
-        requestPath: '/',
+        requestHostname: 'httpbin.org',
+        requestPath: '/get',
         httpMethod: 'GET',
         httpStatus: 200,
       });
@@ -404,8 +403,8 @@ const setupTests = (mode, env = {}) => {
       );
       expect(payload.payload.spans[3].tags).to.deep.equal({
         type: 'http',
-        requestHostname: 'example.com',
-        requestPath: '/',
+        requestHostname: 'httpbin.org',
+        requestPath: '/get',
         httpMethod: 'GET',
         httpStatus: 200,
       });

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -364,7 +364,7 @@ class ServerlessSDK {
           const startTime = new Date().toISOString();
           const start = Date.now();
 
-          const end = () => {
+          const end = (result) => {
             const endTime = new Date().toISOString();
             spanEmitter.emit('span', {
               tags: {
@@ -375,6 +375,7 @@ class ServerlessSDK {
               endTime,
               duration: Date.now() - start,
             });
+            return result;
           };
 
           let result;
@@ -386,7 +387,7 @@ class ServerlessSDK {
           }
           if (isThenable(result)) return result.then(end);
           end();
-          return null;
+          return result;
         };
         contextProxy.serverlessSdk.span = contextProxy.span; // TODO deprecate in next major rev
         // eslint-disable-next-line no-underscore-dangle

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -361,19 +361,18 @@ class ServerlessSDK {
 
         // user spans
         contextProxy.span = (tag, userCode) => {
-          const startTime = new Date().toISOString();
-          const start = Date.now();
+          const startTime = new Date();
 
           const end = (result) => {
-            const endTime = new Date().toISOString();
+            const endTime = new Date();
             spanEmitter.emit('span', {
               tags: {
                 type: 'custom',
                 label: tag,
               },
-              startTime,
-              endTime,
-              duration: Date.now() - start,
+              startTime: startTime.toISOString(),
+              endTime: endTime.toISOString(),
+              duration: endTime.getTime() - startTime.getTime(),
             });
             return result;
           };
@@ -386,8 +385,7 @@ class ServerlessSDK {
             throw e;
           }
           if (isThenable(result)) return result.then(end);
-          end();
-          return result;
+          return end(result);
         };
         contextProxy.serverlessSdk.span = contextProxy.span; // TODO deprecate in next major rev
         // eslint-disable-next-line no-underscore-dangle
@@ -472,7 +470,7 @@ class ServerlessSDK {
 
   static span(label, userCode) {
     // eslint-disable-next-line no-underscore-dangle
-    ServerlessSDK._span(label, userCode);
+    return ServerlessSDK._span(label, userCode);
   }
 
   static tagEvent(label, tag, custom) {


### PR DESCRIPTION
Allows for simpler usage:
```javascript
const foo = await sdk.span('bar', () => Promise.resolve(new Foo()))
```
Prior to this, users would have to
```javascript
let foo
foo = await sdk.span('bar', () => Promise.resolve(new Foo()))
```
Which would get tedious if there were a non-trivial number of span calls.