### PR TITLE
Feature: Support --use-local-credentials flag to skip provider resolu…

### DIFF
--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -3,6 +3,7 @@
 const { getAccessKeyForTenant, getDeployProfile } = require('@serverless/platform-sdk');
 const { ServerlessSDK } = require('@serverless/platform-client');
 const { serviceSlug, instanceSlug } = require('./utils');
+const { getDashboardUrl } = require('./dashboard');
 
 module.exports.configureDeployProfile = async (ctx) => {
   const accessKey = await getAccessKeyForTenant(ctx.sls.service.org);
@@ -85,12 +86,16 @@ module.exports.configureDeployProfile = async (ctx) => {
         ctx.sls.cli.log('ignoring provider credentials error');
       }
     }
+    const providersConfigUrl = `${getDashboardUrl(ctx)}/providers`;
 
     if (providerCredentials.result) {
       const awsCredentials = providerCredentials.result.find(
         (result) => result.providerName === 'aws'
       );
       if (awsCredentials) {
+        ctx.sls.cli.log(
+          `Using provider credentials, configured via dashboard: ${providersConfigUrl}`
+        );
         ctx.provider.cachedCredentials = {
           accessKeyId: awsCredentials.providerDetails.accessKeyId,
           secretAccessKey: awsCredentials.providerDetails.secretAccessKey,
@@ -98,6 +103,10 @@ module.exports.configureDeployProfile = async (ctx) => {
         };
         ctx.provider.cachedCredentials.region = ctx.provider.getRegion();
       }
+    } else {
+      ctx.sls.cli.log(
+        `Using local credentials. Add provider credentials via dashboard: ${providersConfigUrl}`
+      );
     }
   }
 };

--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -15,6 +15,12 @@ module.exports.configureDeployProfile = async (ctx) => {
     },
   } = ctx;
 
+  if (cliOptions['use-local-credentials']) {
+    if (process.env.SLS_DEBUG) {
+      ctx.sls.cli.log('Skipping provider resolution, use-local-credentials option present');
+    }
+    return;
+  }
   const stage = cliOptions.stage || provider.getStage();
   const region = cliOptions.region || provider.getRegion();
   const parameterizedArgs = [];
@@ -47,8 +53,7 @@ module.exports.configureDeployProfile = async (ctx) => {
     });
   } catch (e) {
     if (process.env.SLS_DEBUG) {
-      // eslint-disable-next-line no-console
-      console.log('ignoring profile fetch error', e);
+      ctx.sls.cli.log('ignoring profile fetch error', e);
     }
   }
   if (deploymentProfile && deploymentProfile.providerCredentials) {
@@ -77,8 +82,7 @@ module.exports.configureDeployProfile = async (ctx) => {
       // The platform-client sdk will throw an error for a 404
       // Log it if we're in debug mode
       if (process.env.SLS_DEBUG) {
-        // eslint-disable-next-line no-console
-        console.log('ignoring provider credentials error');
+        ctx.sls.cli.log('ignoring provider credentials error');
       }
     }
 

--- a/lib/deployProfile.test.js
+++ b/lib/deployProfile.test.js
@@ -25,6 +25,10 @@ describe('configureDeployProfile', () => {
     const ctx = {
       provider: { getStage, getRegion },
       sls: {
+        cli: {
+          // eslint-disable-next-line no-console
+          log: (msg) => console.log(msg),
+        },
         service: {
           app: 'app',
           org: 'org',

--- a/lib/providersIntegration.test.js
+++ b/lib/providersIntegration.test.js
@@ -65,4 +65,12 @@ describe('deployProfile', function () {
       region: 'us-east-1',
     });
   });
+  it('Should use local credentials with flag', async () => {
+    const { serverless } = await runServerless({
+      fixture: 'aws-monitored-service',
+      cliArgs: ['print', '--use-local-credentials'],
+      modulesCacheStub,
+    });
+    expect(serverless.providers.aws.cachedCredentials).to.be.null;
+  });
 });


### PR DESCRIPTION
`--use-local-credentials` will now skip specifically fetching providerCredentials. This is to support the `default` provider level set at the org level, which will effectively override all local credentials if configured.

Also, a quick refactor to use the Framework logger, now that `ctx` is passed to `deployProfile.js`