### PR TITLE
Remove "update-notifier" notifications

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,14 +2,12 @@
 
 const chalk = require('chalk');
 const _ = require('lodash');
-const updateNotifier = require('update-notifier');
 const {
   configureFetchDefaults,
   openBrowser,
   getAccessKeyForTenant,
   getMetadata,
 } = require('@serverless/platform-sdk');
-const sfePkgJson = require('../package');
 const errorHandler = require('./errorHandler');
 const logsCollection = require('./logsCollection');
 const login = require('./login');
@@ -595,18 +593,7 @@ class ServerlessEnterprisePlugin {
     // in serverless, which will discard plugin when command not run in service context:
     // https://github.com/serverless/serverless/blob/f0ccf6441ace7b5cc524e774f025a39c3c0667f2/lib/classes/PluginManager.js#L78
     this.provider = this.sls.getProvider('aws');
-    if (this.sls.enterpriseEnabled) {
-      if (!this.sls.isStandaloneExecutable && !this.sls.interactiveCli) {
-        const notifier = updateNotifier({ pkg: sfePkgJson });
-        if (notifier.update && notifier.update.type !== 'major') {
-          this.sls.cli.log(
-            'An updated version of the Serverless Dashboard is available. ' +
-              'Please upgrade by running `npm i -g serverless`'
-          );
-        }
-      }
-      await configureDeployProfile(this);
-    }
+    if (this.sls.enterpriseEnabled) await configureDeployProfile(this);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "semver": "^6.3.0",
     "simple-git": "^1.132.0",
     "source-map-support": "^0.5.19",
-    "update-notifier": "^2.5.0",
     "uuid": "^3.4.0",
     "yamljs": "^0.3.0"
   },


### PR DESCRIPTION
New plugin releases are no longer frequent, and any important are usually followed by Framework release.
Also it's removed in response to https://github.com/serverless/serverless/pull/8185