### PR TITLE
Fix wrapper tests

### DIFF
--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -5,6 +5,7 @@ process.env.SERVERLESS_PLATFORM_STAGE = 'dev';
 const { expect } = require('chai');
 const setup = require('./setup');
 const zlib = require('zlib');
+const wait = require('timers-ext/promise/sleep');
 const { getAccessKeyForTenant, getDeployProfile } = require('@serverless/platform-sdk');
 const awsRequest = require('@serverless/test/aws-request');
 const log = require('log').get('test');
@@ -15,29 +16,60 @@ let serviceName;
 const org = process.env.SERVERLESS_PLATFORM_TEST_ORG || 'integration';
 const app = process.env.SERVERLESS_PLATFORM_TEST_APP || 'integration';
 
-const resolveLog = (encodedLogMsg) => {
-  const logMsg = String(Buffer.from(encodedLogMsg, 'base64'));
-  log.debug('log buffer %s', logMsg);
-  return logMsg;
-};
-
-const resolveAndValidateLog = (encodedLogMsg) => {
-  const logMsg = resolveLog(encodedLogMsg);
-  expect(logMsg).to.match(/SERVERLESS_ENTERPRISE/);
-  const logLine = logMsg.split('\n').find((line) => line.includes('SERVERLESS_ENTERPRISE'));
-  const payloadString = logLine.split('SERVERLESS_ENTERPRISE')[1].split('END RequestId')[0];
-  const result = JSON.parse(payloadString);
-  if (result.b) {
-    const zipped = Buffer.from(result.b, 'base64');
-    const unzipped = JSON.parse(zlib.gunzipSync(zipped));
-    log.debug('unzipped %o', unzipped);
-    return unzipped;
-  }
-  return result;
-};
-
 const setupTests = (mode, env = {}) => {
   let lambdaService;
+  let cloudwatchLogsService;
+
+  const resolveFunctionInvocationLogs = async (functionName, requestId) => {
+    const logs = (
+      await awsRequest(cloudwatchLogsService, 'filterLogEvents', {
+        logGroupName: `/aws/lambda/${functionName}`,
+      })
+    ).events
+      .map(({ message }) => message)
+      .join('');
+    const invocationLastLog = `END RequestId: ${requestId}`;
+    if (!logs.includes(invocationLastLog)) {
+      await wait(1000);
+      return resolveFunctionInvocationLogs(functionName, requestId);
+    }
+
+    return logs.slice(
+      logs.indexOf(`START RequestId: ${requestId}`),
+      logs.indexOf(invocationLastLog) + invocationLastLog.length
+    );
+  };
+
+  const resolveLog = async (functionName, encodedLogMsg) => {
+    let invocationLogs = String(Buffer.from(encodedLogMsg, 'base64'));
+    if (!invocationLogs.includes('START RequestId:')) {
+      // Received incomplete logs
+      // ("Logtype: 'Tail' guarantees to return only the last 4 KB of the logs)
+      // In this case retrieve request logs form Cloudwatch log directly
+      log.debug('incomplete log buffer %s', invocationLogs);
+      invocationLogs = await resolveFunctionInvocationLogs(
+        functionName,
+        invocationLogs.match(/END RequestId: ([a-f0-9-]+)/)[1]
+      );
+    }
+    log.debug('log buffer %s', invocationLogs);
+    return invocationLogs;
+  };
+
+  const resolveAndValidateLog = async (functionName, encodedLogMsg) => {
+    const logMsg = await resolveLog(functionName, encodedLogMsg);
+    expect(logMsg).to.match(/SERVERLESS_ENTERPRISE/);
+    const logLine = logMsg.split('\n').find((line) => line.includes('SERVERLESS_ENTERPRISE'));
+    const payloadString = logLine.split('SERVERLESS_ENTERPRISE')[1].split('END RequestId')[0];
+    const result = JSON.parse(payloadString);
+    if (result.b) {
+      const zipped = Buffer.from(result.b, 'base64');
+      const unzipped = JSON.parse(zlib.gunzipSync(zipped));
+      log.debug('unzipped %o', unzipped);
+      return unzipped;
+    }
+    return result;
+  };
 
   describe(mode, () => {
     before(async () => {
@@ -57,6 +89,11 @@ const setupTests = (mode, env = {}) => {
         },
       };
 
+      cloudwatchLogsService = {
+        name: 'CloudWatchLogs',
+        params: lambdaService.params,
+      };
+
       ({ sls, teardown, serviceName } = await setup('wrapper-service'));
       await sls(['deploy'], { env });
     });
@@ -74,110 +111,122 @@ const setupTests = (mode, env = {}) => {
         // (it'll be great to figure out a more gentle form of communication)
         this.skip();
       }
+      const functionName = `${serviceName}-dev-unresolved`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-unresolved`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload)).to.equal(null);
     });
 
     it('gets right return value from wrapped syncError handler', async () => {
+      const functionName = `${serviceName}-dev-syncError`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-syncError`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload).errorMessage).to.equal('syncError');
     });
 
     it('gets right return value from wrapped async handler', async () => {
+      const functionName = `${serviceName}-dev-async`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-async`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload)).to.equal('asyncReturn');
     });
 
     it('gets right return value from wrapped asyncError handler', async () => {
+      const functionName = `${serviceName}-dev-asyncError`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-asyncError`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload).errorMessage).to.equal('asyncError');
     });
 
     it('gets right return value from wrapped asyncDanglingCallback handler', async () => {
+      const functionName = `${serviceName}-dev-asyncDanglingCallback`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-asyncDanglingCallback`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload)).to.equal('asyncDanglyReturn');
     });
 
     it('gets right return value from wrapped done handler', async () => {
+      const functionName = `${serviceName}-dev-done`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-done`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload)).to.equal('doneReturn');
     });
 
     it('gets right return value from wrapped doneError handler', async () => {
+      const functionName = `${serviceName}-dev-doneError`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-doneError`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload).errorMessage).to.equal('doneError');
     });
 
     it('gets right return value from wrapped callback handler', async () => {
+      const functionName = `${serviceName}-dev-callback`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-callback`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload)).to.equal('callbackReturn');
     });
 
     it('gets right return value from wrapped callback handler with dangling events but callbackWaitsForEmptyEventLoop=false', async () => {
+      const functionName = `${serviceName}-dev-noWaitForEmptyLoop`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-noWaitForEmptyLoop`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload)).to.equal('noWaitForEmptyLoop');
     });
 
     it('gets right return value from wrapped callbackError handler', async () => {
+      const functionName = `${serviceName}-dev-callbackError`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-callbackError`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload).errorMessage).to.equal('callbackError');
     });
 
     it('gets right return value from wrapped fail handler', async () => {
+      const functionName = `${serviceName}-dev-fail`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-fail`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload).errorMessage).to.equal('failError');
     });
 
     it('gets right return value from wrapped succeed handler', async () => {
+      const functionName = `${serviceName}-dev-succeed`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-succeed`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload)).to.equal('succeedReturn');
     });
 
