### PR TITLE
Ensure "sls test" command exits with non zero code on fail

### DIFF
--- a/lib/deployment/parse.test.js
+++ b/lib/deployment/parse.test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const path = require('path');
-const fse = require('fs-extra');
 const proxyquire = require('proxyquire');
 const { version: pluginVersion } = require('../../package.json');
 const { version: sdkVersion } = require('@serverless/platform-sdk/package.json');
@@ -1534,12 +1532,7 @@ describe('parseDeploymentData', () => {
 
 const runServerless = require('../../test/run-serverless');
 
-const fixturesPath = path.join(__dirname, '../../test/fixtures');
-const awsLoggedinMonitoredServicePath = path.join(fixturesPath, 'aws-loggedin-monitored-service');
-
 describe('parseDeploymentData #2', () => {
-  after(() => fse.remove(path.resolve(awsLoggedinMonitoredServicePath, '.serverless')));
-
   it('Should support sumple-git v2.5', async () => {
     // See https://github.com/steveukx/git-js/issues/512
     const modulesCacheStub = {
@@ -1626,7 +1619,7 @@ describe('parseDeploymentData #2', () => {
       },
     };
     await runServerless({
-      cwd: awsLoggedinMonitoredServicePath,
+      fixture: 'aws-loggedin-monitored-service',
       cliArgs: ['deploy'],
       modulesCacheStub,
       awsRequestStubMap,

--- a/lib/interactiveCli/index.test.js
+++ b/lib/interactiveCli/index.test.js
@@ -1,17 +1,9 @@
 'use strict';
 
-const { join } = require('path');
 const sinon = require('sinon');
 const runServerless = require('../../test/run-serverless');
 const { getLoggedInUser } = require('@serverless/platform-sdk');
-const semver = require('semver');
 const setAppConfiguration = require('./set-app');
-
-const setupServerless = require('../../test/setupServerless');
-
-const fixturesPath = join(__dirname, '../../test/fixtures');
-const nonAwsServicePath = join(fixturesPath, 'non-aws-service');
-const nonSupportedRuntimeServicePath = join(fixturesPath, 'non-supported-runtime-service');
 
 const platformSdkStub = {
   configureFetchDefaults: () => {},
@@ -36,15 +28,12 @@ const platformSdkStub = {
 describe('interactiveCli: index', function () {
   this.timeout(1000 * 60 * 3);
 
-  let serverlessVersion;
   let modulesCacheStub;
   let backupIsTTY;
 
   before(async () => {
     backupIsTTY = process.stdin.isTTY;
     process.stdin.isTTY = true;
-    const { version } = await setupServerless();
-    serverlessVersion = version;
     modulesCacheStub = {
       [require.resolve('@serverless/platform-sdk')]: platformSdkStub,
     };
@@ -60,9 +49,8 @@ describe('interactiveCli: index', function () {
   });
 
   it('Should error, when not at AWS service path and using --app/--org', () => {
-    if (semver.lt(serverlessVersion, '1.55.1')) return null; // skip on old sls
     return runServerless({
-      cwd: nonAwsServicePath,
+      fixture: 'non-aws-service',
       cliArgs: ['--org', 'testinteractivecli', '--app', 'other-app'],
       modulesCacheStub,
     }).then(
@@ -81,9 +69,8 @@ describe('interactiveCli: index', function () {
   });
 
   it('Should error, when unsupported runtime and using --app/--org', () => {
-    if (semver.lt(serverlessVersion, '1.55.1')) return null; // skip on old sls
     return runServerless({
-      cwd: nonSupportedRuntimeServicePath,
+      fixture: 'non-supported-runtime-service',
       cliArgs: ['--org', 'testinteractivecli', '--app', 'other-app'],
       modulesCacheStub,
     }).then(

--- a/lib/interactiveCli/register.test.js
+++ b/lib/interactiveCli/register.test.js
@@ -2,7 +2,7 @@
 
 const { join } = require('path');
 const sinon = require('sinon');
-const { readFile, writeFile } = require('fs-extra');
+const { readFile } = require('fs-extra');
 const yaml = require('yamljs');
 const resolveSync = require('ncjsm/resolve/sync');
 const runServerless = require('../../test/run-serverless');
@@ -12,11 +12,6 @@ const setAppConfiguration = require('./set-app');
 
 const setupServerless = require('../../test/setupServerless');
 
-const fixturesPath = join(__dirname, '../../test/fixtures');
-const nonAwsServicePath = join(fixturesPath, 'non-aws-service');
-const nonSupportedRuntimeServicePath = join(fixturesPath, 'non-supported-runtime-service');
-const awsServicePath = join(fixturesPath, 'aws-service');
-const awsLoggedInServicePath = join(fixturesPath, 'aws-loggedin-service');
 const lifecycleHookNamesBlacklist = [
   'interactiveCli:initializeService',
   'interactiveCli:setupAws',
@@ -87,20 +82,20 @@ describe('interactiveCli: register', function () {
 
   it('Should be ineffective, when not at service path', () =>
     runServerless({
-      cwd: fixturesPath,
+      cwd: process.cwd(),
       lifecycleHookNamesBlacklist,
     }));
 
   it('Should be ineffective, when not at AWS service path', () => {
     return runServerless({
-      cwd: nonAwsServicePath,
+      fixture: 'non-aws-service',
       lifecycleHookNamesBlacklist,
     });
   });
 
   it('Should be ineffective, when not at supported runtime service path', () => {
     return runServerless({
-      cwd: nonSupportedRuntimeServicePath,
+      fixture: 'non-supported-runtime-service',
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     });
@@ -108,7 +103,7 @@ describe('interactiveCli: register', function () {
 
   it('Should be ineffective, when logged in', () => {
     return runServerless({
-      cwd: awsLoggedInServicePath,
+      fixture: 'aws-loggedin-service',
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     });
@@ -119,7 +114,7 @@ describe('interactiveCli: register', function () {
       confirm: { shouldEnableMonitoring: false },
     });
     return runServerless({
-      cwd: awsServicePath,
+      fixture: 'aws-service',
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     });
@@ -131,7 +126,7 @@ describe('interactiveCli: register', function () {
       list: { accessMode: 'login' },
     });
     await runServerless({
-      cwd: awsServicePath,
+      fixture: 'aws-service',
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     });
@@ -146,7 +141,7 @@ describe('interactiveCli: register', function () {
     });
     try {
       await runServerless({
-        cwd: awsServicePath,
+        fixture: 'aws-service',
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
@@ -169,7 +164,7 @@ describe('interactiveCli: register', function () {
     });
     try {
       await runServerless({
-        cwd: awsServicePath,
+        fixture: 'aws-service',
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
@@ -180,16 +175,10 @@ describe('interactiveCli: register', function () {
   });
 
   describe('register', () => {
-    const userConfigPath = join(awsServicePath, '.serverlessrc');
-    const serviceConfigPath = join(awsServicePath, 'serverless.yml');
-    let originalUserConfig;
-    let originalServiceConfig;
+    let serviceConfigPath;
+    let serviceName;
     let registeredUser;
     before(async () => {
-      [originalUserConfig, originalServiceConfig] = await Promise.all([
-        readFile(userConfigPath),
-        readFile(serviceConfigPath),
-      ]);
       configureInquirerStub(inquirer, {
         confirm: { shouldEnableMonitoring: true },
         list: { accessMode: 'register' },
@@ -200,8 +189,10 @@ describe('interactiveCli: register', function () {
           dashboardPassword: 'somepassword',
         },
       });
-      return runServerless({
-        cwd: awsServicePath,
+      const {
+        fixtureData: { serviceConfig, servicePath },
+      } = await runServerless({
+        fixture: 'aws-service',
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
         hooks: {
@@ -210,13 +201,10 @@ describe('interactiveCli: register', function () {
           },
         },
       });
+
+      serviceConfigPath = join(servicePath, 'serverless.yml');
+      serviceName = serviceConfig.service;
     });
-    after(() =>
-      Promise.all([
-        writeFile(userConfigPath, originalUserConfig),
-        writeFile(serviceConfigPath, originalServiceConfig),
-      ])
-    );
 
     it('Should login', async () => {
       expect(registeredUser.userId).to.equal('testregisterinteractivecli');
@@ -224,7 +212,7 @@ describe('interactiveCli: register', function () {
 
     it('Should setup monitoring', async () => {
       const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath)));
-      expect(serviceConfig.app).to.equal('some-aws-service-app');
+      expect(serviceConfig.app).to.equal(`${serviceName}-app`);
       expect(serviceConfig.org).to.equal('testregisterinteractivecli');
     });
   });

--- a/lib/interactiveCli/register.test.js
+++ b/lib/interactiveCli/register.test.js
@@ -82,7 +82,7 @@ describe('interactiveCli: register', function () {
 
   it('Should be ineffective, when not at service path', () =>
     runServerless({
-      cwd: process.cwd(),
+      noService: true,
       lifecycleHookNamesBlacklist,
     }));
 

--- a/lib/interactiveCli/set-app.test.js
+++ b/lib/interactiveCli/set-app.test.js
@@ -2,7 +2,7 @@
 
 const { join } = require('path');
 const sinon = require('sinon');
-const { readFile, writeFile } = require('fs-extra');
+const { readFile } = require('fs-extra');
 const yaml = require('yamljs');
 const resolveSync = require('ncjsm/resolve/sync');
 const runServerless = require('../..//test/run-serverless');
@@ -14,15 +14,6 @@ const semver = require('semver');
 const setupServerless = require('../../test/setupServerless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
-const fixturesPath = join(__dirname, '../../test/fixtures');
-const nonAwsServicePath = join(fixturesPath, 'non-aws-service');
-const nonSupportedRuntimeServicePath = join(fixturesPath, 'non-supported-runtime-service');
-const awsServicePath = join(fixturesPath, 'aws-service');
-const awsLoggedInServicePath = join(fixturesPath, 'aws-loggedin-service');
-const awsLoggedInMonitoredServicePath = join(fixturesPath, 'aws-loggedin-monitored-service');
-const awsLoggedInWrongOrgServicePath = join(fixturesPath, 'aws-loggedin-wrongorg-service');
-const awsLoggedInNoAppServicePath = join(fixturesPath, 'aws-loggedin-noapp-service');
-const awsLoggedInWrongAppServicePath = join(fixturesPath, 'aws-loggedin-wrongapp-service');
 const lifecycleHookNamesBlacklist = [
   'interactiveCli:initializeService',
   'interactiveCli:setupAws',
@@ -103,14 +94,14 @@ describe('interactiveCli: set-app', function () {
 
   it('Should be ineffective, when not at service path', () =>
     runServerless({
-      cwd: fixturesPath,
+      cwd: process.cwd(),
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     }));
 
   it('Should be ineffective, when not at AWS service path', () => {
     return runServerless({
-      cwd: nonAwsServicePath,
+      fixture: 'non-aws-service',
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     });
@@ -118,7 +109,7 @@ describe('interactiveCli: set-app', function () {
 
   it('Should be ineffective, when not at supported runtime service path', () => {
     return runServerless({
-      cwd: nonSupportedRuntimeServicePath,
+      fixture: 'non-supported-runtime-service',
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     });
@@ -126,7 +117,7 @@ describe('interactiveCli: set-app', function () {
 
   it('Should be ineffective, when not logged in', () => {
     return runServerless({
-      cwd: awsServicePath,
+      fixture: 'aws-service',
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     });
@@ -134,7 +125,7 @@ describe('interactiveCli: set-app', function () {
 
   it('Should be ineffective, when no orgs are resolved', () => {
     return runServerless({
-      cwd: awsLoggedInServicePath,
+      fixture: 'aws-loggedin-service',
       lifecycleHookNamesBlacklist,
       modulesCacheStub: {
         ...modulesCacheStub,
@@ -148,7 +139,7 @@ describe('interactiveCli: set-app', function () {
 
   it('Should be ineffective, when project has monitoring setup with recognized org and app', () => {
     return runServerless({
-      cwd: awsLoggedInMonitoredServicePath,
+      fixture: 'aws-loggedin-monitored-service',
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     });
@@ -162,7 +153,7 @@ describe('interactiveCli: set-app', function () {
     });
     try {
       await runServerless({
-        cwd: awsLoggedInServicePath,
+        fixture: 'aws-loggedin-service',
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
@@ -177,7 +168,7 @@ describe('interactiveCli: set-app', function () {
       confirm: { shouldEnableMonitoring: true, shouldUpdateOrg: false },
     });
     return runServerless({
-      cwd: awsLoggedInWrongOrgServicePath,
+      fixture: 'aws-loggedin-wrongorg-service',
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     });
@@ -189,32 +180,27 @@ describe('interactiveCli: set-app', function () {
       list: { appUpdateType: 'skip' },
     });
     return runServerless({
-      cwd: awsLoggedInWrongAppServicePath,
+      fixture: 'aws-loggedin-wrongapp-service',
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     });
   });
 
   describe('Monitoring setup', () => {
-    const serviceConfigPath = join(awsLoggedInServicePath, 'serverless.yml');
-    let originalServiceConfig;
-    before(async () => (originalServiceConfig = await readFile(serviceConfigPath)));
-    afterEach(() => {
-      if (originalServiceConfig) return writeFile(serviceConfigPath, originalServiceConfig);
-      return null;
-    });
-
     it('Should setup monitoring for chosen org and app', async () => {
       configureInquirerStub(inquirer, {
         confirm: { shouldEnableMonitoring: true },
         list: { orgName: 'testinteractivecli', appName: 'other-app' },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-service',
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('other-app');
       expect(serverless.service.org).to.equal('testinteractivecli');
@@ -223,28 +209,17 @@ describe('interactiveCli: set-app', function () {
   });
 
   describe('Monitoring setup from CLI flags', () => {
-    const serviceConfigPath1 = join(awsLoggedInServicePath, 'serverless.yml');
-    const serviceConfigPath2 = join(awsLoggedInMonitoredServicePath, 'serverless.yml');
-    let originalServiceConfig1;
-    let originalServiceConfig2;
-    before(async () => {
-      originalServiceConfig1 = await readFile(serviceConfigPath1);
-      originalServiceConfig2 = await readFile(serviceConfigPath2);
-    });
-    afterEach(async () => {
-      if (originalServiceConfig1) await writeFile(serviceConfigPath1, originalServiceConfig1);
-      if (originalServiceConfig2) await writeFile(serviceConfigPath2, originalServiceConfig2);
-    });
-
     it('Should setup monitoring for chosen org and app', async () => {
-      if (semver.lt(serverlessVersion, '1.55.1')) return; // skip on old sls
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-service',
         cliArgs: ['--org', 'testinteractivecli', '--app', 'other-app'],
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath1)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('other-app');
       expect(serverless.service.org).to.equal('testinteractivecli');
@@ -252,17 +227,19 @@ describe('interactiveCli: set-app', function () {
     });
 
     it('Should setup monitoring for chosen org and app even if already configured', async () => {
-      if (semver.lt(serverlessVersion, '1.55.1')) return; // skip on old sls
       configureInquirerStub(inquirer, {
         confirm: { shouldOverrideDashboardConfig: true },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInMonitoredServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-monitored-service',
         cliArgs: ['--org', 'otherorg', '--app', 'app-from-flag'],
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath2)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('otherorg');
       expect(serviceConfig.app).to.equal('app-from-flag');
       expect(serverless.service.org).to.equal('otherorg');
@@ -270,17 +247,19 @@ describe('interactiveCli: set-app', function () {
     });
 
     it('Should not setup monitoring for chosen org and app even if already configured if rejected', async () => {
-      if (semver.lt(serverlessVersion, '1.55.1')) return; // skip on old sls
       configureInquirerStub(inquirer, {
         confirm: { shouldOverrideDashboardConfig: false },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInMonitoredServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-monitored-service',
         cliArgs: ['--org', 'otherorg', '--app', 'app-from-flag'],
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath2)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('some-aws-service-app');
       expect(serverless.service.org).to.equal(undefined);
@@ -292,13 +271,16 @@ describe('interactiveCli: set-app', function () {
       configureInquirerStub(inquirer, {
         list: { orgName: 'testinteractivecli', appName: 'other-app' },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-service',
         cliArgs: ['--org', 'invalid-testinteractivecli', '--app', 'irrelevant'],
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath1)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('other-app');
       expect(serverless.service.org).to.equal('testinteractivecli');
@@ -311,13 +293,16 @@ describe('interactiveCli: set-app', function () {
         confirm: { shouldOverrideDashboardConfig: true },
         list: { orgName: 'otherorg', appName: 'other-app' },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInMonitoredServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-monitored-service',
         cliArgs: ['--org', 'invalid-testinteractivecli', '--app', 'irrelevant'],
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath2)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('otherorg');
       expect(serviceConfig.app).to.equal('other-app');
       expect(serverless.service.org).to.equal('otherorg');
@@ -330,13 +315,16 @@ describe('interactiveCli: set-app', function () {
         confirm: { shouldOverrideDashboardConfig: true },
         list: { orgName: 'testinteractivecli', appName: 'other-app' },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInMonitoredServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-monitored-service',
         cliArgs: ['--org', 'testinteractivecli', '--app', 'invalid'],
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath2)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('other-app');
       expect(serverless.service.org).to.equal('testinteractivecli');
@@ -348,13 +336,16 @@ describe('interactiveCli: set-app', function () {
       configureInquirerStub(inquirer, {
         list: { orgName: 'testinteractivecli', appName: 'other-app' },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-service',
         cliArgs: ['--org', 'testinteractivecli', '--app', 'invalid'],
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath1)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('other-app');
       expect(serverless.service.org).to.equal('testinteractivecli');
@@ -367,12 +358,15 @@ describe('interactiveCli: set-app', function () {
         input: { newAppName: 'frominput' },
         list: { orgName: 'testinteractivecli', appName: '_create_' },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-service',
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath1)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('frominput');
       expect(serverless.service.org).to.equal('testinteractivecli');
@@ -383,25 +377,20 @@ describe('interactiveCli: set-app', function () {
   });
 
   describe('Monitoring setup when invalid org', () => {
-    const serviceConfigPath = join(awsLoggedInWrongOrgServicePath, 'serverless.yml');
-    let originalServiceConfig;
-    before(async () => (originalServiceConfig = await readFile(serviceConfigPath)));
-    afterEach(() => {
-      if (originalServiceConfig) return writeFile(serviceConfigPath, originalServiceConfig);
-      return null;
-    });
-
     it('Should provide a way to setup monitoring with an invalid org setting', async () => {
       configureInquirerStub(inquirer, {
         confirm: { shouldEnableMonitoring: true, shouldUpdateOrg: true },
         list: { orgName: 'testinteractivecli', appName: 'other-app' },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInWrongOrgServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-wrongorg-service',
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('other-app');
       expect(serverless.service.org).to.equal('testinteractivecli');
@@ -410,25 +399,20 @@ describe('interactiveCli: set-app', function () {
   });
 
   describe('Monitoring setup when no app', () => {
-    const serviceConfigPath = join(awsLoggedInNoAppServicePath, 'serverless.yml');
-    let originalServiceConfig;
-    before(async () => (originalServiceConfig = await readFile(serviceConfigPath)));
-    afterEach(() => {
-      if (originalServiceConfig) return writeFile(serviceConfigPath, originalServiceConfig);
-      return null;
-    });
-
     it('Should allow to setup app', async () => {
       configureInquirerStub(inquirer, {
         confirm: { shouldEnableMonitoring: true },
         list: { appName: 'other-app' },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInNoAppServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-noapp-service',
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('other-app');
       expect(serverless.service.org).to.equal('testinteractivecli');
@@ -437,23 +421,18 @@ describe('interactiveCli: set-app', function () {
   });
 
   describe('Monitoring setup when no app with --app flag', () => {
-    const serviceConfigPath = join(awsLoggedInNoAppServicePath, 'serverless.yml');
-    let originalServiceConfig;
-    before(async () => (originalServiceConfig = await readFile(serviceConfigPath)));
-    afterEach(() => {
-      if (originalServiceConfig) return writeFile(serviceConfigPath, originalServiceConfig);
-      return null;
-    });
-
     it('Should allow to setup app', async () => {
       if (semver.lt(serverlessVersion, '1.55.1')) return; // skip on old sls
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInNoAppServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-noapp-service',
         cliArgs: ['--app', 'app-from-flag'],
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('app-from-flag');
       expect(serverless.service.org).to.equal('testinteractivecli');
@@ -465,13 +444,16 @@ describe('interactiveCli: set-app', function () {
       configureInquirerStub(inquirer, {
         list: { appName: 'other-app' },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInNoAppServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-noapp-service',
         cliArgs: ['--app', 'invalid-app-from-flag'],
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('other-app');
       expect(serverless.service.org).to.equal('testinteractivecli');
@@ -480,25 +462,20 @@ describe('interactiveCli: set-app', function () {
   });
 
   describe('Monitoring setup when invalid app', () => {
-    const serviceConfigPath = join(awsLoggedInWrongAppServicePath, 'serverless.yml');
-    let originalServiceConfig;
-    before(async () => (originalServiceConfig = await readFile(serviceConfigPath)));
-    afterEach(() => {
-      if (originalServiceConfig) return writeFile(serviceConfigPath, originalServiceConfig);
-      return null;
-    });
-
     it('Should recognize an invalid app and allow to create it', async () => {
       configureInquirerStub(inquirer, {
         confirm: { shouldEnableMonitoring: true },
         list: { appUpdateType: 'create' },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInWrongAppServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-wrongapp-service',
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('not-created-app');
       expect(serverless.service.org).to.equal('testinteractivecli');
@@ -510,12 +487,15 @@ describe('interactiveCli: set-app', function () {
         confirm: { shouldEnableMonitoring: true },
         list: { appUpdateType: 'chooseExisting', appName: 'other-app' },
       });
-      const { serverless } = await runServerless({
-        cwd: awsLoggedInWrongAppServicePath,
+      const {
+        serverless,
+        fixtureData: { servicePath },
+      } = await runServerless({
+        fixture: 'aws-loggedin-wrongapp-service',
         lifecycleHookNamesBlacklist,
         modulesCacheStub,
       });
-      const serviceConfig = yaml.parse(String(await readFile(serviceConfigPath)));
+      const serviceConfig = yaml.parse(String(await readFile(join(servicePath, 'serverless.yml'))));
       expect(serviceConfig.org).to.equal('testinteractivecli');
       expect(serviceConfig.app).to.equal('other-app');
       expect(serverless.service.org).to.equal('testinteractivecli');

--- a/lib/interactiveCli/set-app.test.js
+++ b/lib/interactiveCli/set-app.test.js
@@ -94,7 +94,7 @@ describe('interactiveCli: set-app', function () {
 
   it('Should be ineffective, when not at service path', () =>
     runServerless({
-      cwd: process.cwd(),
+      noService: true,
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     }));

--- a/lib/outputCommand.test.js
+++ b/lib/outputCommand.test.js
@@ -1,11 +1,7 @@
 'use strict';
 
-const { join } = require('path');
 const sinon = require('sinon');
 const runServerless = require('../test/run-serverless');
-
-const fixturesPath = join(__dirname, '../test/fixtures');
-const awsMonitoredServicePath = join(fixturesPath, 'aws-monitored-service');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
 const platformClientPath = require.resolve('@serverless/platform-client');
@@ -73,7 +69,7 @@ describe('outputCommand', function () {
     it('Should crash when not logged in', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['output', 'list'],
           modulesCacheStub: {
             [platformSdkPath]: {
@@ -90,7 +86,7 @@ describe('outputCommand', function () {
     it('Should crash when no org is configured', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['output', 'list'],
           modulesCacheStub,
         });
@@ -102,7 +98,7 @@ describe('outputCommand', function () {
     it('Should crash when no app is configured', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['output', 'list', '--org', 'some-org'],
           modulesCacheStub,
         });
@@ -114,7 +110,7 @@ describe('outputCommand', function () {
     it('Should crash when no service is configured', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['output', 'list', '--org', 'some-org', '--app', 'some-app'],
           modulesCacheStub,
         });
@@ -124,17 +120,21 @@ describe('outputCommand', function () {
       }
     });
     it('Should support `--org` `--app` CLI params', async () => {
-      const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+      const {
+        stdoutData,
+        fixtureData: {
+          serviceConfig: { service: serviceName },
+        },
+      } = await runServerless({
+        fixture: 'aws-monitored-service',
         cliArgs: ['output', 'list', '--org', 'some-org', '--app', 'some-app'],
         modulesCacheStub,
       });
-
       expect(getServiceStub.args[0][0]).to.deep.equal({
         accessKey: 'access-key',
         app: 'some-app',
         tenant: 'some-org',
-        service: 'some-aws-service',
+        service: serviceName,
       });
 
       expect(stdoutData).to.include('stringOutputName');
@@ -147,7 +147,7 @@ describe('outputCommand', function () {
     });
     it('Should support `--service` CLI params', async () => {
       const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+        fixture: 'aws-monitored-service',
         cliArgs: [
           'output',
           'list',
@@ -178,8 +178,13 @@ describe('outputCommand', function () {
     });
 
     it('Should support `--stage` CLI param', async () => {
-      const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+      const {
+        stdoutData,
+        fixtureData: {
+          serviceConfig: { service: serviceName },
+        },
+      } = await runServerless({
+        fixture: 'aws-monitored-service',
         cliArgs: ['output', 'list', '--stage', 'other'],
         modulesCacheStub,
       });
@@ -187,15 +192,20 @@ describe('outputCommand', function () {
         accessKey: 'access-key',
         app: 'some-aws-service-app',
         tenant: 'testinteractivecli',
-        service: 'some-aws-service',
+        service: serviceName,
       });
 
       expect(stdoutData).to.include('otherOutputName');
       expect(stdoutData).to.include('otherOutputName');
     });
     it('Should support `--region` CLI param', async () => {
-      const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+      const {
+        stdoutData,
+        fixtureData: {
+          serviceConfig: { service: serviceName },
+        },
+      } = await runServerless({
+        fixture: 'aws-monitored-service',
         cliArgs: ['output', 'list', '--region', 'us-east-2'],
         modulesCacheStub,
       });
@@ -203,7 +213,7 @@ describe('outputCommand', function () {
         accessKey: 'access-key',
         app: 'some-aws-service-app',
         tenant: 'testinteractivecli',
-        service: 'some-aws-service',
+        service: serviceName,
       });
 
       expect(stdoutData).to.include('usEast2OutputName');
@@ -211,14 +221,19 @@ describe('outputCommand', function () {
     });
 
     it('Should read configuration from config file', async () => {
-      const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+      const {
+        stdoutData,
+        fixtureData: {
+          serviceConfig: { service: serviceName },
+        },
+      } = await runServerless({
+        fixture: 'aws-monitored-service',
         cliArgs: ['output', 'list'],
         modulesCacheStub,
       });
       expect(getServiceStub.args[0][0]).to.deep.equal({
         accessKey: 'access-key',
-        service: 'some-aws-service',
+        service: serviceName,
         app: 'some-aws-service-app',
         tenant: 'testinteractivecli',
       });
@@ -236,7 +251,7 @@ describe('outputCommand', function () {
     it('Should crash when not logged in', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          fixture: 'aws-monitored-service',
           cliArgs: ['output', 'get', '--name', 'stringOutputName'],
           modulesCacheStub: {
             [platformSdkPath]: {
@@ -253,7 +268,7 @@ describe('outputCommand', function () {
     it('Should crash when no org is configured', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['output', 'get', '--name', 'stringOutputName'],
           modulesCacheStub,
         });
@@ -265,7 +280,7 @@ describe('outputCommand', function () {
     it('Should crash when no app is configured', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['output', 'get', '--name', 'stringOutputName', '--org', 'some-org'],
           modulesCacheStub,
         });
@@ -277,7 +292,7 @@ describe('outputCommand', function () {
     it('Should crash when no service is configured', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: [
             'output',
             'get',
@@ -298,7 +313,7 @@ describe('outputCommand', function () {
     it('Should crash when no name is configured', async () => {
       try {
         await runServerless({
-          cwd: awsMonitoredServicePath,
+          cwd: process.cwd(),
           cliArgs: ['output', 'get'],
           modulesCacheStub,
         });
@@ -308,8 +323,13 @@ describe('outputCommand', function () {
       }
     });
     it('Should support `--org` and `--app` CLI params', async () => {
-      const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+      const {
+        stdoutData,
+        fixtureData: {
+          serviceConfig: { service: serviceName },
+        },
+      } = await runServerless({
+        fixture: 'aws-monitored-service',
         cliArgs: [
           'output',
           'get',
@@ -328,14 +348,14 @@ describe('outputCommand', function () {
         stage: 'dev',
         app: 'some-app',
         tenant: 'some-org',
-        service: 'some-aws-service',
+        service: serviceName,
         region: 'us-east-1',
       });
       expect(stdoutData).to.include('output-value');
     });
     it('Should support `--service` CLI params', async () => {
       const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+        fixture: 'aws-monitored-service',
         cliArgs: ['output', 'get', '--name', 'stringOutputName', '--service', 'other-service'],
         modulesCacheStub,
       });
@@ -352,8 +372,13 @@ describe('outputCommand', function () {
     });
 
     it('Should support `--stage` CLI param', async () => {
-      const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+      const {
+        stdoutData,
+        fixtureData: {
+          serviceConfig: { service: serviceName },
+        },
+      } = await runServerless({
+        fixture: 'aws-monitored-service',
         cliArgs: ['output', 'get', '--name', 'stringOutputName', '--stage', 'foo'],
         modulesCacheStub,
       });
@@ -363,15 +388,20 @@ describe('outputCommand', function () {
         stage: 'foo',
         app: 'some-aws-service-app',
         tenant: 'testinteractivecli',
-        service: 'some-aws-service',
+        service: serviceName,
         region: 'us-east-1',
       });
       expect(stdoutData).to.include('output-value');
     });
 
     it('Should support `--region` CLI param', async () => {
-      const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+      const {
+        stdoutData,
+        fixtureData: {
+          serviceConfig: { service: serviceName },
+        },
+      } = await runServerless({
+        fixture: 'aws-monitored-service',
         cliArgs: ['output', 'get', '--name', 'stringOutputName', '--region', 'us-east-2'],
         modulesCacheStub,
       });
@@ -381,15 +411,20 @@ describe('outputCommand', function () {
         stage: 'dev',
         app: 'some-aws-service-app',
         tenant: 'testinteractivecli',
-        service: 'some-aws-service',
+        service: serviceName,
         region: 'us-east-2',
       });
       expect(stdoutData).to.include('output-value');
     });
 
     it('Should read configuration from config file', async () => {
-      const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+      const {
+        stdoutData,
+        fixtureData: {
+          serviceConfig: { service: serviceName },
+        },
+      } = await runServerless({
+        fixture: 'aws-monitored-service',
         cliArgs: ['output', 'get', '--name', 'stringOutputName'],
         modulesCacheStub,
       });
@@ -399,7 +434,7 @@ describe('outputCommand', function () {
         stage: 'dev',
         app: 'some-aws-service-app',
         tenant: 'testinteractivecli',
-        service: 'some-aws-service',
+        service: serviceName,
         region: 'us-east-1',
       });
       expect(stdoutData).to.include('output-value');

--- a/lib/outputCommand.test.js
+++ b/lib/outputCommand.test.js
@@ -69,7 +69,7 @@ describe('outputCommand', function () {
     it('Should crash when not logged in', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['output', 'list'],
           modulesCacheStub: {
             [platformSdkPath]: {
@@ -86,7 +86,7 @@ describe('outputCommand', function () {
     it('Should crash when no org is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['output', 'list'],
           modulesCacheStub,
         });
@@ -98,7 +98,7 @@ describe('outputCommand', function () {
     it('Should crash when no app is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['output', 'list', '--org', 'some-org'],
           modulesCacheStub,
         });
@@ -110,7 +110,7 @@ describe('outputCommand', function () {
     it('Should crash when no service is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['output', 'list', '--org', 'some-org', '--app', 'some-app'],
           modulesCacheStub,
         });
@@ -268,7 +268,7 @@ describe('outputCommand', function () {
     it('Should crash when no org is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['output', 'get', '--name', 'stringOutputName'],
           modulesCacheStub,
         });
@@ -280,7 +280,7 @@ describe('outputCommand', function () {
     it('Should crash when no app is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['output', 'get', '--name', 'stringOutputName', '--org', 'some-org'],
           modulesCacheStub,
         });
@@ -292,7 +292,7 @@ describe('outputCommand', function () {
     it('Should crash when no service is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: [
             'output',
             'get',
@@ -313,7 +313,7 @@ describe('outputCommand', function () {
     it('Should crash when no name is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['output', 'get'],
           modulesCacheStub,
         });

--- a/lib/paramCommand.test.js
+++ b/lib/paramCommand.test.js
@@ -46,7 +46,7 @@ describe('paramCommand', function () {
     it('Should crash when not logged in', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['param', 'list'],
           modulesCacheStub: {
             [platformSdkPath]: {
@@ -63,7 +63,7 @@ describe('paramCommand', function () {
     it('Should crash when no org is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['param', 'list'],
           modulesCacheStub,
         });
@@ -75,7 +75,7 @@ describe('paramCommand', function () {
     it('Should crash when no app is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['param', 'list', '--org', 'some-org'],
           modulesCacheStub,
         });
@@ -86,7 +86,7 @@ describe('paramCommand', function () {
     });
     it('Should support `--org` and `--app` CLI params', async () => {
       const { stdoutData } = await runServerless({
-        cwd: process.cwd(),
+        noService: true,
         cliArgs: ['param', 'list', '--org', 'some-org', '--app', 'some-app'],
         modulesCacheStub,
       });
@@ -104,7 +104,7 @@ describe('paramCommand', function () {
 
     it('Should support `--stage` CLI param', async () => {
       const { stdoutData } = await runServerless({
-        cwd: process.cwd(),
+        noService: true,
         cliArgs: ['param', 'list', '--org', 'some-org', '--app', 'some-app', '--stage', 'foo'],
         modulesCacheStub,
       });
@@ -144,7 +144,7 @@ describe('paramCommand', function () {
     it('Should crash when not logged in', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['param', 'get', '--name', 'second-param-name'],
           modulesCacheStub: {
             [platformSdkPath]: {
@@ -161,7 +161,7 @@ describe('paramCommand', function () {
     it('Should crash when no org is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['param', 'get', '--name', 'second-param-name'],
           modulesCacheStub,
         });
@@ -173,7 +173,7 @@ describe('paramCommand', function () {
     it('Should crash when no app is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['param', 'get', '--name', 'second-param-name', '--org', 'some-org'],
           modulesCacheStub,
         });
@@ -185,7 +185,7 @@ describe('paramCommand', function () {
     it('Should crash when no name is configured', async () => {
       try {
         await runServerless({
-          cwd: process.cwd(),
+          noService: true,
           cliArgs: ['param', 'get', '--app', 'some-app', '--org', 'some-org'],
           modulesCacheStub,
         });
@@ -196,7 +196,7 @@ describe('paramCommand', function () {
     });
     it('Should support `--org` and `--app` CLI params', async () => {
       const { stdoutData } = await runServerless({
-        cwd: process.cwd(),
+        noService: true,
         cliArgs: [
           'param',
           'get',
@@ -223,7 +223,7 @@ describe('paramCommand', function () {
 
     it('Should support `--stage` CLI param', async () => {
       const { stdoutData } = await runServerless({
-        cwd: process.cwd(),
+        noService: true,
         cliArgs: [
           'param',
           'get',

--- a/lib/paramCommand.test.js
+++ b/lib/paramCommand.test.js
@@ -1,11 +1,7 @@
 'use strict';
 
-const { join } = require('path');
 const sinon = require('sinon');
 const runServerless = require('../test/run-serverless');
-
-const fixturesPath = join(__dirname, '../test/fixtures');
-const awsMonitoredServicePath = join(fixturesPath, 'aws-monitored-service');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
 const platformClientPath = require.resolve('@serverless/platform-client');
@@ -50,7 +46,7 @@ describe('paramCommand', function () {
     it('Should crash when not logged in', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['param', 'list'],
           modulesCacheStub: {
             [platformSdkPath]: {
@@ -67,7 +63,7 @@ describe('paramCommand', function () {
     it('Should crash when no org is configured', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['param', 'list'],
           modulesCacheStub,
         });
@@ -79,7 +75,7 @@ describe('paramCommand', function () {
     it('Should crash when no app is configured', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['param', 'list', '--org', 'some-org'],
           modulesCacheStub,
         });
@@ -90,7 +86,7 @@ describe('paramCommand', function () {
     });
     it('Should support `--org` and `--app` CLI params', async () => {
       const { stdoutData } = await runServerless({
-        cwd: fixturesPath,
+        cwd: process.cwd(),
         cliArgs: ['param', 'list', '--org', 'some-org', '--app', 'some-app'],
         modulesCacheStub,
       });
@@ -108,7 +104,7 @@ describe('paramCommand', function () {
 
     it('Should support `--stage` CLI param', async () => {
       const { stdoutData } = await runServerless({
-        cwd: fixturesPath,
+        cwd: process.cwd(),
         cliArgs: ['param', 'list', '--org', 'some-org', '--app', 'some-app', '--stage', 'foo'],
         modulesCacheStub,
       });
@@ -126,7 +122,7 @@ describe('paramCommand', function () {
     });
     it('Should read configuration from config file', async () => {
       const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+        fixture: 'aws-monitored-service',
         cliArgs: ['param', 'list'],
         modulesCacheStub,
       });
@@ -148,7 +144,7 @@ describe('paramCommand', function () {
     it('Should crash when not logged in', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['param', 'get', '--name', 'second-param-name'],
           modulesCacheStub: {
             [platformSdkPath]: {
@@ -165,7 +161,7 @@ describe('paramCommand', function () {
     it('Should crash when no org is configured', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['param', 'get', '--name', 'second-param-name'],
           modulesCacheStub,
         });
@@ -177,7 +173,7 @@ describe('paramCommand', function () {
     it('Should crash when no app is configured', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['param', 'get', '--name', 'second-param-name', '--org', 'some-org'],
           modulesCacheStub,
         });
@@ -189,7 +185,7 @@ describe('paramCommand', function () {
     it('Should crash when no name is configured', async () => {
       try {
         await runServerless({
-          cwd: fixturesPath,
+          cwd: process.cwd(),
           cliArgs: ['param', 'get', '--app', 'some-app', '--org', 'some-org'],
           modulesCacheStub,
         });
@@ -200,7 +196,7 @@ describe('paramCommand', function () {
     });
     it('Should support `--org` and `--app` CLI params', async () => {
       const { stdoutData } = await runServerless({
-        cwd: fixturesPath,
+        cwd: process.cwd(),
         cliArgs: [
           'param',
           'get',
@@ -227,7 +223,7 @@ describe('paramCommand', function () {
 
     it('Should support `--stage` CLI param', async () => {
       const { stdoutData } = await runServerless({
-        cwd: fixturesPath,
+        cwd: process.cwd(),
         cliArgs: [
           'param',
           'get',
@@ -255,7 +251,7 @@ describe('paramCommand', function () {
     });
     it('Should read configuration from config file', async () => {
       const { stdoutData } = await runServerless({
-        cwd: awsMonitoredServicePath,
+        fixture: 'aws-monitored-service',
         cliArgs: ['param', 'get', '--name', 'second-param-name'],
         modulesCacheStub,
       });

--- a/lib/providersIntegration.test.js
+++ b/lib/providersIntegration.test.js
@@ -1,10 +1,6 @@
 'use strict';
 
-const { join } = require('path');
 const runServerless = require('../test/run-serverless');
-
-const fixturesPath = join(__dirname, '../test/fixtures');
-const awsMonitoredServicePath = join(fixturesPath, 'aws-monitored-service');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
 const platformClientPath = require.resolve('@serverless/platform-client');
@@ -54,7 +50,7 @@ describe('deployProfile', function () {
 
   it('Should override with credentials', async () => {
     const { serverless } = await runServerless({
-      cwd: awsMonitoredServicePath,
+      fixture: 'aws-monitored-service',
       cliArgs: ['print'],
       modulesCacheStub: {
         [platformSdkPath]: {

--- a/lib/studio.test.js
+++ b/lib/studio.test.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const { join } = require('path');
 const runServerless = require('../test/run-serverless');
-
-const awsMonitoredServicePath = join(__dirname, '../test/fixtures/aws-monitored-service');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
 const modulesCacheStub = {
@@ -26,7 +23,7 @@ describe('studio', function () {
 
     try {
       await runServerless({
-        cwd: awsMonitoredServicePath,
+        fixture: 'aws-monitored-service',
         cliArgs: ['studio'],
         modulesCacheStub: {
           [platformSdkPath]: {

--- a/lib/studio/ServerlessExec.js
+++ b/lib/studio/ServerlessExec.js
@@ -12,7 +12,7 @@ const execOptions = {
     ...process.env,
     SLS_DEV_MODE: true,
   },
-  cwd: process.cwd(),
+  noService: true,
   stdio: 'inherit',
 };
 

--- a/lib/test/index.js
+++ b/lib/test/index.js
@@ -9,12 +9,10 @@ const runTest = require('./runTest');
 
 module.exports.test = async (ctx) => {
   if (!ctx.sls.enterpriseEnabled) {
-    ctx.sls.cli.log('Run "serverless" to configure your service for testing.');
-    return;
+    throw new this.sls.classes.Error('Run "serverless" to configure your service for testing.');
   }
   if (!fse.exists('serverless.test.yml')) {
-    ctx.sls.cli.log('No serverless.test.yml file found');
-    return;
+    throw new this.sls.classes.Error('No serverless.test.yml file found');
   }
   let tests = yaml.safeLoad(await fse.readFile('serverless.test.yml'));
 
@@ -113,4 +111,8 @@ module.exports.test = async (ctx) => {
   const passed = chalk.green(`${numTests - errors.length} passed`);
   const failed = chalk.red(`${errors.length} failed`);
   ctx.sls.cli.log(`Test Summary: ${passed}, ${failed}`);
+
+  if (errors.length) {
+    throw new ctx.sls.classes.Error('Test run failed');
+  }
 };

--- a/lib/test/index.test.js
+++ b/lib/test/index.test.js
@@ -37,32 +37,75 @@ const modulesCacheStub = {
   },
 };
 
+const awsRequestStubMap = {
+  CloudFormation: {
+    describeStacks: {
+      Stacks: [{ Outputs: [{ OutputKey: 'ServiceEndpointFoo', OutputValue: 'https://' }] }],
+    },
+  },
+};
+
 describe('test', () => {
-  let stdoutData;
-  before(async () => {
-    ({ stdoutData } = await runServerless({
-      fixture: 'test-command',
-      cliArgs: ['test'],
-      modulesCacheStub,
-      awsRequestStubMap: {
-        CloudFormation: {
-          describeStacks: {
-            Stacks: [{ Outputs: [{ OutputKey: 'ServiceEndpointFoo', OutputValue: 'https://' }] }],
-          },
-        },
-      },
-    }));
+  describe('Pass', () => {
+    let stdoutData;
+    before(async () => {
+      ({ stdoutData } = await runServerless({
+        fixture: 'test-command',
+        cliArgs: ['test'],
+        modulesCacheStub,
+        awsRequestStubMap,
+      }));
+    });
+
+    it('should print summary', () => {
+      expect(stdoutData).to.include('Test Results:');
+      expect(stdoutData).to.include('3 passed');
+      expect(stdoutData).to.include('0 failed');
+    });
+    it('should support specific endpoints', () =>
+      expect(stdoutData).to.include('running - GET foo - endpoint'));
+    it('should auto resolve endpoint', () =>
+      expect(stdoutData).to.include('running - GET foo - function'));
+    it('should auto resolve endpoint written with shorthand notation', () =>
+      expect(stdoutData).to.include('running - GET bar - shorthand'));
   });
 
-  it('should print summary', () => {
-    expect(stdoutData).to.include('Test Results:');
-    expect(stdoutData).to.include('3 passed');
-    expect(stdoutData).to.include('0 failed');
+  describe('Failure', () => {
+    let stdoutData;
+    before(async () => {
+      try {
+        await runServerless({
+          fixture: 'test-command',
+          cliArgs: ['test'],
+          modulesCacheStub: {
+            ...modulesCacheStub,
+            '@serverless/enterprise-plugin/lib/test/runTest': async (testSpec) => {
+              if (testSpec.name === 'function') {
+                throw Object.assign(new Error('Fail'), {
+                  resp: { headers: {} },
+                });
+              }
+            },
+          },
+          awsRequestStubMap,
+        });
+      } catch (error) {
+        stdoutData = error.stdoutData;
+        return;
+      }
+      throw new Error('Unexpected success');
+    });
+
+    it('should print summary', () => {
+      expect(stdoutData).to.include('Test Results:');
+      expect(stdoutData).to.include('2 passed');
+      expect(stdoutData).to.include('1 failed');
+    });
+    it('should support specific endpoints', () =>
+      expect(stdoutData).to.include('running - GET foo - endpoint'));
+    it('should auto resolve endpoint', () =>
+      expect(stdoutData).to.include('running - GET foo - function'));
+    it('should auto resolve endpoint written with shorthand notation', () =>
+      expect(stdoutData).to.include('running - GET bar - shorthand'));
   });
-  it('should support specific endpoints', () =>
-    expect(stdoutData).to.include('running - GET foo - endpoint'));
-  it('should auto resolve endpoint', () =>
-    expect(stdoutData).to.include('running - GET foo - function'));
-  it('should auto resolve endpoint written with shorthand notation', () =>
-    expect(stdoutData).to.include('running - GET bar - shorthand'));
 });

--- a/lib/test/index.test.js
+++ b/lib/test/index.test.js
@@ -1,201 +1,68 @@
 'use strict';
 
-const proxyquire = require('proxyquire');
-const sinon = require('sinon');
-const chalk = require('chalk');
+const runServerless = require('../../test/run-serverless');
 
-let endpoint; // endpoint spec to be returned by readFile
-
-const runTest = sinon.stub().resolves();
-const { test: testFunc } = proxyquire('./', {
-  './runTest': runTest,
-  'fs-extra': {
-    exists: async () => true,
-    readFile: async () =>
-      JSON.stringify([
-        {
-          name: 'foobar',
-          endpoint,
-          response: { body: 'foobar' },
-          request: { headers: { Foo: 'bar' } },
-        },
-      ]),
+const modulesCacheStub = {
+  '@serverless/enterprise-plugin/lib/test/runTest': async () => {},
+  [require.resolve('@serverless/platform-sdk')]: {
+    configureFetchDefaults: () => {},
+    getAccessKeyForTenant: () => 'access-key',
+    getLoggedInUser: () => ({}),
+    getDeployProfile: () => ({}),
+    getMetadata: async () => ({
+      awsAccountId: '377024778620',
+      supportedRuntimes: ['nodejs8.10', 'nodejs10.x', 'python2.7', 'python3.6', 'python3.7'],
+      supportedRegions: [
+        'us-east-1',
+        'us-east-2',
+        'us-west-2',
+        'eu-central-1',
+        'eu-west-1',
+        'eu-west-2',
+        'ap-northeast-1',
+        'ap-southeast-1',
+        'ap-southeast-2',
+      ],
+    }),
   },
-});
-
-const realStdoutWrite = process.stdout.write;
+  [require.resolve('@serverless/platform-client')]: {
+    ServerlessSDK: class ServerlessSDK {
+      async getOrgByName() {
+        return { orgUid: 'foobar' };
+      }
+      async getProvidersByOrgServiceInstance() {
+        return {};
+      }
+    },
+  },
+};
 
 describe('test', () => {
-  afterEach(() => {
-    process.stdout.write = realStdoutWrite;
-  });
-
-  beforeEach(() => {
-    process.stdout.write = sinon.spy();
-  });
-
-  it('calls runTest', async () => {
-    endpoint = { function: 'blah', path: 'blah', method: 'post' };
-    const ctx = {
-      sls: {
-        enterpriseEnabled: true,
-        processedInput: { options: {} },
-        cli: { log: sinon.spy() },
-        service: { functions: {} },
-      },
-      provider: {
-        naming: {
-          getServiceEndpointRegex: () => 'http',
-          getStackName: () => 'stack',
-        },
-        request: async () => ({
-          Stacks: [{ Outputs: [{ OutputKey: 'http', OutputValue: 'https://example.com' }] }],
-        }),
-      },
-    };
-    await testFunc(ctx);
-    expect(runTest.args[0][0]).to.deep.equal(
-      {
-        name: 'foobar',
-        endpoint: { function: 'blah', path: 'blah', method: 'post' },
-        response: { body: 'foobar' },
-        request: { headers: { Foo: 'bar' } },
-      },
-      'blah',
-      'post',
-      'https://example.com'
-    );
-    expect(ctx.sls.cli.log.args).to.deep.equal([
-      [
-        `Test Results:
-
-   Summary --------------------------------------------------
-`,
-      ],
-      [`Test Summary: ${chalk.green('1 passed')}, ${chalk.red('0 failed')}`],
-    ]);
-    expect(process.stdout.write.args).to.deep.equal([
-      ['  running - POST blah - foobar'],
-      [`\r   ${chalk.green('passed')} - POST blah - foobar\n`],
-      ['\n'],
-    ]);
-  });
-
-  it('calls runTest with longform http event', async () => {
-    endpoint = { function: 'blah' };
-    const ctx = {
-      sls: {
-        enterpriseEnabled: true,
-        processedInput: { options: {} },
-        cli: { log: sinon.spy() },
-        service: {
-          functions: {
-            blah: { events: [{ http: { path: 'blah', method: 'post' } }] },
+  let stdoutData;
+  before(async () => {
+    ({ stdoutData } = await runServerless({
+      fixture: 'test-command',
+      cliArgs: ['test'],
+      modulesCacheStub,
+      awsRequestStubMap: {
+        CloudFormation: {
+          describeStacks: {
+            Stacks: [{ Outputs: [{ OutputKey: 'ServiceEndpointFoo', OutputValue: 'https://' }] }],
           },
         },
       },
-      provider: {
-        naming: {
-          getServiceEndpointRegex: () => 'http',
-          getStackName: () => 'stack',
-        },
-        request: async () => ({
-          Stacks: [{ Outputs: [{ OutputKey: 'http', OutputValue: 'https://example.com' }] }],
-        }),
-      },
-    };
-    await testFunc(ctx);
-    expect(runTest.args[0][0]).to.deep.equal(
-      {
-        name: 'foobar',
-        endpoint: {
-          function: 'blah',
-          method: 'post',
-          path: 'blah',
-        },
-        response: { body: 'foobar' },
-        request: { headers: { Foo: 'bar' } },
-      },
-      'blah',
-      'post',
-      'https://example.com'
-    );
-    expect(ctx.sls.cli.log.args).to.deep.equal([
-      [
-        `Test Results:
-
-   Summary --------------------------------------------------
-`,
-      ],
-      [`Test Summary: ${chalk.green('1 passed')}, ${chalk.red('0 failed')}`],
-    ]);
-    expect(process.stdout.write.args).to.deep.equal([
-      ['  running - POST blah - foobar'],
-      [`\r   ${chalk.green('passed')} - POST blah - foobar\n`],
-      ['\n'],
-    ]);
+    }));
   });
 
-  it('calls runTest with shortform http event', async () => {
-    endpoint = { function: 'blah' };
-    const ctx = {
-      sls: {
-        enterpriseEnabled: true,
-        processedInput: { options: {} },
-        cli: { log: sinon.spy() },
-        service: {
-          functions: {
-            blah: { events: [{ http: 'POST blah' }] },
-          },
-        },
-      },
-      provider: {
-        naming: {
-          getServiceEndpointRegex: () => 'http',
-          getStackName: () => 'stack',
-        },
-        request: async () => ({
-          Stacks: [{ Outputs: [{ OutputKey: 'http', OutputValue: 'https://example.com' }] }],
-        }),
-      },
-    };
-    await testFunc(ctx);
-    expect(runTest.args[0][0]).to.deep.equal(
-      {
-        name: 'foobar',
-        endpoint: {
-          function: 'blah',
-          method: 'post',
-          path: 'blah',
-        },
-        response: { body: 'foobar' },
-        request: { headers: { Foo: 'bar' } },
-      },
-      'blah',
-      'post',
-      'https://example.com'
-    );
-    expect(ctx.sls.cli.log.args).to.deep.equal([
-      [
-        `Test Results:
-
-   Summary --------------------------------------------------
-`,
-      ],
-      [`Test Summary: ${chalk.green('1 passed')}, ${chalk.red('0 failed')}`],
-    ]);
-    expect(process.stdout.write.args).to.deep.equal([
-      ['  running - POST blah - foobar'],
-      [`\r   ${chalk.green('passed')} - POST blah - foobar\n`],
-      ['\n'],
-    ]);
+  it('should print summary', () => {
+    expect(stdoutData).to.include('Test Results:');
+    expect(stdoutData).to.include('3 passed');
+    expect(stdoutData).to.include('0 failed');
   });
-
-  it('logs message if sfe not enabled', async () => {
-    const ctx = { sls: { cli: { log: sinon.spy() } } };
-    await testFunc(ctx);
-    expect(ctx.sls.cli.log.calledWith('Run "serverless" to configure your service for testing.')).to
-      .be.true;
-    expect(process.stdout.write.args).to.deep.equal([]);
-  });
+  it('should support specific endpoints', () =>
+    expect(stdoutData).to.include('running - GET foo - endpoint'));
+  it('should auto resolve endpoint', () =>
+    expect(stdoutData).to.include('running - GET foo - function'));
+  it('should auto resolve endpoint written with shorthand notation', () =>
+    expect(stdoutData).to.include('running - GET bar - shorthand'));
 });

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -5,7 +5,6 @@ const sinon = require('sinon');
 const chalk = require('chalk');
 const path = require('path');
 const runServerless = require('../test/run-serverless');
-const fixtures = require('../test/fixtures');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
 const platformClientPath = require.resolve('@serverless/platform-client');
@@ -507,11 +506,9 @@ except Exception as error:
 describe('wrap #2', function () {
   this.timeout(1000 * 60 * 3);
 
-  after(fixtures.cleanup);
-
   it('Should not log meta log on local invocation', async () => {
     const { stdoutData } = await runServerless({
-      cwd: fixtures.map.function,
+      fixture: 'function',
       cliArgs: ['invoke', 'local', '-f', 'function'],
       modulesCacheStub,
     });

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@serverless/eslint-config": "^3.0.0",
-    "@serverless/test": "^5.2.0",
+    "@serverless/test": "^6.1.2",
     "aws-sdk": "^2.771.0",
     "chai": "^4.2.0",
     "eslint": "^7.11.0",
@@ -119,7 +119,7 @@
       "@serverless/test/setup/log",
       "@serverless/test/setup/async-leaks-detector",
       "@serverless/test/setup/mock-homedir",
-      "@serverless/test/setup/restore-cwd",
+      "@serverless/test/setup/mock-cwd",
       "@serverless/test/setup/restore-env",
       "./test/map-mocha-globals"
     ],

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@serverless/eslint-config": "^3.0.0",
-    "@serverless/test": "^4.9.2",
+    "@serverless/test": "^5.2.0",
     "aws-sdk": "^2.771.0",
     "chai": "^4.2.0",
     "eslint": "^7.11.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@serverless/eslint-config": "^3.0.0",
-    "@serverless/test": "^6.1.2",
+    "@serverless/test": "^6.2.2",
     "aws-sdk": "^2.771.0",
     "chai": "^4.2.0",
     "eslint": "^7.11.0",

--- a/test/fixtures/test-command/.serverlessrc
+++ b/test/fixtures/test-command/.serverlessrc
@@ -1,0 +1,31 @@
+{
+  "frameworkId": "00000000-0000-0000-0000-000000000000",
+  "meta": {
+    "created_at": 1560000000,
+    "updated_at": 1560000000
+  },
+  "userId": "testinteractivecli",
+  "users": {
+    "testinteractivecli": {
+      "userId": "testinteractivecli",
+      "name": "Testing Interactive Cli",
+      "email": "test-interactive-cli@interactive.cli",
+      "username": "testinteractivecli",
+      "dashboard": {
+        "refreshToken": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "accessToken": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+        "idToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik56azVNREl5TVRnNFJqWTBORGswT0VJM1JrRXpORGN4UmtVMU1FWXdNemczT1VKQlFqRTBNZyJ9.eyJuaWNrbmFtZSI6InRlc3QtaW50ZXJhY3RpdmUtY2xpIiwibmFtZSI6IlRlc3RpbmcgSW50ZXJhY3RpdmUgQ2xpIiwicGljdHVyZSI6Imh0dHBzOi8vaW50ZXJhdGNpdmUuY2xpL3Rlc3RpbmcucG5nIiwidXBkYXRlZF9hdCI6IjIwMTktMDktMTZUMTU6MTg6NDMuOTk5WiIsImVtYWlsIjoidGVzdGluZ0BpbnRlcmFjdGl2ZS5jbGkiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNzIjoiaHR0cHM6Ly9zZXJ2ZXJsZXNzaW5jLmF1dGgwLmNvbS8iLCJzdWIiOiJ0ZXN0LWludGVyYWN0aXZlLWNsaSIsImF1ZCI6IlhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYIiwiaWF0IjoxNTYwMDAwMDAwLCJleHAiOjMwMDAwMDAwMDB9.GcNQtWSxv9CHTABw-HIjYSvRxTEapDUDqIIWRGmz01XmShQxRGOHRuUg1NKU4w9MpOlB6txHKs8UWd2eZkzw_Z4QmIuLyAVhVklpWP2-xeysPLUyqVTgqAg8kgIUAwdKjmrdpQqHhGd-Q1BIX62-E-qKKx8prmADSw_hgmuvlMuSCa1ajCnfyUXycQxDmbFrvjd24lJER0FSpB2nWWW3KxZ_UBX-TuVmiEtRXg9GYeSv6oIU78PrIhYgJ0QjERRF1yAYamIXNRs-KZ7Z4YiFNC4uKzFH1524pZkS4Q0-pweIvBrrsjekz-vEYcbaVG1zAxDu_yNrYPk5phCy8MHTrQ",
+        "expiresAt": 3000000000000,
+        "username": "testinteractivecli",
+        "accessKeys": {
+          "testinteractivecli": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+        }
+      },
+      "enterprise": {
+        "versionSDK": "2.1.1",
+        "timeLastLogin": 1560000000,
+        "timeLastLogout": 1560000000
+      }
+    }
+  }
+}

--- a/test/fixtures/test-command/serverless.test.yml
+++ b/test/fixtures/test-command/serverless.test.yml
@@ -1,0 +1,26 @@
+- name: endpoint
+  endpoint:
+    function: normal
+    path: foo
+    method: GET
+  response:
+    body: foobar
+    request:
+      headers:
+        Foo: bar
+- name: function
+  endpoint:
+    function: normal
+  response:
+    body: foobar
+    request:
+      headers:
+        Foo: bar
+- name: shorthand
+  endpoint:
+    function: shorthand
+  response:
+    body: foobar
+    request:
+      headers:
+        Foo: bar

--- a/test/fixtures/test-command/serverless.yml
+++ b/test/fixtures/test-command/serverless.yml
@@ -1,0 +1,19 @@
+service: some-aws-service
+provider:
+  name: aws
+  runtime: nodejs12.x
+
+org: testinteractivecli
+app: some-aws-service-app
+
+functions:
+  normal:
+    handler: index.handler
+    events:
+      - http:
+          path: foo
+          method: GET
+  shorthand:
+    handler: index.handler
+    events:
+      - http: GET bar

--- a/test/run-serverless.js
+++ b/test/run-serverless.js
@@ -2,5 +2,30 @@
 
 const runServerless = require('@serverless/test/run-serverless');
 const setupServerless = require('./setupServerless');
+const fixtures = require('./fixtures');
 
-module.exports = async (options) => runServerless((await setupServerless()).root, options);
+module.exports = async (options) => {
+  if (options.fixture && options.cwd) {
+    throw new Error('Either "fixture" or "cwd" should be provided');
+  }
+  const runServerlessOptions = Object.assign({}, options);
+  delete runServerlessOptions.serverlessPath;
+  delete runServerlessOptions.fixture;
+  delete runServerlessOptions.configExt;
+  let fixtureData;
+  if (options.fixture) {
+    fixtureData = await fixtures.setup(options.fixture, { configExt: options.configExt });
+    runServerlessOptions.cwd = fixtureData.servicePath;
+  }
+  try {
+    const result = await runServerless(
+      options.serverlessPath || (await setupServerless()).root,
+      runServerlessOptions
+    );
+    result.fixtureData = fixtureData;
+    return result;
+  } catch (error) {
+    error.fixtureData = fixtureData;
+    throw error;
+  }
+};

--- a/test/setupServerless/index.js
+++ b/test/setupServerless/index.js
@@ -27,7 +27,11 @@ module.exports = memoizee(
     if (process.env.LOCAL_SERVERLESS_LINK_PATH) {
       // Test against local serverless installation which is expected to have
       // this instance of `@serverless/enterprise-plugin` linked in its node_modules
-      const serverlessPath = path.resolve(process.env.LOCAL_SERVERLESS_LINK_PATH);
+      const serverlessPath = path.resolve(
+        __dirname,
+        '../..',
+        process.env.LOCAL_SERVERLESS_LINK_PATH
+      );
       return Promise.all([
         realpath(path.join(__dirname, '../..')),
         realpath(path.join(serverlessPath, 'node_modules/@serverless/enterprise-plugin')).catch(


### PR DESCRIPTION
_bug reported internally_

Additionally:
- Upgraded `@serverless/test` to v6 and updated affected `runServerless` calls
- Refactored `lib/test` tests, so they rely on `runServerless`