### PR TITLE
Improve version update notifications

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -593,7 +593,7 @@ class ServerlessEnterprisePlugin {
     this.provider = this.sls.getProvider('aws');
     if (this.sls.enterpriseEnabled) {
       if (!this.sls.isStandaloneExecutable && !this.sls.interactiveCli) {
-        const updates = updateNotifier({ pkg: sfePkgJson, interval: 1 });
+        const updates = updateNotifier({ pkg: sfePkgJson });
         if (updates.update) {
           this.sls.cli.log(
             'An updated version of the Serverless Dashboard is available. ' +

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -593,8 +593,8 @@ class ServerlessEnterprisePlugin {
     this.provider = this.sls.getProvider('aws');
     if (this.sls.enterpriseEnabled) {
       if (!this.sls.isStandaloneExecutable && !this.sls.interactiveCli) {
-        const updates = updateNotifier({ pkg: sfePkgJson });
-        if (updates.update) {
+        const notifier = updateNotifier({ pkg: sfePkgJson });
+        if (notifier.update) {
           this.sls.cli.log(
             'An updated version of the Serverless Dashboard is available. ' +
               'Please upgrade by running `npm i -g serverless`'

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -594,7 +594,7 @@ class ServerlessEnterprisePlugin {
     if (this.sls.enterpriseEnabled) {
       if (!this.sls.isStandaloneExecutable && !this.sls.interactiveCli) {
         const notifier = updateNotifier({ pkg: sfePkgJson });
-        if (notifier.update) {
+        if (notifier.update && notifier.update.type !== 'major') {
           this.sls.cli.log(
             'An updated version of the Serverless Dashboard is available. ' +
               'Please upgrade by running `npm i -g serverless`'


### PR DESCRIPTION
Notify only of _patch_ and _minor_ updates (new major can only be picked by new Framework version, which has other update notifier running on its own)