### PR TITLE
Support Parameters, override Profiles with Providers/Parameters

### DIFF
--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -7,16 +7,27 @@ const { serviceSlug, instanceSlug } = require('./utils');
 module.exports.configureDeployProfile = async (ctx) => {
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.org);
   let deploymentProfile;
+  const {
+    provider,
+    sls: {
+      service: { app, org, service },
+      processedInput: { options: cliOptions },
+    },
+  } = ctx;
+
+  const stage = cliOptions.stage || provider.getStage();
+  const region = cliOptions.region || provider.getRegion();
+
   try {
     deploymentProfile = await getDeployProfile({
       accessKey,
-      stage: ctx.provider.getStage(),
-      app: ctx.sls.service.app,
-      tenant: ctx.sls.service.org,
+      stage,
+      app,
+      tenant: org,
     });
     if (deploymentProfile.providerCredentials) {
       ctx.provider.cachedCredentials = deploymentProfile.providerCredentials.secretValue;
-      ctx.provider.cachedCredentials.region = ctx.provider.getRegion();
+      ctx.provider.cachedCredentials.region = region;
     }
     ctx.safeguards = deploymentProfile.safeguardsPolicies;
   } catch (e) {
@@ -37,8 +48,8 @@ module.exports.configureDeployProfile = async (ctx) => {
     }
     providerCredentials = await sdkV2.getProvidersByOrgServiceInstance(
       ctx.sls.service.orgUid,
-      serviceSlug(ctx),
-      instanceSlug(ctx)
+      serviceSlug({ app, service }),
+      instanceSlug({ app, service, stage, region })
     );
   } catch (e) {
     if (!e.statusCode === '404') {

--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -18,6 +18,7 @@ module.exports.configureDeployProfile = async (ctx) => {
       ctx.provider.cachedCredentials = deploymentProfile.providerCredentials.secretValue;
       ctx.provider.cachedCredentials.region = ctx.provider.getRegion();
     }
+    ctx.safeguards = deploymentProfile.safeguardsPolicies;
   } catch (e) {
     if (process.env.SLS_DEBUG) {
       // eslint-disable-next-line no-console
@@ -64,5 +65,4 @@ module.exports.configureDeployProfile = async (ctx) => {
       ctx.provider.cachedCredentials.region = ctx.provider.getRegion();
     }
   }
-  ctx.safeguards = deploymentProfile.safeguardsPolicies;
 };

--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -6,16 +6,25 @@ const { serviceSlug, instanceSlug } = require('./utils');
 
 module.exports.configureDeployProfile = async (ctx) => {
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.org);
-  const deploymentProfile = await getDeployProfile({
-    accessKey,
-    stage: ctx.provider.getStage(),
-    app: ctx.sls.service.app,
-    tenant: ctx.sls.service.org,
-  });
-  if (deploymentProfile.providerCredentials) {
-    ctx.provider.cachedCredentials = deploymentProfile.providerCredentials.secretValue;
-    ctx.provider.cachedCredentials.region = ctx.provider.getRegion();
+  let deploymentProfile;
+  try {
+    deploymentProfile = await getDeployProfile({
+      accessKey,
+      stage: ctx.provider.getStage(),
+      app: ctx.sls.service.app,
+      tenant: ctx.sls.service.org,
+    });
+    if (deploymentProfile.providerCredentials) {
+      ctx.provider.cachedCredentials = deploymentProfile.providerCredentials.secretValue;
+      ctx.provider.cachedCredentials.region = ctx.provider.getRegion();
+    }
+  } catch (e) {
+    if (process.env.SLS_DEBUG) {
+      // eslint-disable-next-line no-console
+      console.log('ignoring profile fetch error', e);
+    }
   }
+
   const sdkV2 = new ServerlessSDK({
     accessKey,
   });

--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -25,17 +25,17 @@ module.exports.configureDeployProfile = async (ctx) => {
       app,
       tenant: org,
     });
-    if (deploymentProfile.providerCredentials) {
-      ctx.provider.cachedCredentials = deploymentProfile.providerCredentials.secretValue;
-      ctx.provider.cachedCredentials.region = region;
-    }
-    ctx.safeguards = deploymentProfile.safeguardsPolicies;
   } catch (e) {
     if (process.env.SLS_DEBUG) {
       // eslint-disable-next-line no-console
       console.log('ignoring profile fetch error', e);
     }
   }
