### PR TITLE
Fix discovered SDK wrapper issues

### DIFF
--- a/integration-testing/wrapper.test.js
+++ b/integration-testing/wrapper.test.js
@@ -7,6 +7,7 @@ const setup = require('./setup');
 const zlib = require('zlib');
 const wait = require('timers-ext/promise/sleep');
 const awsRequest = require('@serverless/test/aws-request');
+const hasFailed = require('@serverless/test/has-failed');
 const log = require('log').get('test');
 const { ServerlessSDK } = require('@serverless/platform-client');
 
@@ -125,7 +126,9 @@ describe('integration: wrapper', function () {
     await sls(['deploy']);
   });
 
-  after(() => {
+  after(function () {
+    // Do not remove on fail, to allow further investigation
+    if (hasFailed(this.test.parent)) return null;
     if (teardown) return teardown();
     return null;
   });

--- a/sdk-js/src/index.js
+++ b/sdk-js/src/index.js
@@ -344,7 +344,8 @@ class ServerlessSDK {
               trans.error(error, true, cb);
             } else {
               trans.end();
-              cb();
+              // Resolve in next tick, so dashboard log is flushed before lambda invocation is closed
+              setTimeout(cb);
             }
           } finally {
             finalized = true;

--- a/sdk-js/src/lib/transaction.js
+++ b/sdk-js/src/lib/transaction.js
@@ -188,7 +188,8 @@ class Transaction {
         // End transaction
         this.buildOutput(ERROR); // set this to transaction for now.
         self.end();
-        cb();
+        // Resolve in next tick, so dashboard log is flushed before lambda invocation is closed
+        setTimeout(cb);
       });
     } else {
       // Create Error ID
@@ -209,7 +210,8 @@ class Transaction {
       // End transaction
       this.buildOutput(ERROR); // set this to transaction for now.
       self.end();
-      cb();
+      // Resolve in next tick, so dashboard log is flushed before lambda invocation is closed
+      setTimeout(cb);
     }
   }
 


### PR DESCRIPTION
Addresses two discovered issues

#### Broken current invocation detection

This was exposed by CI fail observed here: https://github.com/serverless/enterprise-plugin/runs/2510616811?check_suite_focus=true

We have a logic which for eventual lambda timeout case reports logs right before lambda times out (so we have record of lambda time out)
It's set via `setTimeout` callback which is always cleared when lambda callback is called (so in most cases before the timeout callback is triggered).

Still in case of unresolved lambdas (lambdas with no logic and no callback called), the invocation ends, while `setTimeout` callback is not cleared, in result it's triggered in next invocation.

In most cases we detect such situation successfully as by storing locally the _callback_ function provided by AWS to handler we check whether we're in invocation in which `setTimeout` callback was registered. However it appears that AWS internals may invoke this leftover `setTimeout` callback before an actual lambda handler is invoked, and in such situation our detection is broken (we assume we're in invocation which registered timeout, which is not true).

This PR fixes (or at least minimizes the likehood of error), by additionally confirming on time in which `setTimeout` callback was invoked. If it's beyond intended time point, we assume it's actually another invocation and do not trigger registered logic.
It definitely fixes our tests

#### Dashboard logs not being flushed in scope of current invocation

While having first issue sorted, I started to struggle with other set of errors, where in some scenarios the dashboard logs were not flushed in given invocation (even though they were definitely issued in their context), but flushed with next one, e.g. below screenshot demonstrates that.


<img width="1909" alt="Screenshot 2021-05-10 at 15 37 46" src="https://user-images.githubusercontent.com/122434/117681586-8d6da400-b1b2-11eb-8286-132602798f38.png">

In tests we invoke `asyncError` lambda twice, with [first invocation](https://github.com/serverless/enterprise-plugin/blob/1050c612fa62810bc80ad7384a8d5e27b948ad20/integration-testing/wrapper.test.js#L163-L171) we test that returned value is right, and with [second](https://github.com/serverless/enterprise-plugin/blob/1050c612fa62810bc80ad7384a8d5e27b948ad20/integration-testing/wrapper.test.js#L283-L291) we test that it reports dashboard log.

In a screenshot above first test invocation request id starts with `a0512`, second test invocation request id starts with `24d7c`. Third one (request id starting with `3dd299`) is one I've triggered manually from AWS console, shortly after I observed test fail.
Test which involved second invocation failed because dashboard log was not found in lambda logs, and as we can see it was indeed not released with it. It became released with next invocation which I triggered manually

I've fixed that by adding minimal delay before we call AWS callback after releasing dashboard logs. Having that in, I've run tests numerous times and didn't observe the issue again.

Additionally I've updated test suite, so service is not removed in case of fail. That makes it easier to further investigate the reason of the issue.




