### PR TITLE
Tests: Ensure tests work with linked `serverless`

### DIFF
--- a/lib/interactiveCli/set-app.test.js
+++ b/lib/interactiveCli/set-app.test.js
@@ -53,6 +53,7 @@ describe('interactiveCli: set-app', function () {
           idToken: '123',
           accessKeys: { testinteractivecli: 'accesskey', otherorg: 'accesskey' },
         }),
+        getConfig: () => ({}),
       },
       [platformClientPath]: {
         ServerlessSDK: class ServerlessSDK {
@@ -157,6 +158,7 @@ describe('interactiveCli: set-app', function () {
         ...modulesCacheStub,
         [configUtilsPath]: {
           getLoggedInUser: () => null,
+          getConfig: () => ({}),
         },
       },
     });


### PR DESCRIPTION
Recent changes, broken tests if they're run with linked serverless instance (configured e.g. via `LOCAL_SERVERLESS_LINK_PATH=../../serverless`)

This patch fixes that