### PR TITLE
Feature: Set providersUsed value on deployments record

### DIFF
--- a/lib/deployProfile.js
+++ b/lib/deployProfile.js
@@ -93,6 +93,7 @@ module.exports.configureDeployProfile = async (ctx) => {
         ctx.sls.cli.log(
           `Using provider credentials, configured via dashboard: ${providersConfigUrl}`
         );
+        ctx.state.providersUsed = true;
         ctx.provider.cachedCredentials = {
           accessKeyId: awsCredentials.providerDetails.accessKeyId,
           secretAccessKey: awsCredentials.providerDetails.secretAccessKey,

--- a/lib/deployment/parse.js
+++ b/lib/deployment/parse.js
@@ -121,6 +121,7 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
       plugins: service.plugins ? service.plugins.modules || service.plugins : [],
       custom: service.custom || {},
       secrets: Array.from(ctx.state.secretsUsed),
+      providersUsed: ctx.state.providersUsed || false,
       outputs,
       error,
       logIngestMode,
@@ -302,6 +303,7 @@ const parseDeploymentData = async (ctx, status = 'success', error = null, archiv
       archived,
       status,
       secrets: Array.from(ctx.state.secretsUsed),
+      providersUsed: ctx.state.providersUsed || false,
       error,
       vcs,
     });

--- a/lib/deployment/parse.test.js
+++ b/lib/deployment/parse.test.js
@@ -1217,7 +1217,6 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
-      providersUsed: true,
     };
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
@@ -1269,7 +1268,7 @@ describe('parseDeploymentData', () => {
       resources: {},
       safeguards: [],
       secrets: ['secret'],
-      providersUsed: true,
+      providersUsed: false,
       outputs: { foo: 'bar' },
       serviceName: 'service',
       stageName: 'dev',

--- a/lib/deployment/parse.test.js
+++ b/lib/deployment/parse.test.js
@@ -112,6 +112,7 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
+      providersUsed: true,
     };
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
@@ -163,6 +164,7 @@ describe('parseDeploymentData', () => {
       resources: {},
       safeguards: [],
       secrets: ['secret'],
+      providersUsed: true,
       outputs: { foo: 'bar', apig: 'api-id' },
       serviceName: 'service',
       stageName: 'dev',
@@ -261,6 +263,7 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
+      providersUsed: true,
     };
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
@@ -314,6 +317,7 @@ describe('parseDeploymentData', () => {
       resources: {},
       safeguards: [],
       secrets: ['secret'],
+      providersUsed: true,
       outputs: { foo: 'bar', apig: 'api-id' },
       serviceName: 'service',
       stageName: 'dev',
@@ -430,6 +434,7 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
+      providersUsed: true,
     };
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
@@ -486,6 +491,7 @@ describe('parseDeploymentData', () => {
       resources: {},
       safeguards: [],
       secrets: ['secret'],
+      providersUsed: true,
       outputs: { foo: 'bar', apig: 'api-id' },
       serviceName: 'service',
       stageName: 'dev',
@@ -590,6 +596,7 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
+      providersUsed: true,
     };
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
@@ -641,6 +648,7 @@ describe('parseDeploymentData', () => {
       resources: {},
       safeguards: [],
       secrets: ['secret'],
+      providersUsed: true,
       outputs: { foo: 'bar' },
       serviceName: 'service',
       stageName: 'dev',
@@ -730,6 +738,7 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
+      providersUsed: true,
     };
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
@@ -781,6 +790,7 @@ describe('parseDeploymentData', () => {
       resources: {},
       safeguards: [],
       secrets: ['secret'],
+      providersUsed: true,
       outputs: { foo: 'bar' },
       serviceName: 'service',
       stageName: 'dev',
@@ -857,6 +867,7 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
+      providersUsed: false,
     };
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
@@ -908,6 +919,7 @@ describe('parseDeploymentData', () => {
       resources: {},
       safeguards: [],
       secrets: ['secret'],
+      providersUsed: false,
       outputs: { foo: 'bar' },
       serviceName: 'service',
       stageName: 'dev',
@@ -971,6 +983,7 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
+      providersUsed: false,
     };
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
@@ -1022,6 +1035,7 @@ describe('parseDeploymentData', () => {
       resources: {},
       safeguards: [],
       secrets: ['secret'],
+      providersUsed: false,
       outputs: { foo: 'bar' },
       serviceName: 'service',
       stageName: 'dev',
@@ -1088,6 +1102,7 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
+      providersUsed: true,
     };
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
@@ -1139,6 +1154,7 @@ describe('parseDeploymentData', () => {
       resources: {},
       safeguards: [],
       secrets: ['secret'],
+      providersUsed: true,
       outputs: { foo: 'bar' },
       serviceName: 'service',
       stageName: 'dev',
@@ -1201,6 +1217,7 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
+      providersUsed: true,
     };
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
@@ -1252,6 +1269,7 @@ describe('parseDeploymentData', () => {
       resources: {},
       safeguards: [],
       secrets: ['secret'],
+      providersUsed: true,
       outputs: { foo: 'bar' },
       serviceName: 'service',
       stageName: 'dev',
@@ -1337,6 +1355,7 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
+      providersUsed: true,
     };
 
     const deployment = await parseDeploymentData({ sls: serverless, serverless, provider, state });
@@ -1390,6 +1409,7 @@ describe('parseDeploymentData', () => {
       resources: {},
       safeguards: [],
       secrets: ['secret'],
+      providersUsed: true,
       outputs: { foo: 'bar', apig: 'api-id' },
       serviceName: 'service',
       stageName: 'qa',
@@ -1475,6 +1495,7 @@ describe('parseDeploymentData', () => {
     const state = {
       safeguardsResults: [],
       secretsUsed: new Set(['secret']),
+      providersUsed: true,
     };
 
     const deployment = await parseDeploymentData(
@@ -1501,6 +1522,7 @@ describe('parseDeploymentData', () => {
       archived: true,
       status: 'success',
       secrets: ['secret'],
+      providersUsed: true,
       error: null,
       vcs: {
         type: 'git',


### PR DESCRIPTION
Feature:
- This PR sets a new boolean, providersUsed, if the backend providers features are used for a deployment
- This PR follows the same pattern as safeguards and secrets
- This PR updated the tests and tests both false/nil