### PR TITLE
Fix `outputs` schema

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -76,7 +76,7 @@ class ServerlessEnterprisePlugin {
         type: 'object',
         patternProperties: {
           '^[a-zA-Z0-9]+$': {
-            oneOf: [
+            anyOf: [
               { type: 'string' },
               { type: 'number' },
               { type: 'boolean' },

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -74,18 +74,15 @@ class ServerlessEnterprisePlugin {
       });
       sls.configSchemaHandler.defineTopLevelProperty('outputs', {
         type: 'object',
-        patternProperties: {
-          '^[a-zA-Z0-9]+$': {
-            anyOf: [
-              { type: 'string' },
-              { type: 'number' },
-              { type: 'boolean' },
-              { type: 'array' },
-              { type: 'object' },
-            ],
-          },
+        additionalProperties: {
+          anyOf: [
+            { type: 'string' },
+            { type: 'number' },
+            { type: 'boolean' },
+            { type: 'array' },
+            { type: 'object' },
+          ],
         },
-        additionalProperties: false,
       });
       sls.configSchemaHandler.defineCustomProperties({
         properties: {


### PR DESCRIPTION
Fixes #506 

After https://github.com/serverless/serverless/pull/8319 in some schema scenarios primitives got converted to arrays, and that happened for `outputs`

This patch ensures it's not the case.

Additionally it fixes the issue of too restrictive outputs name schema. It followed restrictions on AWS side, while on our side there are no name restrictions