### PR TITLE
Remove single studio process restriction

### DIFF
--- a/lib/studio.js
+++ b/lib/studio.js
@@ -5,7 +5,6 @@ const chokidar = require('chokidar');
 const { ServerlessSDK } = require('@serverless/platform-client');
 const { getAccessKeyForTenant } = require('@serverless/platform-sdk');
 const { isEqual } = require('lodash');
-const findProcess = require('find-process');
 
 const isAuthenticated = require('./isAuthenticated');
 const throwAuthError = require('./throwAuthError');
@@ -94,24 +93,6 @@ module.exports = async function (ctx) {
    */
   if (deployToStage === 'prod') {
     sls.cli.log("Stage 'prod' cannot be used with 'serverless studio'");
-    return;
-  }
-
-  /**
-   * Check to see if 'serverless studio' is already running
-   */
-  const processes = await findProcess('name', /(serverless|sls) studio/g);
-
-  if (processes.length === 0) {
-    sls.cli.log('Failed to detect running serverless process. Exiting.');
-    return;
-  }
-
-  /**
-   * Only one process can be running
-   */
-  if (processes.length > 1) {
-    sls.cli.log("Only one instance of 'serverless studio' can be running");
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "child-process-ext": "^2.1.1",
     "chokidar": "^3.4.3",
     "cli-color": "^2.0.0",
-    "find-process": "^1.4.3",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
     "js-yaml": "^3.14.0",


### PR DESCRIPTION
This was an arbitrary limitation we added to the studio process. This method used to detect an already running process is rather buggy, too. There have been several reports, from people who run Windows, that this doesn't not work, and `serverless studio` will fail to run. I think we should just remove this hack for now.