### PR TITLE
CI: Run Node.js v6 tests in isolated mode

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -315,7 +315,7 @@ jobs:
       - name: Unit tests
         run: |
           export LOCAL_SERVERLESS_LINK_PATH=`./scripts/setupTestServerless.js`
-          npm test -- --require "@babel/register" -b
+          npm run test:isolated -- --require "@babel/register" -b
       - name: SDK JS Unit tests
         run: |
           cd sdk-js

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -324,7 +324,7 @@ jobs:
       - name: Unit tests
         run: |
           export LOCAL_SERVERLESS_LINK_PATH=`./scripts/setupTestServerless.js`
-          npm test -- --require "@babel/register" -b
+          npm run test:isolated -- --require "@babel/register" -b
       - name: SDK JS Unit tests
         run: |
           cd sdk-js

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/register": "^7.10.5",
     "@serverless/eslint-config": "^2.2.0",
-    "@serverless/test": "^4.5.0",
+    "@serverless/test": "^4.6.0",
     "aws-sdk": "^2.736.0",
     "chai": "^4.2.0",
     "eslint": "^7.7.0",


### PR DESCRIPTION
It's to prevent segmentation fault errors