### PR TITLE
Fix Python span integration tests

### DIFF
--- a/integration-testing/wrapper-service/handler.py
+++ b/integration-testing/wrapper-service/handler.py
@@ -1,12 +1,15 @@
 import time
 import boto3
-from botocore.vendored import requests
+try:
+  from urllib2 import urlopen
+except ImportError:
+  from urllib.request import urlopen
 
 def success(event, context):
     with context.serverless_sdk.span('create sts client'):
         sts = boto3.client('sts')
     sts.get_caller_identity()
-    requests.get('https://httpbin.org/get')
+    urlopen('https://httpbin.org/get').read()
     return 'success'
 
 def error(event, context):
@@ -14,6 +17,7 @@ def error(event, context):
 
 def http_error(event, context):
     try:
+        from botocore.vendored import requests
         requests.get("https://asdfkasdjsdf")
     except:
         pass


### PR DESCRIPTION
Not exactly sure if a regression was introduced in upstream requests lib
(via vendorized botocore) but it seems like there's indeed a duplicate http
request being made!

Rather than go down the rabbit hole of trying to debug this issue, I
figured we might as well future proof us for upcoming planned changes to
the AWS Python Lambda runtime detailed here:
https://aws.amazon.com/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/

TL;DR don't rely on botocore vendorized requests lib for python 2.7 span
integration tests