### PR TITLE
fix: Look for serverless.ts config

### DIFF
--- a/lib/deployment/getServerlessFilePath.js
+++ b/lib/deployment/getServerlessFilePath.js
@@ -26,12 +26,14 @@ module.exports = async function getServerlessFilePath(filename, servicePath) {
   const yamlFilePath = path.join(servicePath, 'serverless.yaml');
   const jsonFilePath = path.join(servicePath, 'serverless.json');
   const jsFilePath = path.join(servicePath, 'serverless.js');
+  const tsFilePath = path.join(servicePath, 'serverless.ts');
 
-  const [json, yml, yaml, js] = await Promise.all([
+  const [json, yml, yaml, js, ts] = await Promise.all([
     fileExists(jsonFilePath),
     fileExists(ymlFilePath),
     fileExists(yamlFilePath),
     fileExists(jsFilePath),
+    fileExists(tsFilePath),
   ]);
   if (yml) {
     return ymlFilePath;
@@ -41,6 +43,8 @@ module.exports = async function getServerlessFilePath(filename, servicePath) {
     return jsonFilePath;
   } else if (js) {
     return jsFilePath;
+  } else if (ts) {
+    return tsFilePath;
   }
   throw new Error('Could not find any serverless service definition file.');
 };

--- a/lib/deployment/getServerlessFilePath.test.js
+++ b/lib/deployment/getServerlessFilePath.test.js
@@ -17,6 +17,7 @@ describe('getServerlessFilePath', () => {
     expect(lstat.calledWith(path.sep + ['foobar', 'serverless.yaml'].join(path.sep))).to.be.true;
     expect(lstat.calledWith(path.sep + ['foobar', 'serverless.json'].join(path.sep))).to.be.true;
     expect(lstat.calledWith(path.sep + ['foobar', 'serverless.js'].join(path.sep))).to.be.true;
+    expect(lstat.calledWith(path.sep + ['foobar', 'serverless.ts'].join(path.sep))).to.be.true;
   });
 
   it('returns the custom.yml first', async () => {


### PR DESCRIPTION
Adds `serverless.ts` to the list of default config files to search for.

Closes #455 