@@ -191,129 +240,143 @@ const setupTests = (mode, env = {}) => {
         // (it'll be great to figure out a more gentle form of communication)
         this.skip();
       }
+      const functionName = `${serviceName}-dev-unresolved`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-unresolved`,
+        FunctionName: functionName,
       });
-      const logMsg = resolveLog(LogResult);
+      const logMsg = await resolveLog(functionName, LogResult);
       expect(logMsg).to.not.match(/SERVERLESS_ENTERPRISE/);
     });
 
     it('gets SFE log msg from wrapped syncError handler', async () => {
+      const functionName = `${serviceName}-dev-syncError`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-syncError`,
+        FunctionName: functionName,
       });
-      const logResult = resolveAndValidateLog(LogResult);
+      const logResult = await resolveAndValidateLog(functionName, LogResult);
       expect(JSON.stringify(logResult)).to.match(/"errorId":"Error!\$syncError"/);
     });
 
     it('gets SFE log msg from wrapped async handler', async () => {
+      const functionName = `${serviceName}-dev-async`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-async`,
+        FunctionName: functionName,
       });
-      const logResult = resolveAndValidateLog(LogResult);
+      const logResult = await resolveAndValidateLog(functionName, LogResult);
       expect(JSON.stringify(logResult)).to.match(/"errorId":null/);
     });
 
     it('gets SFE log msg from wrapped asyncError handler', async () => {
+      const functionName = `${serviceName}-dev-asyncError`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-asyncError`,
+        FunctionName: functionName,
       });
