### PR TITLE
Migrate `platform-sdk` utils to `serverless/utils` tools

### DIFF
--- a/lib/deployment/parse.test.js
+++ b/lib/deployment/parse.test.js
@@ -1542,7 +1542,6 @@ describe('parseDeploymentData #2', () => {
         getAccessKeyForTenant: () => 'access-key',
         getApp: () => ({ appUid: 'appUid', tenantUid: 'orgUid' }),
         getDeployProfile: () => ({}),
-        getLoggedInUser: () => ({}),
         getMetadata: () => ({ supportedRegions: ['us-east-1'] }),
         Deployment: class Deployment {
           set() {}
@@ -1550,6 +1549,9 @@ describe('parseDeploymentData #2', () => {
           setSubscription() {}
           save() {}
         },
+      },
+      [require.resolve('@serverless/utils/config')]: {
+        getLoggedInUser: () => ({}),
       },
       [require.resolve('simple-git/promise')]: () => ({
         checkIsRepo: async () => true,

--- a/lib/interactiveCli/index.js
+++ b/lib/interactiveCli/index.js
@@ -34,10 +34,10 @@ module.exports = (ctx) => {
       }
     },
     'before:interactiveCli:setupAws': async () => {
-      const registerCheck = await register.check(ctx.sls);
+      const registerCheck = await register.check(ctx);
       if (registerCheck) {
         process.stdout.write('\n');
-        await register.run(ctx.sls, registerCheck);
+        await register.run(ctx, registerCheck);
       }
       const setAppCheck = await setApp.check(ctx.sls);
       if (setAppCheck) {

--- a/lib/interactiveCli/index.js
+++ b/lib/interactiveCli/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
-const { getLoggedInUser } = require('@serverless/platform-sdk');
+const configUtils = require('@serverless/utils/config');
 
 const { getMetadata } = require('@serverless/platform-sdk');
 const { configureDeployProfile } = require('../deployProfile');
@@ -50,7 +50,7 @@ ${chalk.green('Your project is setup for monitoring, troubleshooting and testing
 `);
         // setup deploy if user already logged in so that AWS creds check in SFO works right
         // & temporarily add provider to ctx to fetch deploy profile
-        const user = getLoggedInUser();
+        const user = configUtils.getLoggedInUser();
         if (user) await configureDeployProfile({ ...ctx, provider: ctx.sls.getProvider('aws') });
       }
     },

--- a/lib/interactiveCli/index.test.js
+++ b/lib/interactiveCli/index.test.js
@@ -3,12 +3,10 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const runServerless = require('../../test/run-serverless');
-const { getLoggedInUser } = require('@serverless/platform-sdk');
 const setAppConfiguration = require('./set-app');
 
 const platformSdkStub = {
   configureFetchDefaults: () => {},
-  getLoggedInUser,
   getMetadata: async () => ({
     awsAccountId: '377024778620',
     supportedRuntimes: ['nodejs8.10', 'nodejs10.x', 'python2.7', 'python3.6', 'python3.7'],

--- a/lib/interactiveCli/register.js
+++ b/lib/interactiveCli/register.js
@@ -5,13 +5,13 @@ const {
   createApp,
   getLoggedInUser,
   getMetadata,
-  login,
   register: sdkRegister,
   writeConfigFile,
 } = require('@serverless/platform-sdk');
 const sdkVersion = require('@serverless/platform-sdk/package').version;
 const enableConfirm = require('./enableConfirm');
 const writeOrgAndApp = require('./writeOrgAndApp');
+const login = require('../login');
 
 const isValidEmail = RegExp.prototype.test.bind(
   new RegExp(
@@ -158,11 +158,11 @@ const validadateRegistrationResponseValue = (name, value) => {
 };
 
 const steps = {
-  registerOrLogin: async (serverless) => {
-    const { inquirer } = serverless.interactiveCli;
+  registerOrLogin: async (ctx) => {
+    const { inquirer } = ctx.sls.interactiveCli;
     const registerOrLogin = await registerQuestion(inquirer);
     if (registerOrLogin === 'login') {
-      await login();
+      await login(ctx);
       return;
     }
     const { ownerUserName, orgName, ownerAccessKey, ownerAuth0Id } = await signUp(inquirer);
@@ -194,36 +194,36 @@ const steps = {
 
     const { appName } = await createApp({
       tenant: orgName,
-      app: `${serverless.service.service}-app`,
+      app: `${ctx.sls.service.service}-app`,
       token: ownerAccessKey,
     });
 
-    await writeOrgAndApp(serverless, orgName, appName);
+    await writeOrgAndApp(ctx.sls, orgName, appName);
   },
 };
 
 module.exports = {
-  async check(serverless) {
-    if (!serverless.config.servicePath) return false;
-    if (serverless.service.provider.name !== 'aws') {
+  async check(ctx) {
+    if (!ctx.sls.config.servicePath) return false;
+    if (ctx.sls.service.provider.name !== 'aws') {
       return false;
     }
     const { supportedRegions, supportedRuntimes } = await getMetadata();
-    if (!supportedRuntimes.includes(serverless.service.provider.runtime || 'nodejs10.x')) {
+    if (!supportedRuntimes.includes(ctx.sls.service.provider.runtime || 'nodejs10.x')) {
       return false;
     }
-    if (!supportedRegions.includes(serverless.getProvider('aws').getRegion())) {
+    if (!supportedRegions.includes(ctx.sls.getProvider('aws').getRegion())) {
       return false;
     }
     return !getLoggedInUser();
   },
-  async run(serverless) {
-    const { inquirer } = serverless.interactiveCli;
-    if (!(await enableConfirm(inquirer, serverless.processedInput.options))) {
+  async run(ctx) {
+    const { inquirer } = ctx.sls.interactiveCli;
+    if (!(await enableConfirm(inquirer, ctx.sls.processedInput.options))) {
       return null;
     }
     process.stdout.write('You are not logged in or you do not have a Serverless account.\n\n');
-    return steps.registerOrLogin(serverless);
+    return steps.registerOrLogin(ctx);
   },
   steps,
 };

--- a/lib/interactiveCli/register.js
+++ b/lib/interactiveCli/register.js
@@ -1,12 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
-const {
-  createApp,
-  getMetadata,
-  register: sdkRegister,
-  writeConfigFile,
-} = require('@serverless/platform-sdk');
+const { createApp, getMetadata, register: sdkRegister } = require('@serverless/platform-sdk');
 const sdkVersion = require('@serverless/platform-sdk/package').version;
 const enableConfirm = require('./enableConfirm');
 const writeOrgAndApp = require('./writeOrgAndApp');
@@ -170,7 +165,7 @@ const steps = {
     validadateRegistrationResponseValue('tenantName', orgName);
     validadateRegistrationResponseValue('ownerAccessKey', ownerAccessKey);
     validadateRegistrationResponseValue('ownerAuth0Id', ownerAuth0Id);
-    writeConfigFile({
+    configUtils.set({
       userId: ownerAuth0Id,
       users: {
         [ownerAuth0Id]: {

--- a/lib/interactiveCli/register.js
+++ b/lib/interactiveCli/register.js
@@ -3,7 +3,6 @@
 const chalk = require('chalk');
 const {
   createApp,
-  getLoggedInUser,
   getMetadata,
   register: sdkRegister,
   writeConfigFile,
@@ -12,6 +11,7 @@ const sdkVersion = require('@serverless/platform-sdk/package').version;
 const enableConfirm = require('./enableConfirm');
 const writeOrgAndApp = require('./writeOrgAndApp');
 const login = require('../login');
+const configUtils = require('@serverless/utils/config');
 
 const isValidEmail = RegExp.prototype.test.bind(
   new RegExp(
@@ -215,7 +215,7 @@ module.exports = {
     if (!supportedRegions.includes(ctx.sls.getProvider('aws').getRegion())) {
       return false;
     }
-    return !getLoggedInUser();
+    return !configUtils.getLoggedInUser();
   },
   async run(ctx) {
     const { inquirer } = ctx.sls.interactiveCli;

--- a/lib/interactiveCli/register.test.js
+++ b/lib/interactiveCli/register.test.js
@@ -8,7 +8,6 @@ const yaml = require('yamljs');
 const resolveSync = require('ncjsm/resolve/sync');
 const runServerless = require('../../test/run-serverless');
 const configureInquirerStub = require('@serverless/test/configure-inquirer-stub');
-const { writeConfigFile } = require('@serverless/platform-sdk');
 const setAppConfiguration = require('./set-app');
 const configUtils = require('@serverless/utils/config');
 
@@ -46,7 +45,6 @@ const platformSdkStub = {
       ownerAuth0Id: userName,
     };
   },
-  writeConfigFile,
 };
 
 describe('interactiveCli: register', function () {

--- a/lib/interactiveCli/register.test.js
+++ b/lib/interactiveCli/register.test.js
@@ -38,7 +38,6 @@ const platformSdkStub = {
       'ap-southeast-2',
     ],
   }),
-  login: sinon.stub().resolves(),
   register: async (email, password, userName, orgName) => {
     return {
       ownerUserName: userName,
@@ -56,6 +55,7 @@ describe('interactiveCli: register', function () {
   let modulesCacheStub;
   let inquirer;
   let backupIsTTY;
+  const loginStub = sinon.stub().resolves();
 
   before(async () => {
     backupIsTTY = process.stdin.isTTY;
@@ -67,6 +67,7 @@ describe('interactiveCli: register', function () {
       [require.resolve(inquirerPath)]: inquirer,
       [require.resolve('../deployProfile')]: { configureDeployProfile: async () => {} },
       [require.resolve('./set-app')]: setAppConfiguration,
+      [require.resolve('../login')]: loginStub,
       [require.resolve('@serverless/platform-sdk')]: platformSdkStub,
     };
     sinon.stub(setAppConfiguration, 'check').resolves(false);
@@ -131,7 +132,7 @@ describe('interactiveCli: register', function () {
       lifecycleHookNamesBlacklist,
       modulesCacheStub,
     });
-    expect(platformSdkStub.login.calledOnce).to.be.true;
+    expect(loginStub.calledOnce).to.be.true;
   });
 
   it('Should not accept invalid email at registration step', async () => {

--- a/lib/interactiveCli/register.test.js
+++ b/lib/interactiveCli/register.test.js
@@ -8,8 +8,9 @@ const yaml = require('yamljs');
 const resolveSync = require('ncjsm/resolve/sync');
 const runServerless = require('../../test/run-serverless');
 const configureInquirerStub = require('@serverless/test/configure-inquirer-stub');
-const { getLoggedInUser, writeConfigFile } = require('@serverless/platform-sdk');
+const { writeConfigFile } = require('@serverless/platform-sdk');
 const setAppConfiguration = require('./set-app');
+const configUtils = require('@serverless/utils/config');
 
 const setupServerless = require('../../test/setupServerless');
 
@@ -22,7 +23,6 @@ const lifecycleHookNamesBlacklist = [
 const platformSdkStub = {
   configureFetchDefaults: () => {},
   createApp: async ({ app }) => ({ appName: app }),
-  getLoggedInUser,
   getMetadata: async () => ({
     awsAccountId: '377024778620',
     supportedRuntimes: ['nodejs8.10', 'nodejs10.x', 'python2.7', 'python3.6', 'python3.7'],
@@ -199,7 +199,7 @@ describe('interactiveCli: register', function () {
         modulesCacheStub,
         hooks: {
           after: () => {
-            registeredUser = getLoggedInUser();
+            registeredUser = configUtils.getLoggedInUser();
           },
         },
       });

--- a/lib/interactiveCli/set-app.js
+++ b/lib/interactiveCli/set-app.js
@@ -2,12 +2,12 @@
 
 const _ = require('lodash');
 const chalk = require('chalk');
+const configUtils = require('@serverless/utils/config');
 const {
   createApp,
   createDeployProfile,
   getApps,
   getDeployProfiles,
-  getLoggedInUser,
   getMetadata,
   listTenants,
   refreshToken,
@@ -145,7 +145,7 @@ const steps = {
       for (const org of Object.keys(user.accessKeys)) orgs.add(org);
     } else {
       await refreshToken();
-      user = getLoggedInUser();
+      user = configUtils.getLoggedInUser();
       orgs = new Set(
         (await listTenants({ username: user.username, idToken: user.idToken })).map(
           (org) => org.tenantName
@@ -206,12 +206,12 @@ module.exports = {
     }
     if (!supportedRegions.includes(serverless.getProvider('aws').getRegion())) return false;
 
-    let user = getLoggedInUser();
+    let user = configUtils.getLoggedInUser();
     if (!user) return false;
 
     const orgNames = await steps.resolveOrgNames(user);
     if (!orgNames.size) return false;
-    user = getLoggedInUser(); // Refreshed, as new token might have been generated
+    user = configUtils.getLoggedInUser(); // Refreshed, as new token might have been generated
 
     const orgName = serverless.service.org;
     const appName = serverless.service.app;

--- a/lib/interactiveCli/set-app.js
+++ b/lib/interactiveCli/set-app.js
@@ -2,7 +2,9 @@
 
 const _ = require('lodash');
 const chalk = require('chalk');
+const accountUtils = require('@serverless/utils/account');
 const configUtils = require('@serverless/utils/config');
+const { ServerlessSDK } = require('@serverless/platform-client');
 const {
   createApp,
   createDeployProfile,
@@ -10,7 +12,6 @@ const {
   getDeployProfiles,
   getMetadata,
   listTenants,
-  refreshToken,
   setDefaultDeploymentProfile,
 } = require('@serverless/platform-sdk');
 const enableConfirm = require('./enableConfirm');
@@ -144,7 +145,7 @@ const steps = {
       // make a valid representation
       for (const org of Object.keys(user.accessKeys)) orgs.add(org);
     } else {
-      await refreshToken();
+      await accountUtils.refreshToken(new ServerlessSDK());
       user = configUtils.getLoggedInUser();
       orgs = new Set(
         (await listTenants({ username: user.username, idToken: user.idToken })).map(

--- a/lib/interactiveCli/set-app.test.js
+++ b/lib/interactiveCli/set-app.test.js
@@ -14,6 +14,8 @@ const semver = require('semver');
 const setupServerless = require('../../test/setupServerless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
+const platformClientPath = require.resolve('@serverless/platform-client');
+
 const lifecycleHookNamesBlacklist = [
   'interactiveCli:initializeService',
   'interactiveCli:setupAws',
@@ -69,7 +71,6 @@ describe('interactiveCli: set-app', function () {
       }),
       listTenants: async () => [{ tenantName: 'testinteractivecli' }, { tenantName: 'otherorg' }],
       login: sinon.stub().resolves(),
-      refreshToken: async () => {},
       setDefaultDeploymentProfile: setDefaultDeploymentProfileStub,
     };
     modulesCacheStub = {
@@ -77,6 +78,13 @@ describe('interactiveCli: set-app', function () {
       [require.resolve('./utils')]: { resolveAccessKey: async () => 'token' },
       [require.resolve('.//register')]: registerConfiguration,
       [require.resolve('../deployProfile')]: { configureDeployProfile: async () => {} },
+      [platformClientPath]: {
+        ServerlessSDK: class ServerlessSDK {
+          async refreshToken() {
+            return {};
+          }
+        },
+      },
       [platformSdkPath]: platformSdkStub,
     };
     sinon.stub(registerConfiguration, 'check').resolves(false);

--- a/lib/interactiveCli/set-app.test.js
+++ b/lib/interactiveCli/set-app.test.js
@@ -8,7 +8,6 @@ const yaml = require('yamljs');
 const resolveSync = require('ncjsm/resolve/sync');
 const runServerless = require('../..//test/run-serverless');
 const configureInquirerStub = require('@serverless/test/configure-inquirer-stub');
-const { getLoggedInUser } = require('@serverless/platform-sdk');
 const registerConfiguration = require('./register');
 const semver = require('semver');
 
@@ -53,7 +52,6 @@ describe('interactiveCli: set-app', function () {
         { appName: 'app-from-flag' },
       ],
       getDeployProfiles: async () => [{ deploymentProfileUid: 'some-deploy-profile' }],
-      getLoggedInUser,
       getMetadata: async () => ({
         awsAccountId: '377024778620',
         supportedRuntimes: ['nodejs10.x', 'nodejs12.x', 'python2.7', 'python3.6', 'python3.7'],

--- a/lib/interactiveCli/utils.js
+++ b/lib/interactiveCli/utils.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const { createAccessKeyForTenant, writeConfigFile } = require('@serverless/platform-sdk');
+const { createAccessKeyForTenant } = require('@serverless/platform-sdk');
+const configUtils = require('@serverless/utils/config');
 
 module.exports = {
   resolveAccessKey: async (user, orgName) => {
     if (user.accessKeys && user.accessKeys[orgName]) return user.accessKeys[orgName];
     const token = await createAccessKeyForTenant(orgName);
-    await writeConfigFile({
+    configUtils.set({
       users: { [user.userId]: { dashboard: { accessKeys: { [orgName]: token } } } },
     });
     return token;

--- a/lib/isAuthenticated.js
+++ b/lib/isAuthenticated.js
@@ -1,5 +1,5 @@
 'use strict';
 
-const { getLoggedInUser } = require('@serverless/platform-sdk');
+const configUtils = require('@serverless/utils/config');
 
-module.exports = () => Boolean(getLoggedInUser() || process.env.SERVERLESS_ACCESS_KEY);
+module.exports = () => Boolean(configUtils.getLoggedInUser() || process.env.SERVERLESS_ACCESS_KEY);

--- a/lib/login.js
+++ b/lib/login.js
@@ -2,7 +2,7 @@
 
 const open = require('open');
 const { ServerlessSDK } = require('@serverless/platform-client');
-const { urls, readConfigFile, writeConfigFile } = require('@serverless/platform-sdk');
+const { urls, writeConfigFile } = require('@serverless/platform-sdk');
 
 module.exports = async function (ctx) {
   ctx.sls.cli.log('Logging you in via your default browser...');
@@ -19,27 +19,27 @@ module.exports = async function (ctx) {
 
   const loginData = await loginDataDeferred;
 
-  const configFile = readConfigFile();
-
-  // prepare login data to save it in the FS
-  configFile.userId = loginData.id;
-  configFile.users = configFile.users || {};
-  configFile.users[loginData.id] = {
+  const loginDataToSaveInConfig = {
     userId: loginData.id,
-    name: loginData.name,
-    email: loginData.email,
-    username: loginData.username,
-    dashboard: {
-      refreshToken: loginData.refreshToken,
-      accessToken: loginData.accessToken,
-      idToken: loginData.idToken,
-      expiresAt: loginData.expiresAt,
-      username: loginData.username,
+    users: {
+      [loginData.id]: {
+        userId: loginData.id,
+        name: loginData.name,
+        email: loginData.email,
+        username: loginData.username,
+        dashboard: {
+          refreshToken: loginData.refreshToken,
+          accessToken: loginData.accessToken,
+          idToken: loginData.idToken,
+          expiresAt: loginData.expiresAt,
+          username: loginData.username,
+        },
+      },
     },
   };
 
   // save the login data in the rc file
-  writeConfigFile(configFile);
+  writeConfigFile(loginDataToSaveInConfig);
 
   ctx.sls.cli.log('You sucessfully logged in to Serverless.');
   if (!ctx.sls.service.org || !ctx.sls.service.app) {

--- a/lib/login.js
+++ b/lib/login.js
@@ -2,7 +2,8 @@
 
 const open = require('open');
 const { ServerlessSDK } = require('@serverless/platform-client');
-const { urls, writeConfigFile } = require('@serverless/platform-sdk');
+const { urls } = require('@serverless/platform-sdk');
+const configUtils = require('@serverless/utils/config');
 
 module.exports = async function (ctx) {
   ctx.sls.cli.log('Logging you in via your default browser...');
@@ -39,7 +40,7 @@ module.exports = async function (ctx) {
   };
 
   // save the login data in the rc file
-  writeConfigFile(loginDataToSaveInConfig);
+  configUtils.set(loginDataToSaveInConfig);
 
   ctx.sls.cli.log('You sucessfully logged in to Serverless.');
   if (!ctx.sls.service.org || !ctx.sls.service.app) {

--- a/lib/logout.js
+++ b/lib/logout.js
@@ -1,15 +1,16 @@
 'use strict';
 
-const { getLoggedInUser, logout } = require('@serverless/platform-sdk');
+const accountUtils = require('@serverless/utils/account');
+const configUtils = require('@serverless/utils/config');
 
 module.exports = async function (ctx) {
-  const user = getLoggedInUser();
+  const user = configUtils.getLoggedInUser();
 
   if (!user) {
     ctx.sls.cli.log('You are already logged out');
     return;
   }
 
-  await logout();
+  accountUtils.logout();
   ctx.sls.cli.log('You successfully logged out of Serverless.');
 };

--- a/lib/outputCommand.test.js
+++ b/lib/outputCommand.test.js
@@ -6,12 +6,16 @@ const runServerless = require('../test/run-serverless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
 const platformClientPath = require.resolve('@serverless/platform-client');
+const configUtilsPath = require.resolve('@serverless/utils/config');
+
 const modulesCacheStub = {
   [platformSdkPath]: {
     configureFetchDefaults: () => {},
     getAccessKeyForTenant: () => 'access-key',
-    getLoggedInUser: () => ({}),
     getDeployProfile: () => ({}),
+  },
+  [configUtilsPath]: {
+    getLoggedInUser: () => ({}),
   },
   [platformClientPath]: {
     ServerlessSDK: class ServerlessSDK {
@@ -73,8 +77,8 @@ describe('outputCommand', function () {
           noService: true,
           cliArgs: ['output', 'list'],
           modulesCacheStub: {
-            [platformSdkPath]: {
-              ...modulesCacheStub[platformSdkPath],
+            ...modulesCacheStub,
+            [configUtilsPath]: {
               getLoggedInUser: () => null,
             },
           },
@@ -255,8 +259,8 @@ describe('outputCommand', function () {
           fixture: 'aws-monitored-service',
           cliArgs: ['output', 'get', '--name', 'stringOutputName'],
           modulesCacheStub: {
-            [platformSdkPath]: {
-              ...modulesCacheStub[platformSdkPath],
+            ...modulesCacheStub,
+            [configUtilsPath]: {
               getLoggedInUser: () => null,
             },
           },

--- a/lib/paramCommand.test.js
+++ b/lib/paramCommand.test.js
@@ -6,11 +6,14 @@ const runServerless = require('../test/run-serverless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
 const platformClientPath = require.resolve('@serverless/platform-client');
+const configUtilsPath = require.resolve('@serverless/utils/config');
 
 const modulesCacheStub = {
   [platformSdkPath]: {
     configureFetchDefaults: () => {},
     getAccessKeyForTenant: () => 'access-key',
+  },
+  [configUtilsPath]: {
     getLoggedInUser: () => ({}),
   },
   [platformClientPath]: {
@@ -54,8 +57,8 @@ describe('paramCommand', function () {
           noService: true,
           cliArgs: ['param', 'list'],
           modulesCacheStub: {
-            [platformSdkPath]: {
-              ...modulesCacheStub[platformSdkPath],
+            ...modulesCacheStub,
+            [configUtilsPath]: {
               getLoggedInUser: () => null,
             },
           },
@@ -171,6 +174,9 @@ describe('paramCommand', function () {
           [platformSdkPath]: {
             ...modulesCacheStub[platformSdkPath],
           },
+          [configUtilsPath]: {
+            ...modulesCacheStub[configUtilsPath],
+          },
           [platformClientPath]: {
             ServerlessSDK: class ServerlessSDK {
               async getParamsByOrgServiceInstance(orgUid, serviceSlug, instanceSlug) {
@@ -202,8 +208,8 @@ describe('paramCommand', function () {
           noService: true,
           cliArgs: ['param', 'get', '--name', 'second-param-name'],
           modulesCacheStub: {
-            [platformSdkPath]: {
-              ...modulesCacheStub[platformSdkPath],
+            ...modulesCacheStub,
+            [configUtilsPath]: {
               getLoggedInUser: () => null,
             },
           },

--- a/lib/plugin.test.js
+++ b/lib/plugin.test.js
@@ -53,14 +53,16 @@ describe('plugin', () => {
       './injectLogsIamRole': injectLogsIamRole,
       './isAuthenticated': () => true,
       './setApiGatewayAccessLogFormat': setApiGatewayAccessLogFormat,
-      '@serverless/platform-sdk': {
-        configureFetchDefaults: () => {},
+      '@serverless/config/utils': {
         getLoggedInUser: () => ({
           accessKeys: {
             tenant: '12345',
           },
           idToken: 'ID',
         }),
+      },
+      '@serverless/platform-sdk': {
+        configureFetchDefaults: () => {},
         getAccessKeyForTenant: () => '123456',
         archiveService: async () => {},
         getMetadata: async () => ({ supportedRegions: ['region'] }),

--- a/lib/providersIntegration.test.js
+++ b/lib/providersIntegration.test.js
@@ -5,14 +5,12 @@ const runServerless = require('../test/run-serverless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
 const platformClientPath = require.resolve('@serverless/platform-client');
+const configUtilsPath = require.resolve('@serverless/utils/config');
 
 const modulesCacheStub = {
   [platformSdkPath]: {
     configureFetchDefaults: () => {},
     getAccessKeyForTenant: () => 'access-key',
-    getLoggedInUser: () => ({
-      username: 'foo',
-    }),
     getDeployProfile: () => {
       throw new Error('No application');
     },
@@ -20,6 +18,11 @@ const modulesCacheStub = {
       supportedRegions: ['us-east-1'],
     }),
     getApp: () => ({}),
+  },
+  [configUtilsPath]: {
+    getLoggedInUser: () => ({
+      username: 'foo',
+    }),
   },
   [platformClientPath]: {
     ServerlessSDK: class ServerlessSDK {
@@ -53,14 +56,7 @@ describe('deployProfile', function () {
     const { serverless } = await runServerless({
       fixture: 'aws-monitored-service',
       cliArgs: ['print'],
-      modulesCacheStub: {
-        [platformSdkPath]: {
-          ...modulesCacheStub[platformSdkPath],
-        },
-        [platformClientPath]: {
-          ...modulesCacheStub[platformClientPath],
-        },
-      },
+      modulesCacheStub,
     });
     expect(serverless.providers.aws.cachedCredentials).to.deep.equal({
       accessKeyId: 'aaron stuyvenberg access key',

--- a/lib/studio.test.js
+++ b/lib/studio.test.js
@@ -3,10 +3,14 @@
 const runServerless = require('../test/run-serverless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
+const configUtilsPath = require.resolve('@serverless/utils/config');
+
 const modulesCacheStub = {
   [platformSdkPath]: {
     configureFetchDefaults: () => {},
     getAccessKeyForTenant: () => 'access-key',
+  },
+  [configUtilsPath]: {
     getLoggedInUser: () => ({}),
   },
 };
@@ -26,8 +30,8 @@ describe('studio', function () {
         fixture: 'aws-monitored-service',
         cliArgs: ['studio'],
         modulesCacheStub: {
-          [platformSdkPath]: {
-            ...modulesCacheStub[platformSdkPath],
+          ...modulesCacheStub,
+          [configUtilsPath]: {
             getLoggedInUser: () => null,
           },
         },

--- a/lib/test/index.test.js
+++ b/lib/test/index.test.js
@@ -8,7 +8,6 @@ const modulesCacheStub = {
   [require.resolve('@serverless/platform-sdk')]: {
     configureFetchDefaults: () => {},
     getAccessKeyForTenant: () => 'access-key',
-    getLoggedInUser: () => ({}),
     getDeployProfile: () => ({}),
     getMetadata: async () => ({
       awsAccountId: '377024778620',
@@ -25,6 +24,9 @@ const modulesCacheStub = {
         'ap-southeast-2',
       ],
     }),
+  },
+  [require.resolve('@serverless/utils/config')]: {
+    getLoggedInUser: () => ({}),
   },
   [require.resolve('@serverless/platform-client')]: {
     ServerlessSDK: class ServerlessSDK {

--- a/lib/variables.test.js
+++ b/lib/variables.test.js
@@ -34,12 +34,15 @@ describe('variables', () => {
         require.resolve('./isAuthenticated'),
         require.resolve('@serverless/platform-sdk'),
         require.resolve('@serverless/platform-client'),
+        require.resolve('@serverless/utils/config'),
       ],
       () => {
         Object.assign(require('@serverless/platform-sdk'), {
           getAccessKeyForTenant: async () => 'accessKey',
           getStateVariable,
           getDeployProfile,
+        });
+        Object.assign(require('@serverless/utils/config'), {
           getLoggedInUser: () => true,
         });
         Object.assign(require('@serverless/platform-client'), {

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -9,12 +9,15 @@ const runServerless = require('../test/run-serverless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
 const platformClientPath = require.resolve('@serverless/platform-client');
+const configUtilsPath = require.resolve('@serverless/utils/config');
 
 const modulesCacheStub = {
   [platformSdkPath]: {
     configureFetchDefaults: () => {},
     getAccessKeyForTenant: () => 'access-key',
     getDeployProfile: async () => ({}),
+  },
+  [configUtilsPath]: {
     getLoggedInUser: () => ({}),
   },
   [platformClientPath]: {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@serverless/event-mocks": "^1.1.1",
     "@serverless/platform-client": "^3.1.5",
     "@serverless/platform-sdk": "^2.3.2",
+    "@serverless/utils": "^3.1.0",
     "chalk": "^4.1.0",
     "child-process-ext": "^2.1.1",
     "chokidar": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "serverless/enterprise-plugin",
   "dependencies": {
     "@serverless/event-mocks": "^1.1.1",
-    "@serverless/platform-client": "^3.1.5",
+    "@serverless/platform-client": "^3.9.1",
     "@serverless/platform-sdk": "^2.3.2",
     "@serverless/utils": "^3.1.0",
     "chalk": "^4.1.0",


### PR DESCRIPTION
This PR introduces the following changes:
- Introduce `@serverless/utils` as a dependency
- Bump `@serverless/platform-client` to latest version
- Remove use of `login` from `platform-sdk` and replace it with `login` functionality already implemented in plugin
- Replace `getLoggedInUser`, `readConfigFile`, `writeConfigFile`, `refreshToken` and `logout` from `platform-sdk` with `utils` equivalents

All of the above was tested with current testing suite + I've made a lot of "sanity" testing by hand locally. 

Part of: https://github.com/serverless/enterprise-plugin/issues/464

