### PR TITLE
Expose SDK method to fetch dashboard url for current transaction

### DIFF
--- a/integration-testing/setup.js
+++ b/integration-testing/setup.js
@@ -29,10 +29,11 @@ module.exports = async function (templateName) {
       return writeFile(
         slsYamlPath,
         slsYamlString
-          .replace('SERVICE_PLACEHOLDER', serviceName)
-          .replace('REGION_PLACEHOLDER', region)
-          .replace('ORG_PLACEHOLDER', process.env.SERVERLESS_PLATFORM_TEST_ORG || 'integration')
-          .replace('APP_PLACEHOLDER', process.env.SERVERLESS_PLATFORM_TEST_APP || 'integration')
+          .replace(/SERVICE_PLACEHOLDER/g, serviceName)
+          .replace(/REGION_PLACEHOLDER/g, region)
+          .replace(/ORG_PLACEHOLDER/g, process.env.SERVERLESS_PLATFORM_TEST_ORG || 'integration')
+          .replace(/APP_PLACEHOLDER/g, process.env.SERVERLESS_PLATFORM_TEST_APP || 'integration')
+          .replace(/STAGE_PLACEHOLDER/g, process.env.SERVERLESS_PLATFORM_TEST_STAGE || 'dev')
       );
     }),
     setupServerless().then((data) => data.binary),

--- a/integration-testing/wrapper-service/handler.js
+++ b/integration-testing/wrapper-service/handler.js
@@ -145,3 +145,25 @@ module.exports.getTransactionId = async (event, context) => {
   }
   throw new Error(`transactionId not set/uuid: ${transactionId}`);
 };