-      const logResult = resolveAndValidateLog(LogResult);
+      const logResult = await resolveAndValidateLog(functionName, LogResult);
       expect(JSON.stringify(logResult)).to.match(/"errorId":"Error!\$asyncError"/);
     });
 
     it('gets SFE log msg from wrapped asyncDanglingCallback handler', async () => {
+      const functionName = `${serviceName}-dev-asyncDanglingCallback`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-asyncDanglingCallback`,
+        FunctionName: functionName,
       });
-      const logResult = resolveAndValidateLog(LogResult);
+      const logResult = await resolveAndValidateLog(functionName, LogResult);
       expect(JSON.stringify(logResult)).to.match(/"errorId":null/);
     });
 
     it('gets SFE log msg from wrapped done handler', async () => {
+      const functionName = `${serviceName}-dev-done`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-done`,
+        FunctionName: functionName,
       });
-      const logResult = resolveAndValidateLog(LogResult);
+      const logResult = await resolveAndValidateLog(functionName, LogResult);
       expect(JSON.stringify(logResult)).to.match(/"errorId":null/);
     });
 
     it('gets SFE log msg from wrapped doneError handler', async () => {
+      const functionName = `${serviceName}-dev-doneError`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-doneError`,
+        FunctionName: functionName,
       });
-      const logResult = resolveAndValidateLog(LogResult);
+      const logResult = await resolveAndValidateLog(functionName, LogResult);
       expect(JSON.stringify(logResult)).to.match(/"errorId":"NotAnErrorType!\$doneError"/);
     });
 
     it('gets SFE log msg from wrapped callback handler', async () => {
+      const functionName = `${serviceName}-dev-callback`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-callback`,
+        FunctionName: functionName,
       });
-      const logResult = resolveAndValidateLog(LogResult);
+      const logResult = await resolveAndValidateLog(functionName, LogResult);
       expect(JSON.stringify(logResult)).to.match(/"errorId":null/);
     });
 
     it('gets SFE log msg from wrapped callbackError handler', async () => {
+      const functionName = `${serviceName}-dev-callbackError`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-callbackError`,
+        FunctionName: functionName,
       });
-      const logResult = resolveAndValidateLog(LogResult);
+      const logResult = await resolveAndValidateLog(functionName, LogResult);
       expect(JSON.stringify(logResult)).to.match(/"errorId":"NotAnErrorType!\$callbackError"/);
     });
 
     it('gets SFE log msg from wrapped fail handler', async () => {
+      const functionName = `${serviceName}-dev-fail`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-fail`,
+        FunctionName: functionName,
       });
-      const logResult = resolveAndValidateLog(LogResult);
+      const logResult = await resolveAndValidateLog(functionName, LogResult);
       expect(JSON.stringify(logResult)).to.match(/"errorId":"NotAnErrorType!\$failError"/);
     });
 
     it('gets SFE log msg from wrapped succeed handler', async () => {
+      const functionName = `${serviceName}-dev-succeed`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-succeed`,
+        FunctionName: functionName,
       });
-      const logResult = resolveAndValidateLog(LogResult);
+      const logResult = await resolveAndValidateLog(functionName, LogResult);
       expect(JSON.stringify(logResult)).to.match(/"errorId":null/);
     });
 
     it('gets right duration value from wrapped callback handler', async () => {
+      const functionName = `${serviceName}-dev-callback`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-callback`,
+        FunctionName: functionName,
       });