+  if (deploymentProfile.providerCredentials) {
+    ctx.provider.cachedCredentials = deploymentProfile.providerCredentials.secretValue;
+    ctx.provider.cachedCredentials.region = region;
+  }
+  ctx.safeguards = deploymentProfile.safeguardsPolicies;
 
   const sdkV2 = new ServerlessSDK({
     accessKey,

--- a/lib/deployProfile.test.js
+++ b/lib/deployProfile.test.js
@@ -32,6 +32,7 @@ describe('configureDeployProfile', () => {
           service: 'service',
           provider: { name: 'aws' },
         },
+        processedInput: { options: [] },
       },
     };
     await configureDeployProfile(ctx);

--- a/lib/paramCommand.js
+++ b/lib/paramCommand.js
@@ -7,10 +7,12 @@ const isAuthenticated = require('./isAuthenticated');
 const throwAuthError = require('./throwAuthError');
 const resolveParams = require('./resolveParams');
 
-const verifyInput = function (ctx) {
+const resolveInput = function (ctx) {
   const {
+    provider,
     sls: {
-      service: { app, org },
+      service: { app, org, service },
+      processedInput: { options: cliOptions },
       classes: { Error: ServerlessError },
     },
   } = ctx;
@@ -19,12 +21,14 @@ const verifyInput = function (ctx) {
 
   if (!org) throw new ServerlessError('Missing `org` setting', 'DASHBOARD_MISSING_ORG');
   if (!app) throw new ServerlessError('Missing `app` setting', 'DASHBOARD_MISSING_APP');
+  const stage = cliOptions.stage || provider.getStage();
+  const region = cliOptions.region || provider.getRegion();
+  return { org, app, service, stage, region };
 };
 
 module.exports = {
   get: async (context) => {
-    verifyInput(context);
-    const params = await resolveParams(context);
+    const params = await resolveParams(resolveInput(context));
     const { name } = context.sls.processedInput.options;
     if (!name) {
       throw new context.sls.classes.Error(
@@ -37,9 +41,7 @@ module.exports = {
     else process.stdout.write(`${params[name]}\n`);
   },
   list: async (context) => {
-    verifyInput(context);
-
-    const params = await resolveParams(context);
+    const params = await resolveParams(resolveInput(context));
     const slsCli = context.sls.cli;
     if (isEmpty(params)) {
       slsCli.log('No parameters stored');

--- a/lib/paramCommand.js
+++ b/lib/paramCommand.js
@@ -11,7 +11,7 @@ const resolveInput = function (ctx) {
   const {
     provider,
     sls: {
-      service: { app, org, service },
+      service: { app, org },
       processedInput: { options: cliOptions },
       classes: { Error: ServerlessError },
     },
@@ -23,6 +23,7 @@ const resolveInput = function (ctx) {
   if (!app) throw new ServerlessError('Missing `app` setting', 'DASHBOARD_MISSING_APP');
   const stage = cliOptions.stage || provider.getStage();
   const region = cliOptions.region || provider.getRegion();
+  const service = ctx.sls.service.service || cliOptions.service;
   return { org, app, service, stage, region };
 };
 

--- a/lib/paramCommand.js
+++ b/lib/paramCommand.js
@@ -7,12 +7,10 @@ const isAuthenticated = require('./isAuthenticated');
 const throwAuthError = require('./throwAuthError');
 const resolveParams = require('./resolveParams');
 
-const resolveInput = function (ctx) {
+const verifyInput = function (ctx) {
   const {
-    provider,
     sls: {
       service: { app, org },
-      processedInput: { options: cliOptions },
       classes: { Error: ServerlessError },
     },
   } = ctx;
@@ -21,15 +19,12 @@ const resolveInput = function (ctx) {
 
   if (!org) throw new ServerlessError('Missing `org` setting', 'DASHBOARD_MISSING_ORG');
   if (!app) throw new ServerlessError('Missing `app` setting', 'DASHBOARD_MISSING_APP');
-
-  const stage = cliOptions.stage || provider.getStage();
-
-  return { org, app, stage };
 };
 
 module.exports = {
   get: async (context) => {
-    const params = await resolveParams(resolveInput(context));
+    verifyInput(context);
+    const params = await resolveParams(context);
     const { name } = context.sls.processedInput.options;
     if (!name) {
       throw new context.sls.classes.Error(
@@ -42,7 +37,9 @@ module.exports = {
     else process.stdout.write(`${params[name]}\n`);
   },
   list: async (context) => {
-    const params = await resolveParams(resolveInput(context));
+    verifyInput(context);
+
+    const params = await resolveParams(context);
     const slsCli = context.sls.cli;
     if (isEmpty(params)) {
       slsCli.log('No parameters stored');

--- a/lib/paramCommand.test.js
+++ b/lib/paramCommand.test.js
@@ -19,7 +19,11 @@ const modulesCacheStub = {
       }
 
       async getProvidersByOrgServiceInstance() {
-        return {};
+        return { result: [], metadata: {}, errors: [] };
+      }
+
+      async getParamsByOrgServiceInstance() {
+        return { result: [], metadata: {}, errors: [] };
       }
     },
   },

--- a/lib/paramCommand.test.js
+++ b/lib/paramCommand.test.js
@@ -142,6 +142,56 @@ describe('paramCommand', function () {
       expect(stdoutData).to.include('second-param-name');
       expect(stdoutData).to.include('second-param-value');
     });
+
+    it('Should support `--service` and --region CLI param to talk to Parameters backend', async () => {
+      const getParamsStub = sinon.stub().returns({
+        result: [
+          { paramName: 'paramServiceOne', paramValue: 'paramServiceValueOne' },
+          { paramName: 'paramServiceTwo', paramValue: 'paramServiceValueTwo' },
+        ],
+      });
+      const { stdoutData } = await runServerless({
+        noService: true,
+        cliArgs: [
+          'param',
+          'list',
+          '--org',
+          'some-org',
+          '--app',
+          'some-app',
+          '--stage',
+          'foo',
+          '--service',
+          'some-service',
+          '--region',
+          'us-east-1',
+        ],
+        modulesCacheStub: {
+          [platformSdkPath]: {
+            ...modulesCacheStub[platformSdkPath],
+          },
+          [platformClientPath]: {
+            ServerlessSDK: class ServerlessSDK {
+              async getParamsByOrgServiceInstance(orgUid, serviceSlug, instanceSlug) {
+                return getParamsStub(orgUid, serviceSlug, instanceSlug);
+              }
+              async getOrgByName() {
+                return { orgUid: 'orgUid' };
+              }
+            },
+          },
+        },
+      });
+      expect(getParamsStub.args[0]).to.deep.equal([
+        'orgUid',
+        'appName|some-app|serviceName|some-service',
+        'appName|some-app|serviceName|some-service|stage|foo|region|us-east-1',
+      ]);
+      expect(stdoutData).to.include('paramServiceOne');
+      expect(stdoutData).to.include('paramServiceValueOne');
+      expect(stdoutData).to.include('paramServiceTwo');
+      expect(stdoutData).to.include('paramServiceValueTwo');
+    });
   });
 
   describe('get', () => {

--- a/lib/providersIntegration.test.js
+++ b/lib/providersIntegration.test.js
@@ -16,9 +16,7 @@ const modulesCacheStub = {
     getMetadata: () => ({
       supportedRegions: ['us-east-1'],
     }),
-    getApp: () => ({
-      wtf: 'wtf should this be',
-    }),
+    getApp: () => ({}),
   },
   [platformClientPath]: {
     ServerlessSDK: class ServerlessSDK {

--- a/lib/resolveParams.js
+++ b/lib/resolveParams.js
@@ -9,9 +9,12 @@ module.exports = memoizee(
   async (ctx) => {
     const {
       sls: {
-        service: { org, app, stage },
+        provider,
+        service: { org, app },
+        processedInput: { options: cliOptions },
       },
     } = ctx;
+    const stage = (cliOptions && cliOptions.stage) || provider.getStage();
     const accessKey = await getAccessKeyForTenant(org);
 
     const sdkV2 = new ServerlessSDK({
@@ -27,7 +30,7 @@ module.exports = memoizee(
       instanceSlug(ctx)
     );
     const params = Object.create(null);
-    if (parametersResponse.result.length) {
+    if (parametersResponse.result && parametersResponse.result.length) {
       for (const { paramName, paramValue } of parametersResponse.result) {
         params[paramName] = paramValue;
       }

--- a/lib/resolveParams.js
+++ b/lib/resolveParams.js
@@ -6,28 +6,17 @@ const { ServerlessSDK } = require('@serverless/platform-client');
 const { serviceSlug, instanceSlug } = require('./utils');
 
 module.exports = memoizee(
-  async (ctx) => {
-    const {
-      sls: {
-        provider,
-        service: { org, app },
-        processedInput: { options: cliOptions },
-      },
-    } = ctx;
-    const stage = (cliOptions && cliOptions.stage) || provider.getStage();
+  async ({ org, app, service, stage, region }) => {
     const accessKey = await getAccessKeyForTenant(org);
 
     const sdkV2 = new ServerlessSDK({
       accessKey,
     });
-    if (!ctx.sls.service.orgUid) {
-      const { orgUid } = await sdkV2.getOrgByName(org);
-      ctx.sls.service.orgUid = orgUid;
-    }
+    const { orgUid } = await sdkV2.getOrgByName(org);
     const parametersResponse = await sdkV2.getParamsByOrgServiceInstance(
-      ctx.sls.service.orgUid,
-      serviceSlug(ctx),
-      instanceSlug(ctx)
+      orgUid,
+      serviceSlug({ app, service }),
+      instanceSlug({ app, service, stage, region })
     );
     const params = Object.create(null);
     if (parametersResponse.result && parametersResponse.result.length) {
@@ -51,5 +40,9 @@ module.exports = memoizee(
 
     return params;
   },
-  { promise: true, normalizer: ([{ org, app, stage }]) => JSON.stringify({ org, app, stage }) }
+  {
+    promise: true,
+    normalizer: ([{ org, app, service, stage, region }]) =>
+      JSON.stringify({ org, app, service, stage, region }),
+  }
 );

--- a/lib/resolveParams.js
+++ b/lib/resolveParams.js
@@ -2,22 +2,50 @@
 
 const memoizee = require('memoizee');
 const { getAccessKeyForTenant, getDeployProfile } = require('@serverless/platform-sdk');
+const { ServerlessSDK } = require('@serverless/platform-client');
+const { serviceSlug, instanceSlug } = require('./utils');
 
 module.exports = memoizee(
-  async ({ org, app, stage }) => {
-    const deploymentProfile = await getDeployProfile({
-      accessKey: await getAccessKeyForTenant(org),
-      stage,
-      app,
-      tenant: org,
+  async (ctx) => {
+    const {
+      sls: {
+        service: { org, app, stage },
+      },
+    } = ctx;
+    const accessKey = await getAccessKeyForTenant(org);
+
+    const sdkV2 = new ServerlessSDK({
+      accessKey,
     });
-    const params = Object.create(null);
-    for (const {
-      secretName: name,
-      secretProperties: { value },
-    } of deploymentProfile.secretValues) {
-      params[name] = value;
+    if (!ctx.sls.service.orgUid) {
+      const { orgUid } = await sdkV2.getOrgByName(org);
+      ctx.sls.service.orgUid = orgUid;
     }
+    const parametersResponse = await sdkV2.getParamsByOrgServiceInstance(
+      ctx.sls.service.orgUid,
+      serviceSlug(ctx),
+      instanceSlug(ctx)
+    );
+    const params = Object.create(null);
+    if (parametersResponse.result.length) {
+      for (const { paramName, paramValue } of parametersResponse.result) {
+        params[paramName] = paramValue;
+      }
+    } else {
+      const deploymentProfile = await getDeployProfile({
+        accessKey,
+        stage,
+        app,
+        tenant: org,
+      });
+      for (const {
+        secretName: name,
+        secretProperties: { value },
+      } of deploymentProfile.secretValues) {
+        params[name] = value;
+      }
+    }
+
     return params;
   },
   { promise: true, normalizer: ([{ org, app, stage }]) => JSON.stringify({ org, app, stage }) }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,11 +1,24 @@
 'use strict';
+function resolveInput(ctx) {
+  const {
+    provider,
+    sls: {
+      service: { app, org, service },
+      processedInput: { options: cliOptions },
+    },
+  } = ctx;
+  const stage = cliOptions.stage || provider.getStage();
+  const region = cliOptions.region || provider.getRegion();
+
+  return { app, org, service, cliOptions, provider, stage, region };
+}
 function serviceSlug(ctx) {
-  return `appName|${ctx.sls.service.app}|serviceName|${ctx.sls.service.service}`;
+  const { app, service } = resolveInput(ctx);
+  return `appName|${app}|serviceName|${service}`;
 }
 function instanceSlug(ctx) {
-  return `appName|${ctx.sls.service.app}|serviceName|${
-    ctx.sls.service.service
-  }|stage|${ctx.provider.getStage()}|region|${ctx.provider.getRegion()}`;
+  const { app, service, stage, region } = resolveInput(ctx);
+  return `appName|${app}|serviceName|${service}|stage|${stage}|region|${region}`;
 }
 
 function upperFirst(str) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,23 +1,8 @@
 'use strict';
-function resolveInput(ctx) {
-  const {
-    provider,
-    sls: {
-      service: { app, org, service },
-      processedInput: { options: cliOptions },
-    },
-  } = ctx;
-  const stage = cliOptions.stage || provider.getStage();
-  const region = cliOptions.region || provider.getRegion();
-
-  return { app, org, service, cliOptions, provider, stage, region };
-}
-function serviceSlug(ctx) {
-  const { app, service } = resolveInput(ctx);
+function serviceSlug({ app, service }) {
   return `appName|${app}|serviceName|${service}`;
 }
-function instanceSlug(ctx) {
-  const { app, service, stage, region } = resolveInput(ctx);
+function instanceSlug({ app, service, stage, region }) {
   return `appName|${app}|serviceName|${service}|stage|${stage}|region|${region}`;
 }
 

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -18,11 +18,7 @@ const getValueFromDashboardParams = (ctx) => async (variableString) => {
   }
 
   if (!ctx.sls.enterpriseEnabled) throwAuthError(ctx.sls);
-  const secrets = await resolveParams({
-    org: ctx.sls.service.org,
-    app: ctx.sls.service.app,
-    stage: ctx.provider.getStage(),
-  });
+  const secrets = await resolveParams(ctx);
   if (!secrets[variableName]) {
     throw new ctx.sls.classes.Error(`$\{${variableString}} not defined`);
   }

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const resolveOutput = require('./resolveOutput');
 const resolveParams = require('./resolveParams');
 const throwAuthError = require('./throwAuthError');
+const isAuthenticated = require('./isAuthenticated');
 
 const resolveInput = function (ctx) {
   const {
@@ -13,6 +14,8 @@ const resolveInput = function (ctx) {
       processedInput: { options: cliOptions },
     },
   } = ctx;
+
+  if (!isAuthenticated()) throwAuthError(ctx.sls);
 
   const stage = cliOptions.stage || provider.getStage();
   const region = cliOptions.region || provider.getRegion();

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -5,6 +5,20 @@ const resolveOutput = require('./resolveOutput');
 const resolveParams = require('./resolveParams');
 const throwAuthError = require('./throwAuthError');
 
+const resolveInput = function (ctx) {
+  const {
+    provider,
+    sls: {
+      service: { app, org, service },
+      processedInput: { options: cliOptions },
+    },
+  } = ctx;
+
+  const stage = cliOptions.stage || provider.getStage();
+  const region = cliOptions.region || provider.getRegion();
+  return { org, app, service, stage, region };
+};
+
 // functions for new way of getting variables
 const getValueFromDashboardParams = (ctx) => async (variableString) => {
   const variableName = variableString.slice(variableString.indexOf(':') + 1);
@@ -18,7 +32,7 @@ const getValueFromDashboardParams = (ctx) => async (variableString) => {
   }
 
   if (!ctx.sls.enterpriseEnabled) throwAuthError(ctx.sls);
-  const secrets = await resolveParams(ctx);
+  const secrets = await resolveParams(resolveInput(ctx));
   if (!secrets[variableName]) {
     throw new ctx.sls.classes.Error(`$\{${variableString}} not defined`);
   }

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -30,6 +30,7 @@ describe('variables', () => {
         require.resolve('./variables'),
         require.resolve('./resolveParams'),
         require.resolve('./resolveOutput'),
+        require.resolve('./isAuthenticated'),
         require.resolve('@serverless/platform-sdk'),
         require.resolve('@serverless/platform-client'),
       ],
@@ -38,6 +39,7 @@ describe('variables', () => {
           getAccessKeyForTenant: async () => 'accessKey',
           getStateVariable,
           getDeployProfile,
+          getLoggedInUser: () => true,
         });
         Object.assign(require('@serverless/platform-client'), {
           ServerlessSDK: class ServerlessSDK {

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -31,6 +31,7 @@ describe('variables', () => {
         require.resolve('./resolveParams'),
         require.resolve('./resolveOutput'),
         require.resolve('@serverless/platform-sdk'),
+        require.resolve('@serverless/platform-client'),
       ],
       () => {
         Object.assign(require('@serverless/platform-sdk'), {
@@ -38,7 +39,20 @@ describe('variables', () => {
           getStateVariable,
           getDeployProfile,
         });
-        return { ...require('./variables'), resolveParams: require('./resolveParams') };
+        Object.assign(require('@serverless/platform-client'), {
+          ServerlessSDK: class ServerlessSDK {
+            async getOrgByName() {
+              return { orgUid: 'abcd-1234' };
+            }
+            async getParamsByOrgServiceInstance() {
+              return {};
+            }
+          },
+        });
+        return {
+          ...require('./variables'),
+          resolveParams: require('./resolveParams'),
+        };
       }
     ));
   });
@@ -58,6 +72,9 @@ describe('variables', () => {
         },
         processedInput: {
           commands: [],
+          options: {
+            cliOptions: [],
+          },
         },
         enterpriseEnabled: true,
       },


### PR DESCRIPTION
This pull request handles a few things:
- Modify deployment profile logic to not halt execution if a deployment profile call fails (5xx error caused by a ARN being un-assumable, for example)
- Adds parameters as a way to resolve variables, but also powers the `param` command.
- Params override fetching of profiles, so if a param result is non-empty, we do not fetch deployment profiles