### PR TITLE
Remove deprecated usage of `git.silent`

### DIFF
--- a/lib/deployment/parse.js
+++ b/lib/deployment/parse.js
@@ -13,7 +13,6 @@ const simpleGit = require('simple-git');
 const { version: packageJsonVersion } = require('../../package');
 
 const git = simpleGit();
-git.silent(true);
 
 /*
  * Parse Deployment Data


### PR DESCRIPTION
With 2.7.0, simple-git introduced logging configuration via `DEBUG`: https://github.com/steveukx/git-js/blob/91d6bfdb8c115c2511b55c0bccb3854d0e7775e7/CHANGELOG.md#270---output-handler-and-logging
With one of recent releases, deprecation was introduced for use of `git.silent`: https://github.com/steveukx/git-js/blob/91d6bfdb8c115c2511b55c0bccb3854d0e7775e7/CHANGELOG.md#2320-per-command-configuration
According to the above, logs have to be explicitly turned on via `DEBUG` and `git.silent` is not needed. 

This aims to address the issue with reporting deprecation within framework: https://github.com/serverless/serverless/issues/8912