-      const logResult = resolveAndValidateLog(LogResult);
+      const logResult = await resolveAndValidateLog(functionName, LogResult);
       const duration = parseFloat(JSON.stringify(logResult).match(/"duration":(\d+\.\d+)/)[1]);
       expect(duration).to.be.above(5);
     });
 
     it('gets the callback return value when a promise func calls callback', async () => {
+      const functionName = `${serviceName}-dev-promise-and-callback-race`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-promise-and-callback-race`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload)).to.equal('callbackEarlyReturn');
     });
 
     it('gets spans', async () => {
+      const functionName = `${serviceName}-dev-spans`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-spans`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
       expect(payload.payload.spans.length).to.equal(5);
       // first custom span (create sts client)
@@ -365,11 +428,12 @@ const setupTests = (mode, env = {}) => {
     });
 
     it('gets spans in node 10', async () => {
+      const functionName = `${serviceName}-dev-spans10`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-spans10`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
       expect(payload.payload.spans.length).to.equal(5);
       // first custom span (create sts client)
@@ -421,56 +485,62 @@ const setupTests = (mode, env = {}) => {
     });
 
     it('gets SFE log msg from wrapped node timeout handler', async () => {
+      const functionName = `${serviceName}-dev-timeout`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-timeout`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('report');
     });
 
     it('gets SFE log msg from wrapped node timeout handler with callbackWaitsForEmptyEventLoop true', async () => {
+      const functionName = `${serviceName}-dev-waitForEmptyLoop`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-waitForEmptyLoop`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('report');
     });
 
     it('gets the current transaction id in wrapped node handler', async () => {
+      const functionName = `${serviceName}-dev-getTransactionId`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-getTransactionId`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
     });
 
     it('gets dashboard url for current transaction in wrapped node handler', async () => {
+      const functionName = `${serviceName}-dev-getDashboardUrl`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-getDashboardUrl`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
     });
 
     it('gets the return value when calling python', async () => {
+      const functionName = `${serviceName}-dev-pythonSuccess`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonSuccess`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload)).to.equal('success');
     });
 
     it('gets SFE log msg from wrapped python handler', async () => {
+      const functionName = `${serviceName}-dev-pythonSuccess`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonSuccess`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
       expect(payload.payload.spans.length).to.equal(3);
       expect(new Set(Object.keys(payload.payload.spans[0]))).to.deep.equal(
@@ -500,11 +570,12 @@ const setupTests = (mode, env = {}) => {
     });
 
     it('gets http connection errors from python', async () => {
+      const functionName = `${serviceName}-dev-pythonHttpError`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonHttpError`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
       expect(payload.payload.spans.length).to.equal(1);
       expect(payload.payload.spans[0].tags).to.deep.equal({
@@ -517,20 +588,22 @@ const setupTests = (mode, env = {}) => {
     });
 
     it('gets the return value when calling python2', async () => {
+      const functionName = `${serviceName}-dev-pythonSuccess2`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonSuccess2`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       expect(JSON.parse(Payload)).to.equal('success');
     });
 
     it('gets SFE log msg from wrapped python2 handler', async () => {
+      const functionName = `${serviceName}-dev-pythonSuccess2`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonSuccess2`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
       expect(payload.payload.spans.length).to.equal(3);
       expect(new Set(Object.keys(payload.payload.spans[0]))).to.deep.equal(
@@ -560,11 +633,12 @@ const setupTests = (mode, env = {}) => {
     });
 
     it('gets the error value when calling python error', async () => {
+      const functionName = `${serviceName}-dev-pythonError`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonError`,
+        FunctionName: functionName,
       });
-      resolveLog(LogResult); // Expose debug logs
+      await resolveLog(functionName, LogResult); // Expose debug logs
       const payload = JSON.parse(Payload);
       expect(payload.stackTrace[0]).to.match(
         / *File "\/var\/task\/serverless_sdk\/__init__.py", line \d+, in wrapped_handler\n *return user_handler\(event, context\)\n/
@@ -580,20 +654,22 @@ const setupTests = (mode, env = {}) => {
     });
 
     it('gets SFE log msg from wrapped python error handler', async () => {
+      const functionName = `${serviceName}-dev-pythonError`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonError`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('error');
     });
 
     it('gets node eventTags', async () => {
+      const functionName = `${serviceName}-dev-eventTags`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-eventTags`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
       expect(payload.payload.eventTags.length).to.equal(1);
       expect(payload.payload.eventTags[0]).to.deep.equal({
@@ -604,11 +680,12 @@ const setupTests = (mode, env = {}) => {
     });
 
     it('gets python eventTags', async () => {
+      const functionName = `${serviceName}-dev-pythonEventTags`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonEventTags`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
       expect(payload.payload.eventTags.length).to.equal(1);
       expect(payload.payload.eventTags[0]).to.deep.equal({
@@ -619,22 +696,24 @@ const setupTests = (mode, env = {}) => {
     });
 
     it('sets node endpoint', async () => {
+      const functionName = `${serviceName}-dev-setEndpoint`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-setEndpoint`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
       expect(payload.payload.tags.endpoint).to.equal('/test/:param1');
       expect(payload.payload.tags.endpointMechanism).to.equal('explicit');
     });
 
     it('sets node endpoint along with http metadata', async () => {
+      const functionName = `${serviceName}-dev-setEndpointWithHttpMetadata`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-setEndpointWithHttpMetadata`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
       expect(payload.payload.tags.endpoint).to.equal('/test/:param2');
       expect(payload.payload.tags.httpMethod).to.equal('POST');
@@ -643,11 +722,12 @@ const setupTests = (mode, env = {}) => {
     });
 
     it('sets python endpoint', async () => {
+      const functionName = `${serviceName}-dev-pythonSetEndpoint`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonSetEndpoint`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
       expect(payload.payload.tags.endpoint).to.equal('/test/:param');
       expect(payload.payload.tags.httpMethod).to.equal('PATCH');
@@ -656,39 +736,43 @@ const setupTests = (mode, env = {}) => {
     });
 
     it('gets SFE log msg from wrapped python timeout handler', async () => {
+      const functionName = `${serviceName}-dev-pythonTimeout`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonTimeout`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('report');
     });
 
     it('supports handler nested in a python submodule', async () => {
+      const functionName = `${serviceName}-dev-pythonSubModule`;
       const { Payload, LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonSubModule`,
+        FunctionName: functionName,
       });
-      const result = resolveAndValidateLog(LogResult);
+      const result = await resolveAndValidateLog(functionName, LogResult);
       expect(result.type).to.equal('transaction');
       expect(JSON.parse(Payload)).to.equal('success');
     });
 
     it('gets the current transaction id in wrapped python handler', async () => {
+      const functionName = `${serviceName}-dev-pythonTransactionId`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonTransactionId`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
     });
 
     it('gets dashboard url for current transaction in wrapped python handler', async () => {
+      const functionName = `${serviceName}-dev-pythonDashboardUrl`;
       const { LogResult } = await awsRequest(lambdaService, 'invoke', {
         LogType: 'Tail',
-        FunctionName: `${serviceName}-dev-pythonDashboardUrl`,
+        FunctionName: functionName,
       });
-      const payload = resolveAndValidateLog(LogResult);
+      const payload = await resolveAndValidateLog(functionName, LogResult);
       expect(payload.type).to.equal('transaction');
     });
   });

--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -61,7 +61,13 @@ const setupTests = (mode, env = {}) => {
     expect(logMsg).to.match(/SERVERLESS_ENTERPRISE/);
     const logLine = logMsg.split('\n').find((line) => line.includes('SERVERLESS_ENTERPRISE'));
     const payloadString = logLine.split('SERVERLESS_ENTERPRISE')[1].split('END RequestId')[0];
-    const result = JSON.parse(payloadString);
+    const result = (() => {
+      try {
+        return JSON.parse(payloadString);
+      } catch (error) {
+        throw new Error(`Resolved log payloed is not a valid JSON: ${payloadString}`);
+      }
+    })();
     if (result.b) {
       const zipped = Buffer.from(result.b, 'base64');
       const unzipped = JSON.parse(zlib.gunzipSync(zipped));

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "proxyquire": "^2.1.3",
     "sinon": "^9.2.4",
     "strip-ansi": "^6.0.0",
-    "tar": "^6.1.0"
+    "tar": "^6.1.0",
+    "timers-ext": "^0.1.7"
   },
   "eslintConfig": {
     "extends": "@serverless/eslint-config/node",

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -468,6 +468,7 @@ class ServerlessSDK {
           result = fn(event, contextProxy, (err, res) => finalize(err, () => callback(err, res)));
         } catch (error) {
           finalize(error, () => context.fail(error));
+          return null;
         }
 
         // If promise was returned, handle it


### PR DESCRIPTION
Addresses one of the issues observed in CI fail: https://github.com/serverless/enterprise-plugin/runs/1969384787

In tests we confirm on invocation logs, still per AWS documenation `LogType: 'Tail'` may return only the last 4 KB of log output, and that's not configuration. Due to that in some scenarios incomplete logs are received and we observe fail as e.g.  `SERVERLESS_ENTERPRISE` is not found in tests.

This patch addresses that specific issue.

Additionally it patches doubled result processing in SDK (still afaik it doesn't influence anything, as second handling in all cases was discarded)