### PR TITLE
SDK method exposing Serverless Dashboard transaction id

### DIFF
--- a/integration-testing/wrapper-service/handler.js
+++ b/integration-testing/wrapper-service/handler.js
@@ -141,7 +141,7 @@ module.exports.timeout = () => new Promise((resolve) => setTimeout(resolve, 1000
 module.exports.getTransactionId = async (event, context) => {
   const transactionId = context.serverlessSdk.getTransactionId();
   if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(transactionId)) {
-    return 'asyncReturn';
+    return 'success';
   }
   throw new Error(`transactionId not set/uuid: ${transactionId}`);
 };

--- a/integration-testing/wrapper-service/handler.js
+++ b/integration-testing/wrapper-service/handler.js
@@ -137,3 +137,11 @@ module.exports.waitForEmptyLoop = (event, context, callback) => {
 };
 
 module.exports.timeout = () => new Promise((resolve) => setTimeout(resolve, 10000));
+
+module.exports.getTransactionId = async (event, context) => {
+  const transactionId = context.serverlessSdk.getTransactionId();
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(transactionId)) {
+    return 'asyncReturn';
+  }
+  throw new Error(`transactionId not set/uuid: ${transactionId}`);
+};

--- a/integration-testing/wrapper-service/handler.py
+++ b/integration-testing/wrapper-service/handler.py
@@ -1,5 +1,6 @@
 import time
 import boto3
+import re
 try:
   from urllib2 import urlopen
 except ImportError:
@@ -33,3 +34,10 @@ def set_endpoint(event, context):
 
 def timeout(event, context):
     time.sleep(10)
+
+def get_transaction_id(event, context):
+    transaction_id = context.serverless_sdk.get_transaction_id()
+    print(transaction_id)
+    if re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", transaction_id):
+        return "success"
+    raise Exception("transactionId not set/uuid: {}".format(transaction_id))

--- a/integration-testing/wrapper-service/serverless.yml
+++ b/integration-testing/wrapper-service/serverless.yml
@@ -50,6 +50,8 @@ functions:
     handler: handler.timeout
   waitForEmptyLoop:
     handler: handler.waitForEmptyLoop
+  getTransactionId:
+    handler: handler.getTransactionId
 
   # Python handlers
   pythonSuccess:
@@ -76,3 +78,6 @@ functions:
   pythonSubModule:
     handler: submodule/handler.success
     runtime: python3.7
+  pythonTransactionId:
+    handler: handler.get_transaction_id
+    runtime: python3.8

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -437,6 +437,15 @@ const setupTests = (mode, env = {}) => {
       expect(payload.type).to.equal('report');
     });
 
+    it('gets the current transaction id in wrapped node handler', async () => {
+      const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+        LogType: 'Tail',
+        FunctionName: `${serviceName}-dev-getTransactionId`,
+      });
+      const payload = resolveAndValidateLog(LogResult);
+      expect(payload.type).to.equal('transaction');
+    });
+
     it('gets the return value when calling python', async () => {
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
@@ -653,6 +662,15 @@ const setupTests = (mode, env = {}) => {
       const result = resolveAndValidateLog(LogResult);
       expect(result.type).to.equal('transaction');
       expect(JSON.parse(Payload)).to.equal('success');
+    });
+
+    it('gets the current transaction id in wrapped python handler', async () => {
+      const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+        LogType: 'Tail',
+        FunctionName: `${serviceName}-dev-pythonTransactionId`,
+      });
+      const payload = resolveAndValidateLog(LogResult);
+      expect(payload.type).to.equal('transaction');
     });
   });
 };

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -422,6 +422,10 @@ class ServerlessSDK {
         // eslint-disable-next-line no-underscore-dangle
         ServerlessSDK._setEndpoint = contextProxy.serverlessSdk.setEndpoint;
 
+        contextProxy.serverlessSdk.getTransactionId = () => trans.$.schema.transactionId;
+        // eslint-disable-next-line no-underscore-dangle
+        ServerlessSDK._getTransactionId = contextProxy.serverlessSdk.getTransactionId;
+
         /*
          * Try Running Code
          */
@@ -481,6 +485,10 @@ class ServerlessSDK {
   static setEndpoint(endpoint) {
     // eslint-disable-next-line no-underscore-dangle
     ServerlessSDK._setEndpoint(endpoint);
+  }
+
+  static getTransactionId() {
+    return ServerlessSDK._getTransactionId();
   }
 }
 

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -423,7 +423,6 @@ class ServerlessSDK {
         ServerlessSDK._setEndpoint = contextProxy.serverlessSdk.setEndpoint;
 
         contextProxy.serverlessSdk.getTransactionId = () => trans.$.schema.transactionId;
-        // eslint-disable-next-line no-underscore-dangle
         ServerlessSDK._getTransactionId = contextProxy.serverlessSdk.getTransactionId;
 
         /*


### PR DESCRIPTION
This is helpful in situations where you'd want to log the transaction id to logs/external system like Sentry to aid debugging.