### PR TITLE
Fix error handling in `sls test` command

### DIFF
--- a/lib/test/index.js
+++ b/lib/test/index.js
@@ -9,10 +9,10 @@ const runTest = require('./runTest');
 
 module.exports.test = async (ctx) => {
   if (!ctx.sls.enterpriseEnabled) {
-    throw new this.sls.classes.Error('Run "serverless" to configure your service for testing.');
+    throw new ctx.sls.classes.Error('Run "serverless" to configure your service for testing.');
   }
   if (!fse.exists('serverless.test.yml')) {
-    throw new this.sls.classes.Error('No serverless.test.yml file found');
+    throw new ctx.sls.classes.Error('No serverless.test.yml file found');
   }
   let tests = yaml.safeLoad(await fse.readFile('serverless.test.yml'));
 


### PR DESCRIPTION
Fixes invalid references to serverless instance

_No tests, as this command is scheduled to be deprecated, so there's no point into investing too much effort here_