### PR TITLE
Bump platform client to 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.1.1](https://github.com/serverless/enterprise-plugin/compare/v4.1.0...v4.1.1) (2020-10-13)
+
+### Bug Fixes
+
+- Major upgrade of platform-client which moves to namespaced SDK methods
+- Includes a fix to encodeURI for instanceUIDs which may not be URI safe
+
 ### [4.1.0](https://github.com/serverless/enterprise-plugin/compare/v4.0.4...v4.1.0) (2020-10-13)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "serverless/enterprise-plugin",
   "dependencies": {
     "@serverless/event-mocks": "^1.1.1",
-    "@serverless/platform-client": "^3.1.1",
+    "@serverless/platform-client": "^3.1.2",
     "@serverless/platform-sdk": "^2.3.2",
     "chalk": "^4.1.0",
     "child-process-ext": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/enterprise-plugin",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "The Serverless Dashboard plugin",
   "author": "serverless.com",
   "repository": "serverless/enterprise-plugin",


### PR DESCRIPTION
- Includes fix to encodeURI for stageNames which perhaps haven't been resolved yet (and may not be uri-safe)
- releases v4.1.1