### PR TITLE
Use `user_uid` as `userId` during `login` and `register` 

### DIFF
--- a/lib/interactiveCli/register.js
+++ b/lib/interactiveCli/register.js
@@ -160,16 +160,16 @@ const steps = {
       await login(ctx);
       return;
     }
-    const { ownerUserName, orgName, ownerAccessKey, ownerAuth0Id } = await signUp(inquirer);
+    const { ownerUserName, orgName, ownerAccessKey, ownerUserUid } = await signUp(inquirer);
     validadateRegistrationResponseValue('ownerUserName', ownerUserName);
     validadateRegistrationResponseValue('tenantName', orgName);
     validadateRegistrationResponseValue('ownerAccessKey', ownerAccessKey);
-    validadateRegistrationResponseValue('ownerAuth0Id', ownerAuth0Id);
+    validadateRegistrationResponseValue('ownerUserUid', ownerUserUid);
     configUtils.set({
-      userId: ownerAuth0Id,
+      userId: ownerUserUid,
       users: {
-        [ownerAuth0Id]: {
-          userId: ownerAuth0Id,
+        [ownerUserUid]: {
+          userId: ownerUserUid,
           userName: ownerUserName,
           enterprise: {
             timeLastLogin: Math.round(Date.now() / 1000),

--- a/lib/interactiveCli/register.test.js
+++ b/lib/interactiveCli/register.test.js
@@ -52,6 +52,7 @@ const platformClientStub = {
           tenantName: orgName,
           ownerAccessKey: 'REGISTERTESTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
           ownerAuth0Id: username,
+          ownerUserUid: 'USERUID',
         }),
       };
     }
@@ -218,7 +219,7 @@ describe('interactiveCli: register', function () {
     });
 
     it('Should login', async () => {
-      expect(registeredUser.userId).to.equal('testregisterinteractivecli');
+      expect(registeredUser.userId).to.equal('USERUID');
     });
 
     it('Should setup monitoring', async () => {

--- a/lib/login.js
+++ b/lib/login.js
@@ -15,11 +15,14 @@ module.exports = async function (ctx) {
 
   const loginData = await loginDataDeferred;
 
+  // In `.serverlessrc`, we want to use `user_uid` as `userId` if possible
+  const userId = loginData.user_uid || loginData.id;
+
   const loginDataToSaveInConfig = {
-    userId: loginData.id,
+    userId,
     users: {
-      [loginData.id]: {
-        userId: loginData.id,
+      [userId]: {
+        userId,
         name: loginData.name,
         email: loginData.email,
         username: loginData.username,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "serverless/enterprise-plugin",
   "dependencies": {
     "@serverless/event-mocks": "^1.1.1",
-    "@serverless/platform-client": "^4.2.0",
+    "@serverless/platform-client": "^4.2.1",
     "@serverless/utils": "^4.0.0",
     "chalk": "^4.1.0",
     "child-process-ext": "^2.1.1",


### PR DESCRIPTION
Persist `user_uid` from `login` and `register` operations as `userId` in local `.serverlessrc` config file. 

Related Asana ticket: https://app.asana.com/0/1200011721510709/1200049124629396

