### PR TITLE
Upgrade up to recent Framework changes

### DIFF
--- a/lib/deployment/getServerlessFilePath.js
+++ b/lib/deployment/getServerlessFilePath.js
@@ -1,3 +1,5 @@
+// TODO: Remove this util with next major release
+
 'use strict';
 
 const path = require('path');

--- a/lib/deployment/index.js
+++ b/lib/deployment/index.js
@@ -3,6 +3,5 @@
 module.exports = {
   parseDeploymentData: require('./parse'),
   saveDeployment: require('./save'),
-  getServerlessFilePath: require('./getServerlessFilePath'),
   createAndSetDeploymentUid: require('./createAndSetUid'),
 };

--- a/lib/deployment/parse.js
+++ b/lib/deployment/parse.js
@@ -24,10 +24,13 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
   const deployment = new SDK.Deployment();
 
   const accountId = await ctx.provider.getAccountId();
-  const serverlessFileName = await getServerlessFilePath(
-    ctx.sls.processedInput.options.config,
-    ctx.sls.config.servicePath
-  );
+  // TODO: With next major release remove getServerlessFilePath fallback
+  const serverlessFileName =
+    ctx.sls.configurationPath ||
+    (await getServerlessFilePath(
+      ctx.sls.processedInput.options.config,
+      ctx.sls.config.servicePath
+    ));
   const serverlessFile = (await fs.readFile(serverlessFileName)).toString();
   /*
    * Add deployment data...

--- a/lib/deployment/parse.test.js
+++ b/lib/deployment/parse.test.js
@@ -1551,6 +1551,7 @@ describe('parseDeploymentData #2', () => {
         },
       },
       [require.resolve('@serverless/utils/config')]: {
+        ...require('@serverless/utils/config'),
         getLoggedInUser: () => ({}),
       },
       [require.resolve('simple-git/promise')]: () => ({

--- a/lib/interactiveCli/writeOrgAndApp.js
+++ b/lib/interactiveCli/writeOrgAndApp.js
@@ -10,10 +10,13 @@ const appPattern = /^(?:#\s*)?app\s*:.+/m;
 const orgPattern = /^(?:#\s*)?(?:tenant|org)\s*:.+/m;
 
 module.exports = async (serverless, orgName, appName) => {
-  const serverlessFileName = await getServerlessFilePath(
-    serverless.processedInput.options.config,
-    serverless.config.servicePath
-  );
+  // TODO: With next major release remove getServerlessFilePath fallback
+  const serverlessFileName =
+    serverless.configurationPath ||
+    (await getServerlessFilePath(
+      serverless.processedInput.options.config,
+      serverless.config.servicePath
+    ));
 
   let ymlString = await (async () => {
     if (!yamlExtensions.has(path.extname(serverlessFileName))) return null; // Non YAML config

--- a/lib/outputCommand.test.js
+++ b/lib/outputCommand.test.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai');
 const sinon = require('sinon');
+const configUtils = require('@serverless/utils/config');
 const runServerless = require('../test/run-serverless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
@@ -15,6 +16,7 @@ const modulesCacheStub = {
     getDeployProfile: () => ({}),
   },
   [configUtilsPath]: {
+    ...configUtils,
     getLoggedInUser: () => ({}),
   },
   [platformClientPath]: {
@@ -79,6 +81,7 @@ describe('outputCommand', function () {
           modulesCacheStub: {
             ...modulesCacheStub,
             [configUtilsPath]: {
+              ...configUtils,
               getLoggedInUser: () => null,
             },
           },
@@ -261,6 +264,7 @@ describe('outputCommand', function () {
           modulesCacheStub: {
             ...modulesCacheStub,
             [configUtilsPath]: {
+              ...configUtils,
               getLoggedInUser: () => null,
             },
           },

--- a/lib/paramCommand.test.js
+++ b/lib/paramCommand.test.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai');
 const sinon = require('sinon');
+const configUtils = require('@serverless/utils/config');
 const runServerless = require('../test/run-serverless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
@@ -14,6 +15,7 @@ const modulesCacheStub = {
     getAccessKeyForTenant: () => 'access-key',
   },
   [configUtilsPath]: {
+    ...configUtils,
     getLoggedInUser: () => ({}),
   },
   [platformClientPath]: {
@@ -59,6 +61,7 @@ describe('paramCommand', function () {
           modulesCacheStub: {
             ...modulesCacheStub,
             [configUtilsPath]: {
+              ...configUtils,
               getLoggedInUser: () => null,
             },
           },
@@ -210,6 +213,7 @@ describe('paramCommand', function () {
           modulesCacheStub: {
             ...modulesCacheStub,
             [configUtilsPath]: {
+              ...configUtils,
               getLoggedInUser: () => null,
             },
           },

--- a/lib/providersIntegration.test.js
+++ b/lib/providersIntegration.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
+const configUtils = require('@serverless/utils/config');
 const runServerless = require('../test/run-serverless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
@@ -20,6 +21,7 @@ const modulesCacheStub = {
     getApp: () => ({}),
   },
   [configUtilsPath]: {
+    ...configUtils,
     getLoggedInUser: () => ({
       username: 'foo',
     }),

--- a/lib/studio.test.js
+++ b/lib/studio.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const configUtils = require('@serverless/utils/config');
 const runServerless = require('../test/run-serverless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
@@ -11,6 +12,7 @@ const modulesCacheStub = {
     getAccessKeyForTenant: () => 'access-key',
   },
   [configUtilsPath]: {
+    ...configUtils,
     getLoggedInUser: () => ({}),
   },
 };
@@ -32,6 +34,7 @@ describe('studio', function () {
         modulesCacheStub: {
           ...modulesCacheStub,
           [configUtilsPath]: {
+            ...configUtils,
             getLoggedInUser: () => null,
           },
         },

--- a/lib/test/index.test.js
+++ b/lib/test/index.test.js
@@ -26,6 +26,7 @@ const modulesCacheStub = {
     }),
   },
   [require.resolve('@serverless/utils/config')]: {
+    ...require('@serverless/utils/config'),
     getLoggedInUser: () => ({}),
   },
   [require.resolve('@serverless/platform-client')]: {

--- a/lib/wrap.test.js
+++ b/lib/wrap.test.js
@@ -5,6 +5,7 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const chalk = require('chalk');
 const path = require('path');
+const configUtils = require('@serverless/utils/config');
 const runServerless = require('../test/run-serverless');
 
 const platformSdkPath = require.resolve('@serverless/platform-sdk');
@@ -18,6 +19,7 @@ const modulesCacheStub = {
     getDeployProfile: async () => ({}),
   },
   [configUtilsPath]: {
+    ...configUtils,
     getLoggedInUser: () => ({}),
   },
   [platformClientPath]: {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@serverless/eslint-config": "^3.0.0",
-    "@serverless/test": "^7.7.0",
+    "@serverless/test": "^7.8.0",
     "aws-sdk": "^2.840.0",
     "chai": "^4.3.0",
     "eslint": "^7.19.0",


### PR DESCRIPTION
- Ensure to rely on already resolved on Framework side configuration path
- Fix tests, so they're reliable if `@serverless/utils` is shared among `serverless` and `@serverless/enterprise-plugin` packages (this got broken with #536)
-  Ensure to rely on latest `@serverless/test` which ensures that internal caching of CLI args resolution, has no side effects on tests