### PR TITLE
Import from @serverless/utils/inquirer

### DIFF
--- a/lib/interactiveCli/register.test.js
+++ b/lib/interactiveCli/register.test.js
@@ -54,7 +54,7 @@ const platformSdkStub = {
   writeConfigFile,
 };
 
-describe('interactiveCli: register', function () {
+describe('interactiveCli: register', function() {
   this.timeout(1000 * 60 * 3);
 
   let modulesCacheStub;
@@ -65,7 +65,7 @@ describe('interactiveCli: register', function () {
     backupIsTTY = process.stdin.isTTY;
     process.stdin.isTTY = true;
     const serverlessPath = (await setupServerless()).root;
-    const inquirerPath = resolveSync(serverlessPath, '@serverless/inquirer').realPath;
+    const inquirerPath = resolveSync(serverlessPath, '@serverless/utils/inquirer').realPath;
     inquirer = require(inquirerPath);
     modulesCacheStub = {
       [require.resolve(inquirerPath)]: inquirer,

--- a/lib/interactiveCli/register.test.js
+++ b/lib/interactiveCli/register.test.js
@@ -54,7 +54,7 @@ const platformSdkStub = {
   writeConfigFile,
 };
 
-describe('interactiveCli: register', function() {
+describe('interactiveCli: register', function () {
   this.timeout(1000 * 60 * 3);
 
   let modulesCacheStub;

--- a/lib/interactiveCli/set-app.test.js
+++ b/lib/interactiveCli/set-app.test.js
@@ -47,7 +47,7 @@ describe('interactiveCli: set-app', function () {
     const { root, version } = await setupServerless();
     serverlessPath = root;
     serverlessVersion = version;
-    const inquirerPath = resolveSync(serverlessPath, '@serverless/inquirer').realPath;
+    const inquirerPath = resolveSync(serverlessPath, '@serverless/utils/inquirer').realPath;
     inquirer = require(inquirerPath);
     createAppStub = sinon.spy(async ({ app }) => ({ appName: app }));
     setDefaultDeploymentProfileStub = sinon.stub().resolves();


### PR DESCRIPTION
`@serverless/inquirer` was dropped because it was moved into `utils` in v2

This broke integration tests here which rely, perhaps in a brittle way, on the framework installing `@serverless/inquirer`.
This PR should fix the tests.