+
+module.exports.getDashboardUrl = async (event, context) => {
+  const url = context.serverlessSdk.getDashboardUrl();
+  const domain = process.env.PLATFORM_STAGE === 'prod' ? 'serverless' : 'serverless-dev';
+  const re = new RegExp(
+    [
+      `https://app.${domain}.com`,
+      process.env.ORG,
+      'apps',
+      process.env.APP,
+      process.env.SERVICE,
+      process.env.STAGE,
+      process.env.REGION,
+      'explorer',
+      '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+    ].join('/')
+  );
+  if (re.test(url)) {
+    return 'success';
+  }
+  throw new Error(`dashboard url incorrect: ${url}`);
+};

--- a/integration-testing/wrapper-service/handler.py
+++ b/integration-testing/wrapper-service/handler.py
@@ -1,6 +1,7 @@
 import time
 import boto3
 import re
+import os
 try:
   from urllib2 import urlopen
 except ImportError:
@@ -37,7 +38,24 @@ def timeout(event, context):
 
 def get_transaction_id(event, context):
     transaction_id = context.serverless_sdk.get_transaction_id()
-    print(transaction_id)
     if re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", transaction_id):
         return "success"
     raise Exception("transactionId not set/uuid: {}".format(transaction_id))
+
+def get_dashboard_url(event, context):
+    url = context.serverless_sdk.get_dashboard_url()
+    domain = "serverless" if os.getenv("PLATFORM_STAGE", "dev") == "prod" else "serverless-dev"
+    exp = "/".join([
+      "https://app.{}.com".format(domain),
+      os.getenv("ORG"),
+      "apps",
+      os.getenv("APP"),
+      os.getenv("SERVICE"),
+      os.getenv("STAGE"),
+      os.getenv("REGION"),
+      "explorer",
+      "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    ])
+    if re.match(exp, url):
+        return "success"
+    raise Exception("dashboard url incorrect: {}".format(url))

--- a/integration-testing/wrapper-service/serverless.yml
+++ b/integration-testing/wrapper-service/serverless.yml
@@ -52,6 +52,15 @@ functions:
     handler: handler.waitForEmptyLoop
   getTransactionId:
     handler: handler.getTransactionId
+  getDashboardUrl:
+    handler: handler.getDashboardUrl
+    environment:
+      PLATFORM_STAGE: ${env:SERVERLESS_PLATFORM_STAGE}
+      ORG: ORG_PLACEHOLDER
+      APP: APP_PLACEHOLDER
+      SERVICE: SERVICE_PLACEHOLDER
+      STAGE: STAGE_PLACEHOLDER
+      REGION: REGION_PLACEHOLDER
 
   # Python handlers
   pythonSuccess:
@@ -81,3 +90,13 @@ functions:
   pythonTransactionId:
     handler: handler.get_transaction_id
     runtime: python3.8
+  pythonDashboardUrl:
+    handler: handler.get_dashboard_url
+    runtime: python3.8
+    environment:
+      PLATFORM_STAGE: ${env:SERVERLESS_PLATFORM_STAGE}
+      ORG: ORG_PLACEHOLDER
+      APP: APP_PLACEHOLDER
+      SERVICE: SERVICE_PLACEHOLDER
+      STAGE: STAGE_PLACEHOLDER
+      REGION: REGION_PLACEHOLDER

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -446,6 +446,15 @@ const setupTests = (mode, env = {}) => {
       expect(payload.type).to.equal('transaction');
     });
 
+    it('gets dashboard url for current transaction in wrapped node handler', async () => {
+      const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+        LogType: 'Tail',
+        FunctionName: `${serviceName}-dev-getDashboardUrl`,
+      });
+      const payload = resolveAndValidateLog(LogResult);
+      expect(payload.type).to.equal('transaction');
+    });
+
     it('gets the return value when calling python', async () => {
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
@@ -668,6 +677,15 @@ const setupTests = (mode, env = {}) => {
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
         FunctionName: `${serviceName}-dev-pythonTransactionId`,
+      });
+      const payload = resolveAndValidateLog(LogResult);
+      expect(payload.type).to.equal('transaction');
+    });
+
+    it('gets dashboard url for current transaction in wrapped python handler', async () => {
+      const { LogResult } = await awsRequest(lambdaService, 'invoke', {
+        LogType: 'Tail',
+        FunctionName: `${serviceName}-dev-pythonDashboardUrl`,
       });
       const payload = resolveAndValidateLog(LogResult);
       expect(payload.type).to.equal('transaction');

--- a/lib/wrap.js
+++ b/lib/wrap.js
@@ -240,7 +240,8 @@ sdk = serverless_sdk.SDK(
       ctx.sls.service.custom.enterprise.disableFrameworksInstrumentation
         ? 'True'
         : 'False'
-    }
+    },
+    serverless_platform_stage='${process.env.SERVERLESS_PLATFORM_STAGE || 'prod'}'
 )
 handler_wrapper_kwargs = {'function_name': '${fn.name}', 'timeout': ${fn.timeout}}
 try:

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -429,7 +429,8 @@ sdk = serverless_sdk.SDK(
     disable_http_spans=False,
     stage_name='dev',
     plugin_version='${version}',
-    disable_frameworks_instrumentation=False
+    disable_frameworks_instrumentation=False,
+    serverless_platform_stage: 'prod',
 )
 handler_wrapper_kwargs = {'function_name': 'service-dev-dunc', 'timeout': 6}
 try:

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -430,7 +430,7 @@ sdk = serverless_sdk.SDK(
     stage_name='dev',
     plugin_version='${version}',
     disable_frameworks_instrumentation=False,
-    serverless_platform_stage: 'prod',
+    serverless_platform_stage='prod',
 )
 handler_wrapper_kwargs = {'function_name': 'service-dev-dunc', 'timeout': 6}
 try:

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -430,7 +430,7 @@ sdk = serverless_sdk.SDK(
     stage_name='dev',
     plugin_version='${version}',
     disable_frameworks_instrumentation=False,
-    serverless_platform_stage='prod',
+    serverless_platform_stage='prod'
 )
 handler_wrapper_kwargs = {'function_name': 'service-dev-dunc', 'timeout': 6}
 try:

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -418,6 +418,23 @@ class ServerlessSDK {
         contextProxy.serverlessSdk.getTransactionId = () => trans.$.schema.transactionId;
         ServerlessSDK._getTransactionId = contextProxy.serverlessSdk.getTransactionId;
 
+        contextProxy.serverlessSdk.getDashboardUrl = (transactionId) => {
+          const domain =
+            this.$.serverlessPlatformStage === 'prod' ? 'serverless' : 'serverless-dev';
+          return [
+            `https://app.${domain}.com`,
+            trans.$.schema.tenantId,
+            'apps',
+            trans.$.schema.applicationName,
+            trans.$.schema.serviceName,
+            trans.$.schema.stageName,
+            trans.$.schema.compute.region,
+            'explorer',
+            transactionId || contextProxy.serverlessSdk.getTransactionId(),
+          ].join('/');
+        };
+        ServerlessSDK._getDashboardUrl = contextProxy.serverlessSdk.getDashboardUrl;
+
         /*
          * Try Running Code
          */
@@ -477,6 +494,10 @@ class ServerlessSDK {
 
   static getTransactionId() {
     return ServerlessSDK._getTransactionId();
+  }
+
+  static getDashboardUrl(transactionId) {
+    return ServerlessSDK._getDashboardUrl(transactionId);
   }
 }
 


### PR DESCRIPTION
URL can be logged to 3rd party monitoring sites (like Sentry) and link to transaction details page on Serverless Dashboard.